### PR TITLE
Allow updating quantity and product of a subscription

### DIFF
--- a/packages/api/resolvers/mutations/updateSubscription.js
+++ b/packages/api/resolvers/mutations/updateSubscription.js
@@ -41,7 +41,13 @@ export default async function updateSubscription(
     Subscriptions.updateDelivery({ delivery, subscriptionId });
   }
   if (plan) {
-    Subscriptions.updatePlan({ plan, subscriptionId });
+    if (subscription.status !== SubscriptionStatus.INITIAL) {
+      // If Subscription is not initial, forcefully add a new Period that OVERLAPS the existing periods
+      throw new Error(
+        'TODO: Unchained currently does not support order splitting for subscriptions, therefore updates to quantity, product and configuration of a subscription is forbidden for non initial subscriptions'
+      );
+    }
+    await Subscriptions.updatePlan({ plan, subscriptionId });
   }
   return Subscriptions.findSubscription({ subscriptionId });
 }

--- a/packages/core-subscriptions/plugins/licensed.js
+++ b/packages/core-subscriptions/plugins/licensed.js
@@ -21,7 +21,8 @@ class LicensedSubscriptions extends SubscriptionAdapter {
 
   static orderIndex = 0;
 
-  static isActivatedFor({ usageCalculationType, ...plan }) {  // eslint-disable-line
+  // eslint-disable-next-line
+  static isActivatedFor({ usageCalculationType, ...plan }) {
     return usageCalculationType === 'LICENSED';
   }
 
@@ -42,9 +43,7 @@ class LicensedSubscriptions extends SubscriptionAdapter {
     const { period } = context;
     const beginningOfPeriod = period.start.getTime() <= new Date().getTime();
     if (beginningOfPeriod) {
-      return {
-        context,
-      };
+      return context;
     }
     return null;
   }


### PR DESCRIPTION
This change will allow to change very basic subscription details like the actual product that defines the charging period and the quantity of the product, it fixes #264.

Currently, as long as a subscription is INITIAL, updatePlan will work accordingly but it fails when it's not INITIAL. Before merging this PR, we should add business logic to change an already active subscription's product.

What should happen in that case?

Active Subscription with Product A and 2 periods, one active:
1.2020 - 6.2020
6.2020 - 1.2021

Beeing at date 12.2020 we change the product to Product B which has another price and also is charged monthly so what happens is there will be another period added:

1.2020 - 6.2020
6.2020 - 1.2021 Product A
12.2020 - 1.2021 Product B

That's pretty fine but what if Product B is an upgrade to Product A? In that case we would like to see:
1.2020 - 6.2020
6.2020 - 15.12.2021 Product A
15.12.2020 - 15.1.2021 Product B

There is already an invoice for the former 5.2020 - 1.2021 Product A, so we have to pro-rata deduct and add this situation to the invoice like

15.12.2020 Invoice:
(01.01.2021 - 15.12.2021) Product A Upgrade Credit Note  = - XYZ USD
1 Month Product B = + XYZ USD
Total = Sum of Product A Credit Note and Product B Monthly Price

