### PR TITLE
Add search capability to assortment products select

### DIFF
--- a/examples/controlpanel/components/assortments/FormNewAssortmentProduct.jsx
+++ b/examples/controlpanel/components/assortments/FormNewAssortmentProduct.jsx
@@ -1,16 +1,124 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { toast } from 'react-toastify';
 import { compose, mapProps, withHandlers } from 'recompose';
-import { Segment } from 'semantic-ui-react';
+import {
+  Segment,
+  Dropdown,
+  Header,
+  Image as SemanticImage,
+} from 'semantic-ui-react';
 import { withRouter } from 'next/router';
 import gql from 'graphql-tag';
 import { graphql } from 'react-apollo';
+import { debounce, has } from 'lodash';
+import { useQuery } from '@apollo/react-hooks';
+import { connectField } from 'uniforms';
 import AutoField from 'uniforms-semantic/AutoField';
 import SubmitField from 'uniforms-semantic/SubmitField';
 import ErrorsField from 'uniforms-semantic/ErrorsField';
 import AutoForm from 'uniforms-semantic/AutoForm';
 import withFormSchema from '../../lib/withFormSchema';
 import withFormErrorHandlers from '../../lib/withFormErrorHandlers';
+
+const SEARCH_PRODUCTS = gql`
+  query search($queryString: String) {
+    search(queryString: $queryString, includeInactive: true) {
+      totalProducts
+      products {
+        _id
+        texts {
+          _id
+          title
+          description
+        }
+        media {
+          texts {
+            title
+          }
+          file {
+            url
+            name
+          }
+        }
+      }
+    }
+  }
+`;
+
+const ProductSearchDropdown = ({ onChange, value }) => {
+  const [queryString, setQueryString] = useState('');
+  const { data, loading } = useQuery(SEARCH_PRODUCTS, {
+    variables: {
+      queryString,
+    },
+    skip: !queryString,
+  });
+
+  const handleOnChange = (e, result) => {
+    onChange(result.value);
+  };
+
+  const handleSearchChange = (e, result) => {
+    setQueryString(result.searchQuery);
+  };
+
+  const pollyfillImageUrl = 'https://via.placeholder.com/150';
+
+  const selectImage = (result) => {
+    if (!result.media) return pollyfillImageUrl;
+
+    const foundImageObj = result.media.find((mediaObj) => {
+      if (has(mediaObj, 'file.url')) {
+        const imageObj = new Image();
+        imageObj.src = mediaObj.file.url;
+        return imageObj.complete;
+      }
+      return false;
+    });
+    return (
+      (foundImageObj && foundImageObj.file && foundImageObj.file.url) ||
+      pollyfillImageUrl
+    );
+  };
+
+  const options =
+    data?.search?.products.map((opt) => {
+      return {
+        key: opt.texts._id,
+        value: opt.texts._id,
+        text: opt.texts.title,
+        content: (
+          <Header>
+            <SemanticImage src={selectImage(opt.media)} />
+            <Header.Content>
+              {opt.texts.title}
+              <Header.Subheader>{opt.texts.description}</Header.Subheader>
+            </Header.Content>
+          </Header>
+        ),
+      };
+    }) || [];
+  return (
+    <Dropdown
+      search
+      fluid
+      clearable
+      selection
+      placeholder="Select Product"
+      name="product"
+      loading={loading}
+      onChange={handleOnChange}
+      onSearchChange={debounce(handleSearchChange, 500, {
+        leading: true,
+      })}
+      options={options}
+      value={value}
+      style={{ marginBottom: '1em' }}
+    />
+  );
+};
+
+const ProductSearchDropdownField = connectField(ProductSearchDropdown);
 
 const FormNewAssortmentProduct = ({
   products,
@@ -68,6 +176,9 @@ export default compose(
       type: String,
       optional: false,
       label: 'Product',
+      uniforms: {
+        component: ProductSearchDropdownField,
+      },
     },
   }),
   withHandlers({


### PR DESCRIPTION
This PR borrows from #191 and builds on top of it to provide a custom Uniforms Select field with search functionality for assortment products. But there're few things that needs to be tackled before finalizing this PR:

- `selectImage` function is also used in #191, so I reckon that it's best to export `selectImage` from a shared file for common use though what files? Should I just add a new file inside `lib` directory and export from it?

- When you load the assortment products page you actually get an error `Error: Cannot return null for non-nullable field AssortmentProduct.product.` which occurs at the query located in `packages/api/resolvers/queries/products.js`. The query fails to return any products because it's set to return products with active status only `i.e. -> { status: { '$eq': 'ACTIVE' } }`. Now, I don't really understand is this error happening because we're allowing attaching unactive products to an assortment (misconfigured display query) OR I've not properly populated my DB (Products should be set to active always?) [I'm not well versed in the application domain logic, so please bear with me]

![unchained3](https://user-images.githubusercontent.com/6644545/89169352-68426a00-d57e-11ea-9946-b47e5e11c94d.png)


![unchained2](https://user-images.githubusercontent.com/6644545/89168676-7d6ac900-d57d-11ea-80b0-27af7b3bcabb.png)
 