### PR TITLE
endpoint returns deleted bookmark

### DIFF
--- a/packages/api/resolvers/mutations/bookmark.js
+++ b/packages/api/resolvers/mutations/bookmark.js
@@ -11,5 +11,5 @@ export default function(root, { productId, bookmarked }, { userId }) {
     return Bookmarks.createBookmark({ productId, userId });
   }
   if (foundBookmark) Bookmarks.removeBookmark({ _id: foundBookmark._id });
-  return null;
+  return foundBookmark;
 }

--- a/packages/api/schema/mutation.js
+++ b/packages/api/schema/mutation.js
@@ -625,7 +625,7 @@ export default [
       """
       Bookmarks a product as currently logged in user
       """
-      bookmark(productId: ID!, bookmarked: Boolean = true): Bookmark
+      bookmark(productId: ID!, bookmarked: Boolean = true): Bookmark!
 
       """
       Create a bookmark for a specific user


### PR DESCRIPTION

Currently when removing a bookmark using the `bookmark` mutation unchained will return `null`:
```gql
bookmark(
  productId: ID!
  bookmarked: Boolean = true
): Bookmark
```
This pr changes this behaviour by returning the removed bookmark. The `removeBookmark` mutation already behaves like this.
