### PR TITLE
Multi-cart

### DIFF
--- a/packages/api/errors.js
+++ b/packages/api/errors.js
@@ -43,6 +43,10 @@ export const OrderNotFoundError = createError(
   'OrderNotFoundError',
   'Order not found'
 );
+export const OrderNumberAlreadyExistsError = createError(
+  'OrderNumberAlreadyExistsError',
+  'This orderNumber has already been used by another order'
+);
 export const OrderDiscountNotFoundError = createError(
   'OrderDiscountNotFoundError',
   'Order discount not found'

--- a/packages/api/getCart.js
+++ b/packages/api/getCart.js
@@ -1,0 +1,31 @@
+import { Users } from 'meteor/unchained:core-users';
+import { Orders } from 'meteor/unchained:core-orders';
+import { Countries } from 'meteor/unchained:core-countries';
+import {
+  UserNotFoundError,
+  OrderNotFoundError,
+  OrderWrongStatusError
+} from './errors';
+
+export default ({ orderId, userId, countryContext }) => {
+  if (orderId) {
+    const order = Orders.findOne({ _id: orderId });
+    if (!order) throw new OrderNotFoundError({ orderId });
+    if (!order.isCart()) {
+      throw new OrderWrongStatusError({ data: { status: order.status } });
+    }
+    return order;
+  }
+  const user = Users.findOne({ _id: userId });
+  if (!user) throw new UserNotFoundError({ userId });
+  const cart =
+    user.cart({ countryContext }) ||
+    Orders.createOrder({
+      userId: user._id,
+      currency: Countries.resolveDefaultCurrencyCode({
+        isoCode: countryContext
+      }),
+      countryCode: countryContext
+    });
+  return cart;
+};

--- a/packages/api/resolvers/mutations/addCartDiscount.js
+++ b/packages/api/resolvers/mutations/addCartDiscount.js
@@ -1,24 +1,8 @@
 import { log } from 'meteor/unchained:core-logger';
-import { Users } from 'meteor/unchained:core-users';
-import { Orders } from 'meteor/unchained:core-orders';
-import {
-  UserNotFoundError,
-  OrderNotFoundError,
-  OrderWrongStatusError
-} from '../../errors';
+import getCart from '../../getCart';
 
 export default function(root, { orderId, code }, { userId, countryContext }) {
   log(`mutation addCartDiscount ${code} ${orderId}`, { userId, orderId });
-  if (orderId) {
-    const order = Orders.findOne({ _id: orderId });
-    if (!order) throw new OrderNotFoundError({ orderId });
-    if (!order.isCart()) {
-      throw new OrderWrongStatusError({ data: { status: order.status } });
-    }
-    return order.addDiscount({ code });
-  }
-  const user = Users.findOne({ _id: userId });
-  if (!user) throw new UserNotFoundError({ userId });
-  const cart = user.initCart({ countryContext });
+  const cart = getCart({ orderId, userId, countryContext });
   return cart.addDiscount({ code });
 }

--- a/packages/api/resolvers/mutations/addCartProduct.js
+++ b/packages/api/resolvers/mutations/addCartProduct.js
@@ -1,13 +1,7 @@
 import { log } from 'meteor/unchained:core-logger';
 import { Products } from 'meteor/unchained:core-products';
-import { Users } from 'meteor/unchained:core-users';
-import { Orders } from 'meteor/unchained:core-orders';
-import {
-  ProductNotFoundError,
-  UserNotFoundError,
-  OrderNotFoundError,
-  OrderWrongStatusError
-} from '../../errors';
+import { ProductNotFoundError } from '../../errors';
+import getCart from '../../getCart';
 
 export default function(
   root,
@@ -22,21 +16,7 @@ export default function(
   );
   const product = Products.findOne({ _id: productId });
   if (!product) throw new ProductNotFoundError({ data: { productId } });
-  if (orderId) {
-    const order = Orders.findOne({ _id: orderId });
-    if (!order) throw new OrderNotFoundError({ orderId });
-    if (!order.isCart()) {
-      throw new OrderWrongStatusError({ data: { status: order.status } });
-    }
-    return order.addProductItem({
-      product,
-      quantity,
-      configuration
-    });
-  }
-  const user = Users.findOne({ _id: userId });
-  if (!user) throw new UserNotFoundError({ userId });
-  const cart = user.initCart({ countryContext });
+  const cart = getCart({ orderId, userId, countryContext });
   return cart.addProductItem({
     product,
     quantity,

--- a/packages/api/resolvers/mutations/addCartQuotation.js
+++ b/packages/api/resolvers/mutations/addCartQuotation.js
@@ -1,14 +1,10 @@
 import { log } from 'meteor/unchained:core-logger';
 import { Quotations, QuotationStatus } from 'meteor/unchained:core-quotations';
-import { Users } from 'meteor/unchained:core-users';
-import { Orders } from 'meteor/unchained:core-orders';
 import {
   QuotationNotFoundError,
-  UserNotFoundError,
-  QuotationWrongStatusError,
-  OrderNotFoundError,
-  OrderWrongStatusError
+  QuotationWrongStatusError
 } from '../../errors';
+import getCart from '../../getCart';
 
 export default function(
   root,
@@ -26,21 +22,7 @@ export default function(
   if (quotation.status !== QuotationStatus.PROPOSED) {
     throw new QuotationWrongStatusError({ data: { status: quotation.status } });
   }
-  if (orderId) {
-    const order = Orders.findOne({ _id: orderId });
-    if (!order) throw new OrderNotFoundError({ orderId });
-    if (!order.isCart()) {
-      throw new OrderWrongStatusError({ data: { status: order.status } });
-    }
-    return order.addQuotationItem({
-      quotation,
-      quantity,
-      configuration
-    });
-  }
-  const user = Users.findOne({ _id: userId });
-  if (!user) throw new UserNotFoundError({ userId });
-  const cart = user.initCart({ countryContext });
+  const cart = getCart({ orderId, userId, countryContext });
   return cart.addQuotationItem({
     quotation,
     quantity,

--- a/packages/api/resolvers/mutations/checkoutCart.js
+++ b/packages/api/resolvers/mutations/checkoutCart.js
@@ -1,28 +1,6 @@
 import { log } from 'meteor/unchained:core-logger';
-import { Orders } from 'meteor/unchained:core-orders';
-import { Users } from 'meteor/unchained:core-users';
-import {
-  UserNotFoundError,
-  OrderCheckoutError,
-  UserNoCartError,
-  OrderWrongStatusError,
-  OrderNotFoundError
-} from '../../errors';
-
-const checkoutWithPotentialErrors = (cart, context, options, userId) => {
-  try {
-    return cart.checkout(context, options);
-  } catch (error) {
-    const data = {
-      userId,
-      orderId: cart._id,
-      ...context,
-      detailMessage: error.message
-    };
-    log(data.detailMessage, { userId, orderId: cart._id, level: 'error' });
-    throw new OrderCheckoutError({ data });
-  }
-};
+import { OrderCheckoutError } from '../../errors';
+import getCart from '../../getCart';
 
 export default function(
   root,
@@ -30,31 +8,19 @@ export default function(
   { userId, countryContext, localeContext }
 ) {
   log('mutation checkoutCart', { orderId, userId });
-  if (orderId) {
-    const order = Orders.findOne({ _id: orderId });
-    if (!order) throw new OrderNotFoundError({ data: { orderId } });
-    if (!order.isCart()) {
-      throw new OrderWrongStatusError({ data: { status: order.status } });
-    }
-    return checkoutWithPotentialErrors(
-      order,
-      transactionContext,
-      {
-        localeContext
-      },
-      userId
-    );
-  }
-  const user = Users.findOne({ _id: userId });
-  if (!user) throw new UserNotFoundError({ data: { userId } });
-  const cart = user.cart({ countryContext });
-  if (!cart) throw new UserNoCartError({ data: { userId } });
-  return checkoutWithPotentialErrors(
-    cart,
-    transactionContext,
-    {
+  const cart = getCart({ orderId, userId, countryContext });
+  try {
+    return cart.checkout(transactionContext, {
       localeContext
-    },
-    userId
-  );
+    });
+  } catch (error) {
+    const data = {
+      userId,
+      orderId: cart._id,
+      ...transactionContext,
+      detailMessage: error.message
+    };
+    log(data.detailMessage, { userId, orderId: cart._id, level: 'error' });
+    throw new OrderCheckoutError({ data });
+  }
 }

--- a/packages/api/resolvers/mutations/createCart.js
+++ b/packages/api/resolvers/mutations/createCart.js
@@ -1,0 +1,21 @@
+import { log } from 'meteor/unchained:core-logger';
+import { Users } from 'meteor/unchained:core-users';
+import { Orders } from 'meteor/unchained:core-orders';
+import { Countries } from 'meteor/unchained:core-countries';
+import { OrderNumberAlreadyExistsError, UserNotFoundError } from '../../errors';
+
+export default function(root, { orderNumber }, { countryContext, userId }) {
+  log('mutation createCart', { userId });
+  const order = Orders.findOne({ orderNumber });
+  if (order) throw new OrderNumberAlreadyExistsError({ orderNumber });
+  const user = Users.findOne({ _id: userId });
+  if (!user) throw new UserNotFoundError({ userId });
+  return Orders.createOrder({
+    userId: user._id,
+    orderNumber,
+    currency: Countries.resolveDefaultCurrencyCode({
+      isoCode: countryContext
+    }),
+    countryCode: countryContext
+  });
+}

--- a/packages/api/resolvers/mutations/emptyCart.js
+++ b/packages/api/resolvers/mutations/emptyCart.js
@@ -1,26 +1,10 @@
 import { log } from 'meteor/unchained:core-logger';
-import { Users } from 'meteor/unchained:core-users';
-import { Orders, OrderPositions } from 'meteor/unchained:core-orders';
-import {
-  UserNotFoundError,
-  OrderNotFoundError,
-  OrderWrongStatusError
-} from '../../errors';
+import { OrderPositions } from 'meteor/unchained:core-orders';
+import getCart from '../../getCart';
 
 export default function(root, { orderId }, { userId, countryContext }) {
   log('mutation emptyCart', { userId, orderId });
-  if (orderId) {
-    const order = Orders.findOne({ _id: orderId });
-    if (!order) throw new OrderNotFoundError({ orderId });
-    if (!order.isCart()) {
-      throw new OrderWrongStatusError({ data: { status: order.status } });
-    }
-    OrderPositions.removePositions({ orderId });
-    return order;
-  }
-  const user = Users.findOne({ _id: userId });
-  if (!user) throw new UserNotFoundError({ userId });
-  const cart = user.cart({ countryContext });
+  const cart = getCart({ orderId, userId, countryContext });
   if (!cart) return null;
   OrderPositions.removePositions({ orderId: cart._id });
   return cart;

--- a/packages/api/resolvers/mutations/index.js
+++ b/packages/api/resolvers/mutations/index.js
@@ -38,6 +38,7 @@ import updateProductWarehousing from './updateProductWarehousing';
 import updateProductSupply from './updateProductSupply';
 import addProductAssignment from './addProductAssignment';
 import removeProductAssignment from './removeProductAssignment';
+import createCart from './createCart';
 import addCartProduct from './addCartProduct';
 import addCartDiscount from './addCartDiscount';
 import addCartQuotation from './addCartQuotation';
@@ -152,6 +153,7 @@ export default {
   updateCurrency: acl(actions.manageCurrencies)(updateCurrency),
   removeCurrency: acl(actions.manageCurrencies)(removeCurrency),
 
+  createCart: acl(actions.createCart)(createCart),
   addCartProduct: acl(actions.updateCart)(addCartProduct),
   addCartDiscount: acl(actions.updateCart)(addCartDiscount),
   addCartQuotation: acl(actions.updateCart)(addCartQuotation),

--- a/packages/api/resolvers/mutations/updateCart.js
+++ b/packages/api/resolvers/mutations/updateCart.js
@@ -1,11 +1,5 @@
 import { log } from 'meteor/unchained:core-logger';
-import { Users } from 'meteor/unchained:core-users';
-import { Orders } from 'meteor/unchained:core-orders';
-import {
-  UserNotFoundError,
-  OrderNotFoundError,
-  OrderWrongStatusError
-} from '../../errors';
+import getCart from '../../getCart';
 
 export default function(
   root,
@@ -13,19 +7,7 @@ export default function(
   { countryContext, userId }
 ) {
   log('mutation updateCart', { userId });
-  let order;
-  if (orderId) {
-    order = Orders.findOne({ _id: orderId });
-    if (!order) throw new OrderNotFoundError({ data: { orderId } });
-    if (!order.isCart()) {
-      throw new OrderWrongStatusError({ data: { status: order.status } });
-    }
-  } else {
-    const user = Users.findOne({ _id: userId });
-    if (!user) throw new UserNotFoundError({ userId });
-    order = user.initCart({ countryContext });
-  }
-
+  let order = getCart({ orderId, userId, countryContext });
   if (meta) {
     order = order.updateContext(meta);
   }

--- a/packages/api/resolvers/queries/orders.js
+++ b/packages/api/resolvers/queries/orders.js
@@ -11,6 +11,13 @@ export default function(
   if (!includeCarts) {
     selector.status = { $ne: OrderStatus.OPEN };
   }
-  const orders = Orders.find(selector, { skip: offset, limit }).fetch();
+  const options = {
+    skip: offset,
+    limit,
+    sort: {
+      created: -1
+    }
+  };
+  const orders = Orders.find(selector, options).fetch();
   return orders;
 }

--- a/packages/api/resolvers/types/user.js
+++ b/packages/api/resolvers/types/user.js
@@ -35,6 +35,6 @@ export default {
   cart(user, params, context = {}) {
     const { countryContext, userId } = context;
     checkAction(actions.viewUserOrders, userId, [user, params, context]);
-    return user.cart({ countryContext });
+    return user.cart({ countryContext, ...params });
   }
 };

--- a/packages/api/roles/all.js
+++ b/packages/api/roles/all.js
@@ -28,6 +28,7 @@ export default (role, actions) => {
   role.allow(actions.manageFilters, () => false);
   role.allow(actions.manageUsers, () => false);
   role.allow(actions.updateCart, () => false);
+  role.allow(actions.createCart, () => false);
   role.allow(actions.checkoutCart, () => false);
   role.allow(actions.updateOrder, () => false);
   role.allow(actions.updateOrderDiscount, () => false);

--- a/packages/api/roles/index.js
+++ b/packages/api/roles/index.js
@@ -54,6 +54,7 @@ export const actions = [
   'manageWarehousingProviders',
   'manageAssortments',
   'manageFilters',
+  'createCart',
   'updateCart',
   'checkoutCart',
   'updateOrder',

--- a/packages/api/roles/loggedIn.js
+++ b/packages/api/roles/loggedIn.js
@@ -86,6 +86,7 @@ export default (role, actions) => {
   role.allow(actions.updateOrderDelivery, isOwnedOrderDelivery);
   role.allow(actions.checkoutCart, isOwnedOrderOrCart);
   role.allow(actions.updateCart, isOwnedOrderOrCart);
+  role.allow(actions.createCart, () => true);
   role.allow(actions.reviewProduct, () => true);
   role.allow(actions.updateProductReview, () => isOwnedProductReview);
   role.allow(actions.requestQuotation, () => true);

--- a/packages/api/schema/mutation.js
+++ b/packages/api/schema/mutation.js
@@ -88,6 +88,12 @@ export default [
       loginAsGuest: LoginMethodResponse
 
       """
+      Creates an alternative cart. If you use this feature, you should use explicit orderId's when using the
+      cart mutations. Else it will work like a stack and the checkout will use the very first cart of the user.
+      """
+      createCart(orderNumber: String!): Order!
+
+      """
       Add a new item to the cart. Order gets generated with status = open (= order before checkout / cart) if necessary.
       """
       addCartProduct(

--- a/packages/api/schema/types/user.js
+++ b/packages/api/schema/types/user.js
@@ -55,8 +55,8 @@ export default [
       emails: [UserEmail!]
       roles: [String!]
       tags: [String!]
-      cart: Order
-      orders(includeDrafts: Boolean = false): [Order!]!
+      cart(orderNumber: String!): Order
+      orders(includeCarts: Boolean = false): [Order!]!
       quotations: [Quotation!]!
       logs(offset: Int, limit: Int): [Log!]!
     }

--- a/packages/core-orders/db/orders/helpers.js
+++ b/packages/core-orders/db/orders/helpers.js
@@ -49,18 +49,6 @@ Users.helpers({
     }
     return null;
   },
-  initCart({ countryContext }) {
-    return (
-      this.cart({ countryContext }) ||
-      Orders.createOrder({
-        userId: this._id,
-        currency: Countries.resolveDefaultCurrencyCode({
-          isoCode: countryContext
-        }),
-        countryCode: countryContext
-      })
-    );
-  },
   orders() {
     return Orders.find(
       { userId: this._id },

--- a/packages/core-orders/db/orders/helpers.js
+++ b/packages/core-orders/db/orders/helpers.js
@@ -38,26 +38,31 @@ Logs.helpers({
 });
 
 Users.helpers({
-  cart({ countryContext } = {}) {
-    const openOrders = Orders.find({
-      userId: this._id,
-      status: OrderStatus.OPEN,
-      countryCode: countryContext || this.lastLogin.country
-    });
-    if (openOrders.count() > 0) {
-      return openOrders.fetch()[0];
+  cart({ countryContext, orderNumber } = {}) {
+    const selector = {
+      countryCode: countryContext || this.lastLogin.country,
+      status: { $eq: OrderStatus.OPEN }
+    };
+    if (orderNumber) selector.orderNumber = orderNumber;
+    const carts = this.orders(selector);
+    console.log(carts);
+    if (carts.length > 0) {
+      return carts[0];
     }
     return null;
   },
-  orders() {
-    return Orders.find(
-      { userId: this._id },
-      {
-        sort: {
-          created: -1
-        }
+  orders({ includeCarts = false, status, ...rest } = {}) {
+    const selector = { userId: this._id, ...rest };
+    if (!includeCarts || status) {
+      selector.status = status || { $ne: OrderStatus.OPEN };
+    }
+    const options = {
+      sort: {
+        created: -1
       }
-    ).fetch();
+    };
+    const orders = Orders.find(selector, options).fetch();
+    return orders;
   }
 });
 
@@ -580,7 +585,7 @@ Orders.updateContext = ({ context, orderId }) => {
   return Orders.findOne({ _id: orderId });
 };
 
-Orders.newOrderNumber = () => {
+Orders.getUniqueOrderNumber = () => {
   let orderNumber = null;
   const hashids = new Hashids(
     'unchained',
@@ -626,7 +631,10 @@ Orders.updateStatus = ({ status, orderId, info = '' }) => {
     case OrderStatus.PENDING: // eslint-disable-line no-fallthrough
       if (!order.ordered) {
         modifier.$set.ordered = date;
-        modifier.$set.orderNumber = Orders.newOrderNumber();
+      }
+      if (!order.orderNumber) {
+        // Order Numbers can be set by the user
+        modifier.$set.orderNumber = Orders.getUniqueOrderNumber();
       }
       break;
     default:

--- a/packages/core-orders/db/orders/schema.js
+++ b/packages/core-orders/db/orders/schema.js
@@ -24,8 +24,8 @@ Orders.attachSchema(
     {
       userId: { type: String, index: true },
       status: { type: String, index: true },
+      orderNumber: { type: String, index: true, unique: true },
       ordered: Date,
-      orderNumber: String,
       confirmed: Date,
       fullfilled: Date,
       billingAddress: Address,


### PR DESCRIPTION
This will add multi-cart support in a way that does not interfer with the standard way of having just one cart per user. Through a new mutation one can add a new cart by providing a unique orderNumber.

If you just use the cart mutations like before and do a checkout without providing an actual orderId, the first cart in order of creation is assumed. If you have 3 carts and do 3 checkouts, this represents a queue: Each time checkout get's called, the oldest cart gets checked out.

## Schema changes

New mutation:

```graphql
createCart(orderNumber: String!): Order
```

Enhances User:

Changes

```graphql
orders(includeDrafts: Boolean = false): [Order!]!
```

to

```graphql
orders(includeCarts: Boolean = false): [Order!]!
```

Even if it looks like it does introduce a breaking change, in fact it does not as includeDrafts on User.orders never actually worked and was meaningless.