### PR TITLE
Add nodes on-click 

### DIFF
--- a/examples/controlpanel/components/assortments/AssortmentGraph.jsx
+++ b/examples/controlpanel/components/assortments/AssortmentGraph.jsx
@@ -47,7 +47,7 @@ const AssortmentGraph = ({ data, router }) => (
     <Table.Body>
       <Table.Row>
         <Table.Cell>
-          <CytoscapeComponentWithNoSSR data={data} />
+          <CytoscapeComponentWithNoSSR assortments={data.assortments} />
         </Table.Cell>
       </Table.Row>
     </Table.Body>
@@ -86,26 +86,16 @@ export default compose(
       ) {
         _id
         texts {
-          _id
           title
         }
         linkedAssortments {
           _id
           parent {
             _id
-            texts {
-              _id
-              title
-            }
           }
           child {
             _id
-            texts {
-              _id
-              title
-            }
           }
-          tags
         }
       }
     }

--- a/examples/controlpanel/components/assortments/CytoscapeComponent.jsx
+++ b/examples/controlpanel/components/assortments/CytoscapeComponent.jsx
@@ -161,11 +161,13 @@ const CytoscapeComponentWrapper = ({ assortments }) => {
                     label: linkedAssortment.child.texts.title,
                   },
                 },
-                ...nodeEdges.filter((edge) => {
-                  return [nodeIds, linkedAssortment.child._id].includes(
-                    edge.data.target
-                  );
-                }),
+                ...new Set(
+                  nodeEdges.filter((edge) => {
+                    return [nodeIds, linkedAssortment.child._id].includes(
+                      edge.data.target
+                    );
+                  })
+                ),
               ]);
             }
           }

--- a/examples/controlpanel/components/assortments/CytoscapeComponent.jsx
+++ b/examples/controlpanel/components/assortments/CytoscapeComponent.jsx
@@ -161,7 +161,11 @@ const CytoscapeComponentWrapper = ({ assortments }) => {
                     label: linkedAssortment.child.texts.title,
                   },
                 },
-                ...nodeEdges,
+                ...nodeEdges.filter((edge) => {
+                  return [nodeIds, linkedAssortment.child._id].includes(
+                    edge.data.target
+                  );
+                }),
               ]);
             }
           }

--- a/examples/controlpanel/components/assortments/CytoscapeComponent.jsx
+++ b/examples/controlpanel/components/assortments/CytoscapeComponent.jsx
@@ -1,10 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import Cytoscape from 'cytoscape';
 import CytoscapeComponent from 'react-cytoscapejs';
 import dagre from 'cytoscape-dagre';
-import { useQuery } from '@apollo/client';
+import { useApolloClient } from '@apollo/client';
 import gql from 'graphql-tag';
