### PR TITLE
Breadcrumb link fix

### DIFF
--- a/examples/controlpanel/components/BreadcrumbTrail.jsx
+++ b/examples/controlpanel/components/BreadcrumbTrail.jsx
@@ -10,7 +10,7 @@ const BreadcrumbTrail = ({ assortmentPaths }) => {
             {pathIndex > 0 && linkIndex === 0 && <br />}
             <Breadcrumb.Section
               key={link.assortmentId}
-              href={`edit?_id=${link.assortmentId}`}
+              href={`?_id=${link.assortmentId}`}
               link
             >
               {link.assortmentTexts.title}


### PR DESCRIPTION
A remedy for https://github.com/unchainedshop/unchained/issues/162
Remove `edit` prefix as it leads to stacking creating resolvable routes.
Example: http://localhost:4000/assortments/edit/edit?_id=wsmjf93iBBQirEoEc
