### PR TITLE
fix: sort products by sequence

### DIFF
--- a/packages/api/resolvers/queries/products.js
+++ b/packages/api/resolvers/queries/products.js
@@ -13,7 +13,7 @@ export default function(
     { userId }
   );
   const selector = {};
-  const sort = { published: -1 };
+  const sort = { sequence: 1, published: -1 };
   const options = { skip: offset, limit, sort };
 
   if (slugs.length > 0) {


### PR DESCRIPTION
small change: products resolver sorts now by sequence instead of published-date. If severall products have same sequence, it would sort by published as before