-import remove from 'lodash/remove';
 
 const GET_ASSORTMENT_LINKS = gql`
   query assortmentLinks($assortmentId: ID) {
@@ -36,124 +35,44 @@ Cytoscape.use(dagre);
 const layout = { name: 'dagre', fit: true };
 
 const CytoscapeComponentWrapper = ({ assortments }) => {
-  const [node, setNode] = useState({});
-  const [graphElements, setGraphElements] = useState([]);
-  const { data, loading } = useQuery(GET_ASSORTMENT_LINKS, {
-    variables: {
-      assortmentId: node?.id,
-    },
-    skip: !node?.id,
-  });
+  const client = useApolloClient();
 
-  const drawNode = (item) => {
-    setGraphElements((prevGraphElements) => {
-      return [
-        ...prevGraphElements,
-        {
-          data: {
-            id: item._id,
-            label: item.texts.title,
-          },
-        },
-      ];
+  const elements = [];
+
+  assortments?.forEach((item) => {
+    elements.push({
+      data: {
+        id: item._id,
+        label: item.texts.title,
+      },
     });
-  };
-
-  const drawEdge = (linkedAssortment) => {
-    // We check whether child/target exists or not for linking to work properly
-    // parent already exists since we're searching inside its linked assortments
-    // Also, we check for already existing links before adding new ones since
-    // the parent and child cross-references each other
-    if (
-      assortments.find(
-        (assortment) => assortment._id === linkedAssortment.child._id
-      ) &&
-      !graphElements.find((link) => {
-        return (
-          link.data.source === linkedAssortment.parent._id &&
-          link.data.target === linkedAssortment.child._id
-        );
-      })
-    ) {
-      setGraphElements((prevGraphElements) => {
-        return [
-          ...prevGraphElements,
-          {
+    if (item.linkedAssortments) {
+      item.linkedAssortments.forEach((linkedAssortment) => {
+        // We check whether child/target exists or not for linking to work properly
+        // parent already exists since we're searching inside its linked assortments
+        // Also, we check for already existing links before adding new ones since
+        // the parent and child cross-references each other
+        if (
+          assortments.find(
+            (assortment) => assortment._id === linkedAssortment.child._id
+          ) &&
+          !elements.find((link) => {
+            return (
+              link.data.source === linkedAssortment.parent._id &&
+              link.data.target === linkedAssortment.child._id
+            );
+          })
+        ) {
+          elements.push({
             data: {
               source: linkedAssortment.parent._id,
               target: linkedAssortment.child._id,
             },
-          },
-        ];
+          });
+        }
       });
     }
-  };
-
-  const drawGraph = function () {
-    assortments?.forEach((item) => {
-      drawNode(item);
-
-      if (item.linkedAssortments) {
-        item.linkedAssortments.forEach((linkedAssortment) => {
-          drawEdge(linkedAssortment);
-        });
-      }
-    });
-  };
-
-  useEffect(() => {
-    drawGraph(); // Initial Draw
-  }, []);
-
-  useEffect(() => {
-    data?.assortment?.linkedAssortments.forEach((linkedAssortment) => {
-      if (
-        !graphElements.find(
-          (element) => element.data.id === linkedAssortment.child._id
-        )
-      ) {
-        setGraphElements((prevGraphElements) => {
-          return [
-            ...prevGraphElements,
-            {
-              data: {
-                display: true,
-                id: linkedAssortment.child._id,
-                label: linkedAssortment.child.texts.title,
-              },
-            },
-          ];
-        });
-      }
-
-      // Check for edges
-      if (
-        graphElements.find(
-          (element) => element.data.id === linkedAssortment.child._id
-        ) &&
-        !graphElements.find((element) => {
-          return (
-            element.data.source === linkedAssortment.parent._id &&
-            element.data.target === linkedAssortment.child._id
-          );
-        })
-      ) {
-        setGraphElements((prevGraphElements) => {
-          return [
-            ...prevGraphElements,
-            {
-              data: {
-                source: linkedAssortment.parent._id,
-                target: linkedAssortment.child._id,
-              },
-            },
-          ];
-        });
-      }
-    });
-  }, [node]);
-
-  // console.log('graphElements', graphElements);
+  });
 
   const stylesheet = [
     {
@@ -180,18 +99,57 @@ const CytoscapeComponentWrapper = ({ assortments }) => {
   ];
   return (
     <CytoscapeComponent
-      elements={graphElements}
+      elements={elements}
       layout={layout}
       style={{ width: '100%', height: '600px' }}
       stylesheet={stylesheet}
       cy={(cy) => {
-        cy = cy.on('tap', 'node', function (evt) {
+        cy.on('add', 'node', () => {
+          cy.layout(layout).run();
+          cy.fit();
+        });
+        cy.on('tap', 'node', async function (evt) {
           const node = evt.target;
-          setNode((prevNode) => {
+          const { data } = await client.query({
+            query: GET_ASSORTMENT_LINKS,
+            variables: { assortmentId: node.id() },
+          });
+          const nodeIds = cy.nodes().map((node) => node.id());
+          const edges = cy.edges().map((edge) => {
             return {
-              id: node.id(),
-              display: prevNode !== node.id(),
+              source: edge.source().id(),
+              target: edge.target().id(),
             };
+          });
+          data?.assortment?.linkedAssortments.forEach((linkedAssortment) => {
+            if (
+              !nodeIds.find(
+                (nodeId) => nodeId === linkedAssortment.child._id
+              ) &&
+              !edges.find((edge) => {
+                return (
+                  edge.source === linkedAssortment.parent._id &&
+                  edge.target === linkedAssortment.child._id
+                );
+              })
+            ) {
+              cy.add([
+                {
+                  group: 'nodes',
+                  data: {
+                    id: linkedAssortment.child._id,
+                    label: linkedAssortment.child.texts.title,
+                  },
+                },
+                {
+                  group: 'edges',
+                  data: {
+                    source: linkedAssortment.parent._id,
+                    target: linkedAssortment.child._id,
+                  },
+                },
+              ]);
+            }
           });
         });
       }}

--- a/examples/controlpanel/components/assortments/CytoscapeComponent.jsx
+++ b/examples/controlpanel/components/assortments/CytoscapeComponent.jsx
@@ -1,49 +1,159 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import Cytoscape from 'cytoscape';
 import CytoscapeComponent from 'react-cytoscapejs';
 import dagre from 'cytoscape-dagre';
+import { useQuery } from '@apollo/client';
+import gql from 'graphql-tag';
+import remove from 'lodash/remove';
+
+const GET_ASSORTMENT_LINKS = gql`
+  query assortmentLinks($assortmentId: ID) {
+    assortment(assortmentId: $assortmentId) {
+      _id
+      linkedAssortments {
+        _id
+        parent {
+          _id
+          texts {
+            _id
+            title
+          }
+        }
+        child {
+          _id
+          texts {
+            _id
+            title
+          }
+        }
+      }
+    }
+  }
+`;
 
 Cytoscape.use(dagre);
 
 const layout = { name: 'dagre', fit: true };
 
-const CytoscapeComponentWrapper = ({ data }) => {
-  const elements = [];
-  data.assortments?.forEach((item) => {
-    elements.push({
-      data: {
-        id: item._id,
-        label: item.texts.title,
-      },
-    });
-    if (item.linkedAssortments) {
-      item.linkedAssortments.forEach((linkedAssortment) => {
-        // We check whether child/target exists or not for linking to work properly
-        // parent already exists since we're searching inside its linked assortments
-        // Also, we check for already existing links before adding new ones since 
-        // the parent and child cross-references each other 
+const CytoscapeComponentWrapper = ({ assortments }) => {
+  const [node, setNode] = useState({});
+  const [graphElements, setGraphElements] = useState([]);
+  const { data, loading } = useQuery(GET_ASSORTMENT_LINKS, {
+    variables: {
+      assortmentId: node?.id,
+    },
+    skip: !node?.id,
+  });
 
-        if (
-          data.assortments.find(
-            (assortment) => assortment._id === linkedAssortment.child._id
-          ) &&
-          !elements.find((link) => {
-            return (
-              link.data.source === linkedAssortment.parent._id &&
-              link.data.target === linkedAssortment.child._id
-            );
-          })
-        ) {
-          elements.push({
+  const drawNode = (item) => {
+    setGraphElements((prevGraphElements) => {
+      return [
+        ...prevGraphElements,
+        {
+          data: {
+            id: item._id,
+            label: item.texts.title,
+          },
+        },
+      ];
+    });
+  };
+
+  const drawEdge = (linkedAssortment) => {
+    // We check whether child/target exists or not for linking to work properly
+    // parent already exists since we're searching inside its linked assortments
+    // Also, we check for already existing links before adding new ones since
+    // the parent and child cross-references each other
+    if (
+      assortments.find(
+        (assortment) => assortment._id === linkedAssortment.child._id
+      ) &&
+      !graphElements.find((link) => {
+        return (
+          link.data.source === linkedAssortment.parent._id &&
+          link.data.target === linkedAssortment.child._id
+        );
+      })
+    ) {
+      setGraphElements((prevGraphElements) => {
+        return [
+          ...prevGraphElements,
+          {
             data: {
               source: linkedAssortment.parent._id,
               target: linkedAssortment.child._id,
             },
-          });
-        }
+          },
+        ];
       });
     }
-  });
+  };
+
+  const drawGraph = function () {
+    assortments?.forEach((item) => {
+      drawNode(item);
+
+      if (item.linkedAssortments) {
+        item.linkedAssortments.forEach((linkedAssortment) => {
+          drawEdge(linkedAssortment);
+        });
+      }
+    });
+  };
+
+  useEffect(() => {
+    drawGraph(); // Initial Draw
+  }, []);
+
+  useEffect(() => {
+    data?.assortment?.linkedAssortments.forEach((linkedAssortment) => {
+      if (
+        !graphElements.find(
+          (element) => element.data.id === linkedAssortment.child._id
+        )
+      ) {
+        setGraphElements((prevGraphElements) => {
+          return [
+            ...prevGraphElements,
+            {
+              data: {
+                display: true,
+                id: linkedAssortment.child._id,
+                label: linkedAssortment.child.texts.title,
+              },
+            },
+          ];
+        });
+      }
+
+      // Check for edges
+      if (
+        graphElements.find(
+          (element) => element.data.id === linkedAssortment.child._id
+        ) &&
+        !graphElements.find((element) => {
+          return (
+            element.data.source === linkedAssortment.parent._id &&
+            element.data.target === linkedAssortment.child._id
+          );
+        })
+      ) {
+        setGraphElements((prevGraphElements) => {
+          return [
+            ...prevGraphElements,
+            {
+              data: {
+                source: linkedAssortment.parent._id,
+                target: linkedAssortment.child._id,
+              },
+            },
+          ];
+        });
+      }
+    });
+  }, [node]);
+
+  // console.log('graphElements', graphElements);
 
   const stylesheet = [
     {
@@ -70,10 +180,21 @@ const CytoscapeComponentWrapper = ({ data }) => {
   ];
   return (
     <CytoscapeComponent
-      elements={elements}
+      elements={graphElements}
       layout={layout}
       style={{ width: '100%', height: '600px' }}
       stylesheet={stylesheet}
+      cy={(cy) => {
+        cy = cy.on('tap', 'node', function (evt) {
+          const node = evt.target;
+          setNode((prevNode) => {
+            return {
+              id: node.id(),
+              display: prevNode !== node.id(),
+            };
+          });
+        });
+      }}
       zoom={2}
     />
   );


### PR DESCRIPTION
This PR relies on `cy` prop to set up event listeners to invoke the fetch and display logic for linked assortments of a node(assortment). 

The two event listeners are:
- `cy.on 'tap', 'node'`
This event listens to clicks/taps on nodes and then fetches the linked assortments using Apollo client:
```
const { data } = await client.query({
            query: GET_ASSORTMENT_LINKS,
            variables: { assortmentId: node.id() },
          });
```


- `cy.on 'add', node`
```
cy.on('add', 'node', () => {
          cy.layout(layout).run();
          cy.fit();
        });
```
The listens to the the addition of any new nodes and invokes(resets) the layout to avoid stacking the nodes on top of each other.  