### PR TITLE
relax ID restriction

### DIFF
--- a/packages/core-products/db/product-media/schema.js
+++ b/packages/core-products/db/product-media/schema.js
@@ -5,8 +5,8 @@ import { ProductMedia, ProductMediaTexts } from './collections';
 ProductMedia.attachSchema(
   new SimpleSchema(
     {
-      mediaId: { type: SimpleSchema.RegEx.Id, required: true, index: true },
-      productId: { type: SimpleSchema.RegEx.Id, required: true, index: true },
+      mediaId: { type: String, required: true, index: true },
+      productId: { type: String, required: true, index: true },
       sortKey: { type: Number, required: true },
       tags: { type: Array, index: true },
       'tags.$': String,
@@ -21,7 +21,7 @@ ProductMediaTexts.attachSchema(
   new SimpleSchema(
     {
       productMediaId: {
-        type: SimpleSchema.RegEx.Id,
+        type: String,
         required: true,
         index: true
       },

--- a/packages/core-products/db/product-reviews/schema.js
+++ b/packages/core-products/db/product-reviews/schema.js
@@ -2,7 +2,8 @@ import SimpleSchema from 'simpl-schema';
 import { Schemas } from 'meteor/unchained:utils';
 import { ProductReviews } from './collections';
 
-export const ProductReviewVoteTypes = { // eslint-disable-line
+export const ProductReviewVoteTypes = {
+  // eslint-disable-line
   UPVOTE: 'UPVOTE',
   DOWNVOTE: 'DOWNVOTE',
   REPORT: 'REPORT'
@@ -24,7 +25,7 @@ ProductReviews.attachSchema(
       votes: Array,
       'votes.$': { type: Object, required: true },
       'votes.$.timestamp': { type: Date, required: true },
-      'votes.$.userId': { type: SimpleSchema.RegEx.Id, required: true },
+      'votes.$.userId': { type: String, required: true },
       'votes.$.type': {
         type: String,
         required: true,

--- a/packages/core-products/db/product-variations/schema.js
+++ b/packages/core-products/db/product-variations/schema.js
@@ -2,7 +2,8 @@ import SimpleSchema from 'simpl-schema';
 import { Schemas } from 'meteor/unchained:utils';
 import { ProductVariations, ProductVariationTexts } from './collections';
 
-export const ProductVariationType = { // eslint-disable-line
+export const ProductVariationType = {
+  // eslint-disable-line
   COLOR: 'COLOR',
   TEXT: 'TEXT'
 };
@@ -10,7 +11,7 @@ export const ProductVariationType = { // eslint-disable-line
 ProductVariations.attachSchema(
   new SimpleSchema(
     {
-      productId: { type: SimpleSchema.RegEx.Id, required: true, index: true },
+      productId: { type: String, required: true, index: true },
       key: String,
       type: String,
       options: Array,
@@ -25,7 +26,7 @@ ProductVariationTexts.attachSchema(
   new SimpleSchema(
     {
       productVariationId: {
-        type: SimpleSchema.RegEx.Id,
+        type: String,
         required: true,
         index: true
       },

--- a/packages/core-products/db/products/schema.js
+++ b/packages/core-products/db/products/schema.js
@@ -52,7 +52,7 @@ const ProductProxySchema = new SimpleSchema(
     assignments: Array,
     'assignments.$': Object,
     'assignments.$.vector': { type: Object, blackbox: true },
-    'assignments.$.productId': SimpleSchema.RegEx.Id
+    'assignments.$.productId': String
   },
   { requiredByDefault: false }
 );
@@ -84,7 +84,7 @@ Products.attachSchema(
         required: true
       },
       status: { type: String, index: true },
-      authorId: { type: SimpleSchema.RegEx.Id, required: true },
+      authorId: { type: String, required: true },
       published: Date,
       tags: { type: Array, index: true },
       'tags.$': String,
@@ -107,7 +107,7 @@ Products.attachSchema(
 ProductTexts.attachSchema(
   new SimpleSchema(
     {
-      productId: { type: SimpleSchema.RegEx.Id, required: true, index: true },
+      productId: { type: String, required: true, index: true },
       locale: { type: String, required: true, index: true },
       vendor: String,
       title: String,


### PR DESCRIPTION
this PR removes the validation of `SimpleSchema.RegEx.Id` on all Ids and replaces it with simple String.

## Reasoning

While it is generally preferable to have non-guessable IDs, it sometimes make sense to have predefined IDs, in particular if you import products or similar from external sources.

This change does not change any default behaviour, it just allows to pass any string s ID when you create a Product