### PR TITLE
relax orderitem

### DIFF
--- a/packages/api/schema/types/order/item.js
+++ b/packages/api/schema/types/order/item.js
@@ -19,10 +19,10 @@ export default [
 
     type OrderItem {
       _id: ID!
-      product: Product!
+      product: Product
       order: Order!
       quantity: Int!
-      originalProduct: Product!
+      originalProduct: Product
       quotation: Quotation
       unitPrice: Money
       total(category: OrderItemPriceCategory): Money


### PR DESCRIPTION
if you remove products, but have orders with these products around, you can't fetch the order or cart anymore, it will throw a server error.

it's better to relax that here so that clients can react to this situation. 