### PR TITLE
Tests filters

### DIFF
--- a/packages/api/resolvers/mutations/createFilter.js
+++ b/packages/api/resolvers/mutations/createFilter.js
@@ -1,21 +1,11 @@
 import { log } from 'meteor/unchained:core-logger';
-import { Filters, FilterTypes } from 'meteor/unchained:core-filters';
+import { Filters } from 'meteor/unchained:core-filters';
 
-export default function(
-  root,
-  { filter: inputData },
-  { localeContext, userId }
-) {
+export default function(root, { filter }, { localeContext, userId }) {
   log('mutation createFilter', { userId });
-  const { key, type, title, options } = inputData;
-  const filter = {
-    created: new Date(),
-    type: FilterTypes[type],
-    key,
-    options
-  };
-  const filterId = Filters.insert(filter);
-  const filterObject = Filters.findOne({ _id: filterId });
-  filterObject.upsertLocalizedText(localeContext.language, { title });
-  return filterObject;
+  return Filters.createFilter({
+    locale: localeContext.language,
+    authorId: userId,
+    ...filter
+  });
 }

--- a/packages/api/resolvers/mutations/removeFilter.js
+++ b/packages/api/resolvers/mutations/removeFilter.js
@@ -3,7 +3,5 @@ import { Filters } from 'meteor/unchained:core-filters';
 
 export default function(root, { filterId }, { userId }) {
   log(`mutation removeFilter ${filterId}`, { userId });
-  const filter = Filters.findOne({ _id: filterId });
-  Filters.remove({ _id: filterId });
-  return filter;
+  return Filters.removeFilter({ filterId });
 }

--- a/packages/api/resolvers/mutations/updateFilter.js
+++ b/packages/api/resolvers/mutations/updateFilter.js
@@ -3,14 +3,8 @@ import { Filters } from 'meteor/unchained:core-filters';
 
 export default function(root, { filter, filterId }, { userId }) {
   log(`mutation updateFilter ${filterId}`, { userId });
-  Filters.update(
-    { _id: filterId },
-    {
-      $set: {
-        ...filter,
-        updated: new Date()
-      }
-    }
-  );
-  return Filters.findOne({ _id: filterId });
+  return Filters.updateFilter({
+    filterId,
+    ...filter
+  });
 }

--- a/packages/core-filters/plugins/local-search.js
+++ b/packages/core-filters/plugins/local-search.js
@@ -61,14 +61,22 @@ class LocalSearch extends FilterAdapter {
   }
 
   async transformFilterSelector(last) {
-    // eslint-disable-line
     const { query = {} } = this.context;
-    const { queryString } = query;
+    const { queryString, filterIds, includeInactive } = query;
 
-    if (queryString) {
-      return {
-        isActive: true
-      };
+    if (queryString && !filterIds) {
+      // Global search without assortment scope:
+      // Return all filters
+      const selector = { ...last };
+      if (selector?.key) {
+        // Do not restrict to keys
+        delete selector.key;
+      }
+      if (!includeInactive) {
+        // Include only active filters
+        selector.isActive = true;
+      }
+      return selector;
     }
 
     return last;

--- a/packages/core-filters/plugins/local-search.js
+++ b/packages/core-filters/plugins/local-search.js
@@ -30,8 +30,7 @@ class LocalSearch extends FilterAdapter {
 
     if (!queryString) return productIdResolver;
 
-    const allProductIds = await productIdResolver;
-    if (allProductIds && allProductIds.length === 0) return productIdResolver;
+    const restrictedProductIds = await productIdResolver;
 
     const selector = AMAZON_DOCUMENTDB_COMPAT_MODE
       ? {
@@ -48,7 +47,9 @@ class LocalSearch extends FilterAdapter {
           $text: { $search: queryString }
         };
 
-    selector.productId = { $in: allProductIds };
+    if (restrictedProductIds) {
+      selector.productId = { $in: new Set(restrictedProductIds) };
+    }
 
     const productIds = ProductTexts.find(selector, {
       fields: {

--- a/packages/core-filters/plugins/local-search.js
+++ b/packages/core-filters/plugins/local-search.js
@@ -59,6 +59,20 @@ class LocalSearch extends FilterAdapter {
 
     return productIds;
   }
+
+  async transformFilterSelector(last) {
+    // eslint-disable-line
+    const { query = {} } = this.context;
+    const { queryString } = query;
+
+    if (queryString) {
+      return {
+        isActive: true
+      };
+    }
+
+    return last;
+  }
 }
 
 FilterDirector.registerAdapter(LocalSearch);

--- a/packages/core-filters/search/resolve-filter-selector.js
+++ b/packages/core-filters/search/resolve-filter-selector.js
@@ -1,10 +1,6 @@
 import { FilterDirector } from 'meteor/unchained:core-filters';
 
-const defaultSelector = ({
-  filterIds = [],
-  filterQuery = {},
-  includeInactive
-}) => {
+const defaultSelector = ({ filterIds, filterQuery = {}, includeInactive }) => {
   const selector = {};
   const keys = Object.keys(filterQuery);
   if (Array.isArray(filterIds)) {

--- a/tests/filters.test.js
+++ b/tests/filters.test.js
@@ -70,7 +70,11 @@ describe('Filters', () => {
             $queryString: String
             $filterQuery: [FilterQueryInput!]
           ) {
-            search(queryString: $queryString, filterQuery: $filterQuery) {
+            search(
+              queryString: $queryString
+              filterQuery: $filterQuery
+              includeInactive: true
+            ) {
               totalProducts
               filters {
                 filteredProducts
@@ -97,7 +101,20 @@ describe('Filters', () => {
       });
       expect(search).toMatchObject({
         totalProducts: 1,
-        filters: expect.anything()
+        filters: [
+          {
+            filteredProducts: 1,
+            definition: {
+              key: 'tags'
+            }
+          },
+          {
+            filteredProducts: 1,
+            definition: {
+              key: 'warehousing.baseUnit'
+            }
+          }
+        ]
       });
     });
   });

--- a/tests/filters.test.js
+++ b/tests/filters.test.js
@@ -1,0 +1,68 @@
+import { setupDatabase, createLoggedInGraphqlFetch } from './helpers';
+import { ADMIN_TOKEN } from './seeds/users';
+
+let connection;
+let db; // eslint-disable-line
+let graphqlFetch;
+
+describe('Filters', () => {
+  beforeAll(async () => {
+    [db, connection] = await setupDatabase();
+    graphqlFetch = await createLoggedInGraphqlFetch(ADMIN_TOKEN);
+  });
+
+  afterAll(async () => {
+    await connection.close();
+  });
+
+  describe('Mutation.createFilter', () => {
+    it('create a new filter', async () => {
+      const { data: { createFilter } = {} } = await graphqlFetch({
+        query: /* GraphQL */ `
+          mutation createFilter($filter: CreateFilterInput!) {
+            createFilter(filter: $filter) {
+              _id
+              isActive
+              texts {
+                title
+              }
+              type
+              key
+              options {
+                _id
+                texts {
+                  _id
+                  title
+                  subtitle
+                }
+                value
+              }
+            }
+          }
+        `,
+        variables: {
+          filter: {
+            key: 'warehousing.baseUnit',
+            title: 'Mengeneinheit Filter',
+            type: 'SINGLE_CHOICE',
+            options: ['ST']
+          }
+        }
+      });
+      expect(createFilter).toMatchObject({
+        isActive: false,
+        texts: {
+          title: 'Mengeneinheit Filter'
+        },
+        type: 'SINGLE_CHOICE',
+        key: 'warehousing.baseUnit',
+        options: [
+          {
+            texts: null,
+            value: 'ST'
+          }
+        ]
+      });
+    });
+  });
+});

--- a/tests/filters.test.js
+++ b/tests/filters.test.js
@@ -16,7 +16,7 @@ describe('Filters', () => {
   });
 
   describe('Mutation.createFilter', () => {
-    it('create a new filter', async () => {
+    it('create a new single choice filter', async () => {
       const { data: { createFilter } = {} } = await graphqlFetch({
         query: /* GraphQL */ `
           mutation createFilter($filter: CreateFilterInput!) {
@@ -62,6 +62,42 @@ describe('Filters', () => {
             value: 'ST'
           }
         ]
+      });
+
+      const { data: { search } = {} } = await graphqlFetch({
+        query: /* GraphQL */ `
+          query search(
+            $queryString: String
+            $filterQuery: [FilterQueryInput!]
+          ) {
+            search(queryString: $queryString, filterQuery: $filterQuery) {
+              totalProducts
+              filters {
+                filteredProducts
+                definition {
+                  _id
+                  key
+                }
+                options {
+                  isSelected
+                  filteredProducts
+                  definition {
+                    _id
+                    value
+                  }
+                }
+              }
+            }
+          }
+        `,
+        variables: {
+          queryString: 'product',
+          filterQuery: null
+        }
+      });
+      expect(search).toMatchObject({
+        totalProducts: 1,
+        filters: expect.anything()
       });
     });
   });

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -12,6 +12,7 @@ import seedPayments from './seeds/payments';
 import seedWarehousings from './seeds/warehousings';
 import seedOrders from './seeds/orders';
 import seedQuotations from './seeds/quotations';
+import seedFilters from './seeds/filters';
 
 Collection.prototype.findOrInsertOne = async function findOrInsertOne(
   doc,
@@ -40,6 +41,7 @@ export const setupDatabase = async () => {
   await seedWarehousings(db);
   await seedOrders(db);
   await seedQuotations(db);
+  await seedFilters(db);
 
   return [db, connection];
 };

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -26,15 +26,6 @@ Collection.prototype.findOrInsertOne = async function findOrInsertOne(
   }
 };
 
-const clearCollections = async db => {
-  const collections = await db.collections();
-  return Promise.all(
-    collections.map(async collection => {
-      return collection.deleteMany({});
-    })
-  );
-};
-
 export const setupDatabase = async () => {
   const connection = await MongoClient.connect(global.__MONGO_URI__, {
     useNewUrlParser: true,
@@ -42,7 +33,7 @@ export const setupDatabase = async () => {
     poolSize: 1
   });
   const db = await connection.db(global.__MONGO_DB_NAME__);
-  await clearCollections(db);
+  await db.dropDatabase();
   await seedUsers(db);
   await seedProducts(db);
   await seedDeliveries(db);
@@ -62,7 +53,7 @@ export const wipeDatabase = async () => {
     useUnifiedTopology: true
   });
   const db = await connection.db(global.__MONGO_DB_NAME__);
-  await clearCollections(db);
+  await db.dropDatabase();
   await connection.close();
 };
 

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -26,6 +26,15 @@ Collection.prototype.findOrInsertOne = async function findOrInsertOne(
   }
 };
 
+const clearCollections = async db => {
+  const collections = await db.collections();
+  return Promise.all(
+    collections.map(async collection => {
+      return collection.deleteMany({});
+    })
+  );
+};
+
 export const setupDatabase = async () => {
   const connection = await MongoClient.connect(global.__MONGO_URI__, {
     useNewUrlParser: true,
@@ -33,7 +42,7 @@ export const setupDatabase = async () => {
     poolSize: 1
   });
   const db = await connection.db(global.__MONGO_DB_NAME__);
-  await db.dropDatabase();
+  await clearCollections(db);
   await seedUsers(db);
   await seedProducts(db);
   await seedDeliveries(db);
@@ -53,7 +62,7 @@ export const wipeDatabase = async () => {
     useUnifiedTopology: true
   });
   const db = await connection.db(global.__MONGO_DB_NAME__);
-  await db.dropDatabase();
+  await clearCollections(db);
   await connection.close();
 };
 

--- a/tests/seeds/assortments.js
+++ b/tests/seeds/assortments.js
@@ -1,0 +1,68 @@
+export const SimpleAssortment = {
+  _id: 'simple-assortment',
+  created: new Date('2019-07-30T09:23:26.253+0000'),
+  type: 'SIMPLE_PRODUCT',
+  status: 'ACTIVE',
+  sequence: 0,
+  authorId: 'admin',
+  slugs: ['old-slug-de', 'slug-de', 'slug-fr'],
+  updated: new Date('2019-09-10T14:29:37.015+0000'),
+  published: new Date('2019-07-30T09:23:57.329+0000'),
+  warehousing: {
+    sku: 'SKU',
+    baseUnit: 'ST'
+  },
+  tags: ['tag-1', 'tag-2', 'highlight'],
+  commerce: {
+    pricing: [
+      {
+        amount: 10000,
+        maxQuantity: 0,
+        isTaxable: true,
+        isNetPrice: false,
+        currencyCode: 'CHF',
+        countryCode: 'CH'
+      }
+    ]
+  },
+  supply: {
+    weightInGram: 1570,
+    heightInMillimeters: 250,
+    lengthInMillimeters: 300,
+    widthInMillimeters: 400
+  }
+};
+
+export const GermanAssortmentText = {
+  _id: 'german',
+  locale: 'de',
+  assortmentId: 'simple-assortment',
+  slug: 'slug-de',
+  title: 'simple assortment de',
+  updated: new Date('2019-09-10T14:28:46.103+0000'),
+  brand: 'brand-de',
+  description: 'text-de',
+  labels: ['label-de-1', 'label-de-2'],
+  subtitle: 'subsimple assortment de',
+  vendor: 'vendor-de'
+};
+
+export const FrenchAssortmentText = {
+  _id: 'french',
+  locale: 'fr',
+  assortmentId: 'simple-assortment',
+  labels: ['label-fr-1'],
+  slug: 'slug-fr',
+  title: 'title-fr',
+  updated: new Date('2019-09-10T14:28:46.105+0000'),
+  brand: 'brand-fr-1',
+  description: 'text-fr-1',
+  subtitle: 'subtitle-fr',
+  vendor: 'vendor-fr-1'
+};
+
+export default async function seedAssortments(db) {
+  await db.collection('assortments').findOrInsertOne(SimpleAssortment);
+  await db.collection('assortment_texts').findOrInsertOne(GermanAssortmentText);
+  await db.collection('assortment_texts').findOrInsertOne(FrenchAssortmentText);
+}

--- a/tests/seeds/filters.js
+++ b/tests/seeds/filters.js
@@ -3,12 +3,12 @@ export const MultiChoiceFilter = {
   created: new Date('2020-03-16T09:31:42.690+0000'),
   type: 'MULTI_CHOICE',
   key: 'tags',
-  options: [],
+  options: ['highlight', 'tag-1', 'tag-2'],
   updated: new Date('2020-03-16T09:32:31.996+0000'),
   isActive: true
 };
 
-export const GermanFilterText = {
+export const GermanMultiChoiceFilterText = {
   _id: 'german',
   filterId: 'multichoice-filter',
   filterOptionValue: null,
@@ -18,7 +18,7 @@ export const GermanFilterText = {
   subtitle: null
 };
 
-export const FrenchFilterText = {
+export const FrenchMultiChoiceFilterText = {
   _id: 'french',
   filterId: 'multichoice-filter',
   filterOptionValue: null,
@@ -28,6 +28,10 @@ export const FrenchFilterText = {
 
 export default async function seedFilters(db) {
   await db.collection('filters').findOrInsertOne(MultiChoiceFilter);
-  await db.collection('filter_texts').findOrInsertOne(GermanFilterText);
-  await db.collection('filter_texts').findOrInsertOne(FrenchFilterText);
+  await db
+    .collection('filter_texts')
+    .findOrInsertOne(GermanMultiChoiceFilterText);
+  await db
+    .collection('filter_texts')
+    .findOrInsertOne(FrenchMultiChoiceFilterText);
 }

--- a/tests/seeds/filters.js
+++ b/tests/seeds/filters.js
@@ -1,0 +1,33 @@
+export const MultiChoiceFilter = {
+  _id: 'multichoice-filter',
+  created: new Date('2020-03-16T09:31:42.690+0000'),
+  type: 'MULTI_CHOICE',
+  key: 'tags',
+  options: [],
+  updated: new Date('2020-03-16T09:32:31.996+0000'),
+  isActive: true
+};
+
+export const GermanFilterText = {
+  _id: 'german',
+  filterId: 'multichoice-filter',
+  filterOptionValue: null,
+  locale: 'de',
+  title: 'Special',
+  updated: new Date('2020-03-16T09:32:10.940+0000'),
+  subtitle: null
+};
+
+export const FrenchFilterText = {
+  _id: 'french',
+  filterId: 'multichoice-filter',
+  filterOptionValue: null,
+  locale: 'fr',
+  updated: new Date('2020-03-16T09:32:10.943+0000')
+};
+
+export default async function seedFilters(db) {
+  await db.collection('filters').findOrInsertOne(MultiChoiceFilter);
+  await db.collection('filter_texts').findOrInsertOne(GermanFilterText);
+  await db.collection('filter_texts').findOrInsertOne(FrenchFilterText);
+}

--- a/tests/seeds/products.js
+++ b/tests/seeds/products.js
@@ -12,7 +12,7 @@ export const SimpleProduct = {
     sku: 'SKU',
     baseUnit: 'ST'
   },
-  tags: ['tag-1', 'tag-2'],
+  tags: ['tag-1', 'tag-2', 'highlight'],
   commerce: {
     pricing: [
       {

--- a/tests/seeds/products.js
+++ b/tests/seeds/products.js
@@ -38,7 +38,7 @@ export const GermanProductText = {
   locale: 'de',
   productId: 'simple-product',
   slug: 'slug-de',
-  title: 'title-de',
+  title: 'simple product title de',
   updated: new Date('2019-09-10T14:28:46.103+0000'),
   brand: 'brand-de',
   description: 'text-de',
@@ -53,7 +53,7 @@ export const FrenchProductText = {
   productId: 'simple-product',
   labels: ['label-fr-1'],
   slug: 'slug-fr',
-  title: 'title-fr',
+  title: 'simple product title fr',
   updated: new Date('2019-09-10T14:28:46.105+0000'),
   brand: 'brand-fr-1',
   description: 'text-fr-1',
@@ -133,6 +133,9 @@ export const SimpleProductReview = {
 };
 
 export default async function seedProducts(db) {
+  await db.collection('product_texts').createIndex({
+    title: 'text'
+  });
   await db.collection('products').findOrInsertOne(SimpleProduct);
   await db.collection('product_reviews').findOrInsertOne(SimpleProductReview);
   await db.collection('product_texts').findOrInsertOne(GermanProductText);


### PR DESCRIPTION
Breaking:

- Full text search now correctly returns an empty resultset if the search has been upfront limited by a productId list of 0 array items (fixes an edge case with the local search provider)
- Unscoped Faceted search now returns all active filters when the local-search plugin is activated
- Unscoped Faceted search now returns even inactive filters if the filterQuery has a key of an existent filter

Minor:
- Allow skipInvalidation flags on createFilter and updateFilter