### PR TITLE
fix: cart/order has no meta

### DIFF
--- a/packages/api/resolvers/types/order.js
+++ b/packages/api/resolvers/types/order.js
@@ -12,6 +12,8 @@ export default {
   currency(obj) {
     return Currencies.findOne({ isoCode: obj.currency });
   },
-
+  meta(obj) {
+    return obj.context;
+  },
   logs: checkTypeResolver(actions.viewLogs, 'logs'),
 };


### PR DESCRIPTION
meta always return null because the underlying property is `context`