### PR TITLE
Enable introspection for example

### DIFF
--- a/examples/minimal/boot.js
+++ b/examples/minimal/boot.js
@@ -76,5 +76,5 @@ const initializeDatabase = () => {
 Meteor.startup(() => {
   configureEmailTemplates();
   initializeDatabase();
-  startPlatform();
+  startPlatform({ introspection: true });
 });


### PR DESCRIPTION
If introspection is disabled, the control-panel does not work. It needs introspection to populate the type drop-downs.