### PR TITLE
Fix: Worker: Only parse JSON if it is JSON

### DIFF
--- a/packages/core-worker/plugins/http-request.js
+++ b/packages/core-worker/plugins/http-request.js
@@ -24,9 +24,12 @@ class HttpRequestWorkerPlugin extends WorkerPlugin {
         headers: { 'Content-Type': 'application/json', ...headers }
       });
 
-      const result = await res.json();
+      const contentType = res.headers.get('content-type');
+      const isJson = contentType && contentType.includes('application/json');
 
-      if (res.status === 200) {
+      const result = isJson ? await res.json() : { text: await res.text() };
+
+      if (res.status === 200 && res.ok) {
         return { success: true, result };
       }
       return { success: false, result };


### PR DESCRIPTION
Only try to parse JSON if the content is actually marked as JSON. Otherwise, just use the response as text.