### PR TITLE
Fix toggle error

### DIFF
--- a/examples/controlpanel/components/orders/OrderList.jsx
+++ b/examples/controlpanel/components/orders/OrderList.jsx
@@ -103,7 +103,8 @@ export default compose(
   withHandlers({
     toggleShowCarts: ({ updateHasMore, isShowCarts, setShowCarts }) => () => {
       setShowCarts(!isShowCarts);
-      updateHasMore(true);
+      // eslint-disable-next-line no-unused-expressions
+      updateHasMore && updateHasMore(true);
     },
   })
 )(OrderList);


### PR DESCRIPTION
On fresh new installation the `updateHasMore` would be undefined yet it's triggered so we perform a simple guard to ensure that it exists.