### PR TITLE
feat: allow to add multiple cart products in one request

### DIFF
--- a/packages/api/resolvers/mutations/addMultipleCartProducts.js
+++ b/packages/api/resolvers/mutations/addMultipleCartProducts.js
@@ -1,0 +1,31 @@
+import { log } from 'meteor/unchained:core-logger';
+import { Products } from 'meteor/unchained:core-products';
+import { ProductNotFoundError } from '../../errors';
+import getCart from '../../getCart';
+
+export default function(
+  root,
+  { orderId, items },
+  { user, userId, countryContext }
+) {
+  /* verify existence of products */
+  const itemsWithProducts = items.map(({ productId, ...item }) => {
+    const product = Products.findOne({ _id: productId });
+    if (!product) throw new ProductNotFoundError({ data: { productId } });
+    return {
+      ...item,
+      product
+    };
+  });
+
+  const cart = getCart({ orderId, user, countryContext });
+  return itemsWithProducts.map(({ product, quantity, configuration }) => {
+    log(
+      `mutation addCartProduct ${product._id} ${quantity} ${
+        configuration ? JSON.stringify(configuration) : ''
+      }`,
+      { userId, orderId }
+    );
+    return cart.addProductItem({ product, quantity, configuration });
+  });
+}

--- a/packages/api/resolvers/mutations/index.js
+++ b/packages/api/resolvers/mutations/index.js
@@ -40,6 +40,7 @@ import addProductAssignment from './addProductAssignment';
 import removeProductAssignment from './removeProductAssignment';
 import createCart from './createCart';
 import addCartProduct from './addCartProduct';
+import addMultipleCartProducts from './addMultipleCartProducts';
 import addCartDiscount from './addCartDiscount';
 import addCartQuotation from './addCartQuotation';
 import updateCart from './updateCart';
@@ -155,6 +156,7 @@ export default {
 
   createCart: acl(actions.createCart)(createCart),
   addCartProduct: acl(actions.updateCart)(addCartProduct),
+  addMultipleCartProducts: acl(actions.updateCart)(addMultipleCartProducts),
   addCartDiscount: acl(actions.updateCart)(addCartDiscount),
   addCartQuotation: acl(actions.updateCart)(addCartQuotation),
   updateCart: acl(actions.updateCart)(updateCart),

--- a/packages/api/schema/inputTypes.js
+++ b/packages/api/schema/inputTypes.js
@@ -232,5 +232,11 @@ export default [
       productId: ID!
       quantity: Int!
     }
+
+    input OrderItemInput {
+      productId: ID!
+      quantity: Int = 1
+      configuration: [ProductConfigurationParameterInput!]
+    }
   `
 ];

--- a/packages/api/schema/mutation.js
+++ b/packages/api/schema/mutation.js
@@ -104,6 +104,14 @@ export default [
       ): OrderItem!
 
       """
+      Add multiple new item to the cart. Order gets generated with status = open (= order before checkout / cart) if necessary.
+      """
+      addMultipleCartProducts(
+        orderId: ID
+        items: [OrderItemInput!]!
+      ): [OrderItem]!
+
+      """
       Add a new discount to the cart, a new order gets generated with status = open (= order before checkout / cart) if necessary
       """
       addCartDiscount(orderId: ID, code: String!): OrderDiscount!


### PR DESCRIPTION
workaround for https://github.com/unchainedshop/unchained/issues/26

adds a new new mutation `addMultipleCartProducts`

does not fix the underlying concurrency problem though, but i think this is one obvious usecase were you can run into that problem.