### PR TITLE
Extend Pick Up Delivery Providers with PickUp Locations data

### DIFF
--- a/examples/minimal/boot.js
+++ b/examples/minimal/boot.js
@@ -4,7 +4,8 @@ import { Users } from 'meteor/unchained:core-users';
 
 import { Factory } from 'meteor/dburles:factory';
 
-import 'meteor/unchained:core-delivery/plugins/send-mail';
+import 'meteor/unchained:core-delivery/plugins/post';
+import 'meteor/unchained:core-delivery/plugins/pick-mup';
 import 'meteor/unchained:core-warehousing/plugins/google-sheets';
 import 'meteor/unchained:core-discounting/plugins/half-price';
 import 'meteor/unchained:core-documents/plugins/smallinvoice';

--- a/packages/api/resolvers/types/order-delivery-pickup.js
+++ b/packages/api/resolvers/types/order-delivery-pickup.js
@@ -1,6 +1,10 @@
 export default {
-  address(obj) {
-    return obj.transformedContextValue('address');
+  activePickUpLocation(obj) {
+    const { orderPickUpLocationId } = obj.context || {};
+    return obj.provider().run('pickUpLocationById', orderPickUpLocationId);
+  },
+  pickUpLocations(obj) {
+    return obj.provider().run('pickUpLocations');
   },
   status(obj) {
     return obj.normalizedStatus();

--- a/packages/api/schema/mutation.js
+++ b/packages/api/schema/mutation.js
@@ -201,7 +201,7 @@ export default [
       """
       updateOrderDeliveryPickUp(
         orderDeliveryId: ID!
-        address: AddressInput
+        orderPickUpLocationId: ID!
         meta: JSON
       ): OrderDeliveryPickUp!
 

--- a/packages/api/schema/types/geo-position.js
+++ b/packages/api/schema/types/geo-position.js
@@ -1,0 +1,9 @@
+export default [
+  /* GraphQL */ `
+    type GeoPosition {
+      latitude: Float!
+      longitude: Float!
+      altitute: Float
+    }
+  `
+];

--- a/packages/api/schema/types/index.js
+++ b/packages/api/schema/types/index.js
@@ -22,6 +22,7 @@ import warehousing from './warehousing';
 import order from './order';
 import product from './product';
 import quotation from './quotation';
+import geoposition from './geo-position';
 import bookmark from './bookmark';
 
 export default [
@@ -49,5 +50,6 @@ export default [
   ...product,
   ...order,
   ...quotation,
+  ...geoposition,
   ...bookmark
 ];

--- a/packages/api/schema/types/order/delivery.js
+++ b/packages/api/schema/types/order/delivery.js
@@ -34,7 +34,8 @@ export default [
       fee: Money
       meta: JSON
 
-      address: Address
+      pickUpLocations: [OrderPickUpLocation!]!
+      activePickUpLocation: OrderPickUpLocation
     }
 
     type OrderDeliveryShipping implements OrderDelivery {

--- a/packages/api/schema/types/order/index.js
+++ b/packages/api/schema/types/order/index.js
@@ -3,5 +3,13 @@ import delivery from './delivery';
 import discount from './discount';
 import item from './item';
 import payment from './payment';
+import pickuplocation from './pick-up-location';
 
-export default [...order, ...item, ...discount, ...delivery, ...payment];
+export default [
+  ...order,
+  ...item,
+  ...discount,
+  ...delivery,
+  ...payment,
+  ...pickuplocation
+];

--- a/packages/api/schema/types/order/pick-up-location.js
+++ b/packages/api/schema/types/order/pick-up-location.js
@@ -1,0 +1,11 @@
+export default [
+  /* GraphQL */ `
+    type OrderPickUpLocation {
+      _id: ID!
+      order: Order!
+      name: String!
+      address: Address
+      geoPoint: GeoPosition
+    }
+  `
+];

--- a/packages/core-delivery/db/helpers.js
+++ b/packages/core-delivery/db/helpers.js
@@ -33,6 +33,16 @@ DeliveryProviders.helpers({
       this.defaultContext(context)
     );
   },
+  run(command, ...args) {
+    return Promise.await(
+      new DeliveryDirector(this).run(
+        this.defaultContext({
+          command,
+          args
+        })
+      )
+    );
+  },
   send(context) {
     return Promise.await(
       new DeliveryDirector(this).send(this.defaultContext(context))

--- a/packages/core-delivery/director.js
+++ b/packages/core-delivery/director.js
@@ -45,6 +45,14 @@ export class DeliveryAdapter {
     return false;
   }
 
+  async pickUpLocationById(id) {  // eslint-disable-line
+    return null;
+  }
+
+  async pickUpLocations() {  // eslint-disable-line
+    return [];
+  }
+
   isAutoReleaseAllowed() { // eslint-disable-line
     // if you return false here,
     // the order will need manual confirmation before
@@ -101,6 +109,11 @@ export class DeliveryDirector {
     const adapter = this.interface(context);
     const sendResult = await adapter.send(transactionContext);
     return sendResult;
+  }
+
+  async run({ command, args, ...context }) {
+    const adapter = this.interface(context);
+    return adapter[command](args);
   }
 
   isActive(context) {

--- a/packages/core-delivery/plugins/pick-mup.js
+++ b/packages/core-delivery/plugins/pick-mup.js
@@ -1,0 +1,108 @@
+import {
+  DeliveryAdapter,
+  DeliveryDirector,
+  DeliveryError
+} from 'meteor/unchained:core-delivery';
+
+import fetch from 'isomorphic-unfetch';
+
+const fetchPickMupLocations = async (key, idsFilter) => {
+  const data = await fetch(
+    `https://web-api.migros.ch/widgets/stores?key=${key}&verbosity=detail&limit=5000&aggregation_options%5Bempty_buckets%5D=true&filters%5Bmarkets%5D%5B0%5D%5B%5D=super&filters%5Bmarkets%5D%5B0%5D%5B%5D=mno&filters%5Bmarkets%5D%5B0%5D%5B%5D=voi&filters%5Bmarkets%5D%5B0%5D%5B%5D=mp&filters%5Bmarkets%5D%5B0%5D%5B%5D=out&filters%5Bmarkets%5D%5B0%5D%5B%5D=spx&filters%5Bmarkets%5D%5B0%5D%5B%5D=doi&filters%5Bmarkets%5D%5B0%5D%5B%5D=mec&filters%5Bmarkets%5D%5B0%5D%5B%5D=mica&filters%5Bmarkets%5D%5B0%5D%5B%5D=res&filters%5Bmarkets%5D%5B0%5D%5B%5D=flori&filters%5Bmarkets%5D%5B0%5D%5B%5D=gour&filters%5Bmarkets%5D%5B0%5D%5B%5D=alna&filters%5Bmarkets%5D%5B0%5D%5B%5D=cof&filters%5Bmarkets%5D%5B0%5D%5B%5D=chng&filters%5Bservices%5D%5Bsub_type%5D%5B%5D=pickmup&aggregation_groups%5B_custom%5D%5Bopen_on%5D%5Bnow%5D=20190923T11%3A45&aggregation_groups%5B_custom%5D%5Bopen_on%5D%5Bafter_1900%5D=20190923T19%3A01&aggregation_groups%5B_custom%5D%5Bopen_on%5D%5Bsundays%5D=sunday&aggregation_groups%5Bmarkets%5D%5B_terms%5D%5B%5D=super&aggregation_groups%5Bmarkets%5D%5B_terms%5D%5B%5D=voi&aggregation_groups%5Bmarkets%5D%5B_terms%5D%5B%5D=mp&aggregation_groups%5Bmarkets%5D%5B_terms%5D%5B%5D=mec&aggregation_groups%5Bmarkets%5D%5B_terms%5D%5B%5D=spx&aggregation_groups%5Bmarkets%5D%5B_terms%5D%5B%5D=doi&aggregation_groups%5Bmarkets%5D%5B_terms%5D%5B%5D=mica&aggregation_groups%5Bmarkets%5D%5B_terms%5D%5B%5D=out&aggregation_groups%5Bmarkets%5D%5B_terms%5D%5B%5D=flori&aggregation_groups%5Bmarkets%5D%5B_terms%5D%5B%5D=alna&aggregation_groups%5Bmarkets%5D%5B_terms%5D%5B%5D=res&aggregation_groups%5Bmarkets%5D%5B_terms%5D%5B%5D=gour&aggregation_groups%5Bmarkets%5D%5B_terms%5D%5B%5D=cof&aggregation_groups%5Bmarkets%5D%5B_terms%5D%5B%5D=res&aggregation_groups%5Bmarkets%5D%5B_terms%5D%5B%5D=gour&aggregation_groups%5Bmarkets%5D%5B_terms%5D%5B%5D=cof&aggregation_groups%5Bservices%5D%5Bsub_type%5D%5B_terms%5D%5B%5D=market-service-mig_clean&aggregation_groups%5Bservices%5D%5Bsub_type%5D%5B_terms%5D%5B%5D=market-service-mig_online&aggregation_groups%5Bservices%5D%5Bsub_type%5D%5B_terms%5D%5B%5D=pickmup&aggregation_groups%5Bservices%5D%5Bsub_type%5D%5B_terms%5D%5B%5D=post-service-point&aggregation_groups%5Bservices%5D%5Bsub_type%5D%5B_terms%5D%5B%5D=subito-selfscanning&aggregation_groups%5Bservices%5D%5Bsub_type%5D%5B_terms%5D%5B%5D=subito-selfcheckout&aggregation_groups%5Bservices%5D%5Bsub_type%5D%5B_terms%5D%5B%5D=market-service-mig_bakery&aggregation_groups%5Bservices%5D%5Bsub_type%5D%5B_terms%5D%5B%5D=counter-mez&aggregation_groups%5Bservices%5D%5Bsub_type%5D%5B_terms%5D%5B%5D=counter-fisch&aggregation_groups%5Bservices%5D%5Bsub_type%5D%5B_terms%5D%5B%5D=counter-kaes&aggregation_groups%5Bservices%5D%5Bsub_type%5D%5B_terms%5D%5B%5D=srv${
+      idsFilter ? `&ids[]=${idsFilter}` : ''
+    }`,
+    {
+      credentials: 'omit',
+      headers: {
+        accept: 'application/json, text/javascript, */*; q=0.01',
+        'accept-language': 'de',
+        'sec-fetch-mode': 'cors',
+        origin: 'https://filialen.migros.ch',
+        DNT: '1',
+        'user-agent':
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36'
+      },
+      body: null,
+      method: 'GET'
+    }
+  );
+  const result = await data.json();
+  const { stores = [] } = result || {};
+  return stores.flatMap(({ markets = [], location, id } = {}) => {
+    return markets.map(({ full_name }) => { // eslint-disable-line
+      const {
+        geo: { lat, lon },
+        zip,
+        country,
+        address,
+        city,
+        address2
+      } = location;
+      return {
+        _id: id,
+        name: full_name,
+        address: {
+          addressLine: address,
+          addressLine2: address2,
+          postalCode: zip,
+          countryCode: country,
+          city
+        },
+        geoPoint: {
+          latitude: lat,
+          longitude: lon
+        }
+      };
+    });
+  });
+};
+
+class PickMup extends DeliveryAdapter {
+  static key = 'shop.unchained.pick-mup';
+
+  static label = 'Migros Pick M Up';
+
+  static version = '1.0';
+
+  static initialConfiguration = [{ key: 'key', value: '' }];
+
+  isActive() { // eslint-disable-line
+    return false;
+  }
+
+  static typeSupported(type) {
+    return type === 'PICKUP';
+  }
+
+  getKey() {
+    // Load https://filialen.migros.ch/de/filter:market_services-pickmup, open the browser developer tools and look for the sessionKey:
+    // <html lang="de" data-setup="{'env': 'production','sessionKey': '8ApUDaqeNER3Mest'}" class="no-js">
+    return this.config.reduce((current, item) => {
+      if (item.key === 'key') return item.value;
+      return current;
+    }, null);
+  }
+
+  configurationError() { // eslint-disable-line
+    if (!this.getKey()) {
+      return DeliveryError.INCOMPLETE_CONFIGURATION;
+    }
+    return null;
+  }
+
+  async estimatedDeliveryThroughput(warehousingThroughputTime) { // eslint-disable-line
+    return 0;
+  }
+
+  async pickUpLocationById(id) {
+    const [foundLocation] = await fetchPickMupLocations(this.getKey(), id);
+    return foundLocation;
+  }
+
+  async pickUpLocations() {
+    const result = await fetchPickMupLocations(this.getKey());
+    return result;
+  }
+}
+
+DeliveryDirector.registerAdapter(PickMup);

--- a/packages/core-delivery/plugins/post.js
+++ b/packages/core-delivery/plugins/post.js
@@ -11,12 +11,15 @@ class Post extends DeliveryAdapter {
   static version = '1.0';
 
   static initialConfiguration = [];
+
   isActive() { // eslint-disable-line
     return false;
   }
-  static typeSupported(type) {  // eslint-disable-line
-    return false;
+
+  static typeSupported(type) {
+    return type === 'SHIPPING';
   }
+
   configurationError() { // eslint-disable-line
     return null;
   }

--- a/packages/core-warehousing/plugins/google-sheets.js
+++ b/packages/core-warehousing/plugins/google-sheets.js
@@ -145,6 +145,7 @@ class GoogleSheets extends WarehousingAdapter {
   async commissioningTime(quantity) {
     const { product, deliveryProvider } = this.context;
     const { sku } = product.warehousing || {};
+    if (!sku) return null;
     const { type } = deliveryProvider;
     const selector = `DELIVERY_HOURS:${type}`;
     const timeInHours = await this.getRemoteTime(


### PR DESCRIPTION
- adds all/active pickupLocations feature to pickup providers, 
- removes address from Pickup providers (breaking)
- adds Pick-M-Up Dummy plugin to test the feature

OrderPickupDelivery.pickUpLocations
OrderPickupDelivery.activePickUpLocation
OrderPickUpLocation
GeoPosition