### PR TITLE
Remove not found error

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   },
   "scripts": {
     "lint": "eslint packages tests --cache --fix --ext=js --ext=ts",
-    "pretest": "npm run lint --silent && npm run typecheck",
     "lint:ci": "eslint packages tests --ext=jsx --ext=js",
     "test": "jest --runInBand tests/*",
     "test:ci": "jest --ci --runInBand tests/*",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "scripts": {
     "lint": "eslint packages tests --cache --fix --ext=js --ext=ts",
+    "pretest": "npm run lint --silent && npm run typecheck",
     "lint:ci": "eslint packages tests --ext=jsx --ext=js",
     "test": "jest --runInBand tests/*",
     "test:ci": "jest --ci --runInBand tests/*",

--- a/packages/api/resolvers/queries/assortment.js
+++ b/packages/api/resolvers/queries/assortment.js
@@ -1,19 +1,13 @@
 import { log } from 'meteor/unchained:core-logger';
 import { Assortments } from 'meteor/unchained:core-assortments';
-import { InvalidIdError, AssortmentNotFoundError } from '../../errors';
+import { InvalidIdError } from '../../errors';
 
 export default function assortment(root, { assortmentId, slug }, { userId }) {
   log(`query assortment ${assortmentId} ${slug}`, { userId });
 
   if (!assortmentId === !slug) throw new InvalidIdError({ assortmentId, slug });
-
-  const foundAssortment = Assortments.findAssortment({
+  return Assortments.findAssortment({
     assortmentId,
     slug,
   });
-
-  if (!foundAssortment)
-    throw new AssortmentNotFoundError({ assortmentId, slug });
-
-  return foundAssortment;
 }

--- a/packages/api/resolvers/queries/country.js
+++ b/packages/api/resolvers/queries/country.js
@@ -1,13 +1,10 @@
 import { log } from 'meteor/unchained:core-logger';
 import { Countries } from 'meteor/unchained:core-countries';
-import { CountryNotFoundError, InvalidIdError } from '../../errors';
+import { InvalidIdError } from '../../errors';
 
 export default function country(root, { countryId }, { userId }) {
   log(`query country ${countryId}`, { userId });
 
   if (!countryId) throw new InvalidIdError({ countryId });
-  const foundCountry = Countries.findCountry({ countryId });
-  if (!foundCountry) throw new CountryNotFoundError({ countryId });
-
-  return foundCountry;
+  return Countries.findCountry({ countryId });
 }

--- a/packages/api/resolvers/queries/currency.js
+++ b/packages/api/resolvers/queries/currency.js
@@ -1,13 +1,10 @@
 import { log } from 'meteor/unchained:core-logger';
 import { Currencies } from 'meteor/unchained:core-currencies';
-import { CurrencyNotFoundError, InvalidIdError } from '../../errors';
+import { InvalidIdError } from '../../errors';
 
 export default function currency(root, { currencyId }, { userId }) {
   log(`query currency ${currencyId}`, { userId });
 
   if (!currencyId) throw new InvalidIdError({ currencyId });
-  const foundCurrency = Currencies.findCurrency({ currencyId });
-  if (!foundCurrency) throw new CurrencyNotFoundError({ currencyId });
-
-  return foundCurrency;
+  return Currencies.findCurrency({ currencyId });
 }

--- a/packages/api/resolvers/queries/deliveryProvider.js
+++ b/packages/api/resolvers/queries/deliveryProvider.js
@@ -1,6 +1,6 @@
 import { log } from 'meteor/unchained:core-logger';
 import { DeliveryProviders } from 'meteor/unchained:core-delivery';
-import { DeliverProviderNotFoundError, InvalidIdError } from '../../errors';
+import { InvalidIdError } from '../../errors';
 
 export default function deliveryProvider(
   root,
@@ -8,12 +8,6 @@ export default function deliveryProvider(
   { userId }
 ) {
   log(`query deliveryProvider ${deliveryProviderId}`, { userId });
-
   if (!deliveryProviderId) throw new InvalidIdError({ deliveryProviderId });
-
-  const provider = DeliveryProviders.findProvider({ deliveryProviderId });
-
-  if (!provider) throw new DeliverProviderNotFoundError({ deliveryProviderId });
-
-  return provider;
+  return DeliveryProviders.findProvider({ deliveryProviderId });
 }

--- a/packages/api/resolvers/queries/filter.js
+++ b/packages/api/resolvers/queries/filter.js
@@ -1,15 +1,10 @@
 import { log } from 'meteor/unchained:core-logger';
 import { Filters } from 'meteor/unchained:core-filters';
-import { FilterNotFoundError, InvalidIdError } from '../../errors';
+import { InvalidIdError } from '../../errors';
 
 export default function filter(root, { filterId }, { userId }) {
   log(`query filter ${filterId}`, { userId });
 
   if (!filterId) throw new InvalidIdError({ filterId });
-
-  const foundFilter = Filters.findFilter({ filterId });
-
-  if (!foundFilter) throw new FilterNotFoundError({ filterId });
-
-  return foundFilter;
+  return Filters.findFilter({ filterId });
 }

--- a/packages/api/resolvers/queries/language.js
+++ b/packages/api/resolvers/queries/language.js
@@ -1,11 +1,9 @@
 import { log } from 'meteor/unchained:core-logger';
 import { Languages } from 'meteor/unchained:core-languages';
-import { LanguageNotFoundError, InvalidIdError } from '../../errors';
+import { InvalidIdError } from '../../errors';
 
 export default function language(root, { languageId }, { userId }) {
   log(`query language ${languageId}`, { userId });
   if (!languageId) throw new InvalidIdError({ languageId });
-  const foundLanguage = Languages.findLanguage({ languageId });
-  if (!foundLanguage) throw new LanguageNotFoundError({ languageId });
-  return foundLanguage;
+  return Languages.findLanguage({ languageId });
 }

--- a/packages/api/resolvers/queries/order.js
+++ b/packages/api/resolvers/queries/order.js
@@ -1,12 +1,10 @@
 import { log } from 'meteor/unchained:core-logger';
 import { Orders } from 'meteor/unchained:core-orders';
-import { OrderNotFoundError, InvalidIdError } from '../../errors';
+import { InvalidIdError } from '../../errors';
 
 export default function order(root, { orderId }, { userId }) {
   log(`query order ${orderId}`, { userId, orderId });
 
   if (!orderId) throw new InvalidIdError({ orderId });
-  const foundOrder = Orders.findOrder({ orderId });
-  if (!foundOrder) throw new OrderNotFoundError({ orderId });
-  return foundOrder;
+  return Orders.findOrder({ orderId });
 }

--- a/packages/api/resolvers/queries/paymentProvider.js
+++ b/packages/api/resolvers/queries/paymentProvider.js
@@ -1,6 +1,6 @@
 import { log } from 'meteor/unchained:core-logger';
 import { PaymentProviders } from 'meteor/unchained:core-payment';
-import { PaymentProviderNotFoundError, InvalidIdError } from '../../errors';
+import { InvalidIdError } from '../../errors';
 
 export default function paymentProvider(
   root,
@@ -9,8 +9,5 @@ export default function paymentProvider(
 ) {
   log(`query paymentProvider ${paymentProviderId}`, { userId });
   if (!paymentProviderId) throw new InvalidIdError({ paymentProviderId });
-  const provider = PaymentProviders.findProvider({ paymentProviderId });
-  if (!provider) throw new PaymentProviderNotFoundError({ paymentProviderId });
-
-  return provider;
+  return PaymentProviders.findProvider({ paymentProviderId });
 }

--- a/packages/api/resolvers/queries/product.js
+++ b/packages/api/resolvers/queries/product.js
@@ -1,11 +1,10 @@
 import { log } from 'meteor/unchained:core-logger';
 import { Products } from 'meteor/unchained:core-products';
-import { ProductNotFoundError, InvalidIdError } from '../../errors';
+import { InvalidIdError } from '../../errors';
 
 export default function product(root, { productId, slug }, { userId }) {
   log(`query product ${productId} ${slug}`, { userId });
+
   if (!productId === !slug) throw new InvalidIdError({ productId, slug });
-  const foundProduct = Products.findProduct({ productId, slug });
-  if (!foundProduct) throw new ProductNotFoundError({ productId });
-  return foundProduct;
+  return Products.findProduct({ productId, slug });
 }

--- a/packages/api/resolvers/queries/productCatalogPrices.js
+++ b/packages/api/resolvers/queries/productCatalogPrices.js
@@ -1,12 +1,11 @@
 import { log } from 'meteor/unchained:core-logger';
 import { Products } from 'meteor/unchained:core-products';
-import { ProductNotFoundError, InvalidIdError } from '../../errors';
+import { InvalidIdError } from '../../errors';
 
 export default function productCatalogPrices(root, { productId }, { userId }) {
   log(`query productCatalogPrices ${productId}`, { userId });
 
   if (!productId) throw new InvalidIdError({ productId });
   const product = Products.findProduct({ productId });
-  if (!product) throw new ProductNotFoundError({ productId });
-  return product.catalogPrices();
+  return product?.catalogPrices();
 }

--- a/packages/api/resolvers/queries/productReview.js
+++ b/packages/api/resolvers/queries/productReview.js
@@ -1,12 +1,9 @@
 import { log } from 'meteor/unchained:core-logger';
 import { ProductReviews } from 'meteor/unchained:core-products';
-import { ProductReviewNotFoundError, InvalidIdError } from '../../errors';
+import { InvalidIdError } from '../../errors';
 
 export default function productReview(root, { productReviewId }, { userId }) {
   log(`query productReview ${productReviewId}`, { userId });
   if (!productReviewId) throw new InvalidIdError({ productReviewId });
-  const review = ProductReviews.findReview({ productReviewId });
-  if (!review) throw new ProductReviewNotFoundError({ productReviewId });
-
-  return review;
+  return ProductReviews.findReview({ productReviewId });
 }

--- a/packages/api/resolvers/queries/quotation.js
+++ b/packages/api/resolvers/queries/quotation.js
@@ -1,11 +1,10 @@
 import { log } from 'meteor/unchained:core-logger';
 import { Quotations } from 'meteor/unchained:core-quotations';
-import { QuotationNotFoundError, InvalidIdError } from '../../errors';
+import { InvalidIdError } from '../../errors';
 
 export default function quotation(root, { quotationId }, { userId }) {
   log(`query quotation ${quotationId}`, { userId, quotationId });
+
   if (!quotationId) throw new InvalidIdError({ quotationId });
-  const foundQuotation = Quotations.findQuotation({ quotationId });
-  if (!foundQuotation) throw new QuotationNotFoundError({ quotationId });
-  return foundQuotation;
+  return Quotations.findQuotation({ quotationId });
 }

--- a/packages/api/resolvers/queries/search-products.js
+++ b/packages/api/resolvers/queries/search-products.js
@@ -1,10 +1,7 @@
 import { log } from 'meteor/unchained:core-logger';
 import { Assortments } from 'meteor/unchained:core-assortments';
 import { searchProducts } from 'meteor/unchained:core-filters';
-import {
-  QueryStringRequiredError,
-  AssortmentNotFoundError,
-} from '../../errors';
+import { QueryStringRequiredError } from '../../errors';
 
 export default async function searchQuery(root, query, context) {
   const { userId } = context;
@@ -13,8 +10,7 @@ export default async function searchQuery(root, query, context) {
   log(`query search ${assortmentId} ${JSON.stringify(query)}`, { userId });
   if (assortmentId) {
     const assortment = Assortments.findAssortment({ assortmentId });
-    if (!assortment) throw new AssortmentNotFoundError({ assortmentId });
-    return assortment.searchProducts({
+    return assortment?.searchProducts({
       query,
       forceLiveCollection,
       ignoreChildAssortments,

--- a/packages/api/resolvers/queries/shopInfo.ts
+++ b/packages/api/resolvers/queries/shopInfo.ts
@@ -1,9 +1,13 @@
 import { log } from 'meteor/unchained:core-logger';
 import { UnchainedServerContext } from '../../api';
 
-export default function shopInfo(_, __, context: UnchainedServerContext) {
+export default function shopInfo(
+  _,
+  __,
+  context: UnchainedServerContext
+): { version: string } {
   log('query shopInfo', { userId: context.userId });
   return {
-    version: context.version, // eslint-disable-line
+    version: context.version,
   };
 }

--- a/packages/api/resolvers/queries/subscription.js
+++ b/packages/api/resolvers/queries/subscription.js
@@ -1,12 +1,10 @@
 import { log } from 'meteor/unchained:core-logger';
 import { Subscriptions } from 'meteor/unchained:core-subscriptions';
-import { SubscriptionNotFoundError, InvalidIdError } from '../../errors';
+import { InvalidIdError } from '../../errors';
 
 export default function subscription(root, { subscriptionId }, { userId }) {
   log(`query subscription ${subscriptionId}`, { userId, subscriptionId });
+
   if (!subscriptionId) throw new InvalidIdError({ subscriptionId });
-  const foundSubscription = Subscriptions.findSubscription({ subscriptionId });
-  if (!foundSubscription)
-    throw new SubscriptionNotFoundError({ subscriptionId });
-  return foundSubscription;
+  return Subscriptions.findSubscription({ subscriptionId });
 }

--- a/packages/api/resolvers/queries/user.js
+++ b/packages/api/resolvers/queries/user.js
@@ -1,11 +1,8 @@
 import { log } from 'meteor/unchained:core-logger';
 import { Users } from 'meteor/unchained:core-users';
-import { UserNotFoundError } from '../../errors';
 
 export default function user(root, { userId: Id }, { userId: ownUserId }) {
   log(`query user ${Id}`, { Id: ownUserId });
-  const foundUser = Users.findUser({ userId: Id || ownUserId });
-  if (!foundUser) throw new UserNotFoundError({ userId: Id });
 
-  return foundUser;
+  return Users.findUser({ userId: Id || ownUserId });
 }

--- a/packages/api/resolvers/queries/warehousingProvider.js
+++ b/packages/api/resolvers/queries/warehousingProvider.js
@@ -1,6 +1,6 @@
 import { log } from 'meteor/unchained:core-logger';
 import { WarehousingProviders } from 'meteor/unchained:core-warehousing';
-import { WarehousingProviderNotFoundError, InvalidIdError } from '../../errors';
+import { InvalidIdError } from '../../errors';
 
 export default function warehousingProvider(
   root,
@@ -8,13 +8,10 @@ export default function warehousingProvider(
   { userId }
 ) {
   log(`query warehousingProvider ${warehousingProviderId}`, { userId });
+
   if (!warehousingProviderId)
     throw new InvalidIdError({ warehousingProviderId });
-  const foundWarehousingProvider = WarehousingProviders.findProvider({
+  return WarehousingProviders.findProvider({
     warehousingProviderId,
   });
-  if (!foundWarehousingProvider)
-    throw new WarehousingProviderNotFoundError({ warehousingProviderId });
-
-  return foundWarehousingProvider;
 }

--- a/packages/api/resolvers/queries/work.js
+++ b/packages/api/resolvers/queries/work.js
@@ -1,12 +1,10 @@
 import { log } from 'meteor/unchained:core-logger';
 import { WorkerDirector } from 'meteor/unchained:core-worker';
-import { WorkNotFoundError, InvalidIdError } from '../../errors';
+import { InvalidIdError } from '../../errors';
 
 export default function work(root, { workId }, { userId }) {
   log(`query work ${workId}`, { userId });
 
   if (!workId) throw new InvalidIdError({ workId });
-  const foundWork = WorkerDirector.work({ workId });
-  if (!foundWork) throw new WorkNotFoundError({ workId });
-  return foundWork;
+  return WorkerDirector.work({ workId });
 }

--- a/tests/assortments.test.js
+++ b/tests/assortments.test.js
@@ -271,40 +271,6 @@ describe('Assortments', () => {
       expect(assortment._id).toBe(SimpleAssortment[0]._id);
     });
 
-    it('return not found error for non-existing id', async () => {
-      const { errors } = await graphqlFetch({
-        query: /* GraphQL */ `
-          query Assortment($assortmentId: ID, $slug: String) {
-            assortment(assortmentId: $assortmentId, slug: $slug) {
-              _id
-            }
-          }
-        `,
-        variables: {
-          assortmentId: 'non-existing-id',
-        },
-      });
-
-      expect(errors[0]?.extensions?.code).toEqual('AssortmentNotFoundError');
-    });
-
-    it('return not found error for non-existing slug', async () => {
-      const { errors } = await graphqlFetch({
-        query: /* GraphQL */ `
-          query Assortment($assortmentId: ID, $slug: String) {
-            assortment(assortmentId: $assortmentId, slug: $slug) {
-              _id
-            }
-          }
-        `,
-        variables: {
-          slug: 'non-existing-slug',
-        },
-      });
-
-      expect(errors[0]?.extensions?.code).toEqual('AssortmentNotFoundError');
-    });
-
     it('return error for non-existing id', async () => {
       const { errors } = await graphqlFetch({
         query: /* GraphQL */ `

--- a/tests/auth-admin.test.js
+++ b/tests/auth-admin.test.js
@@ -121,23 +121,6 @@ describe('Auth for admin users', () => {
         _id: User._id,
       });
     });
-
-    it('returns not found error when passed non existing userID', async () => {
-      const { errors } = await graphqlFetchAsAdminUser({
-        query: /* GraphQL */ `
-          query user($userId: ID) {
-            user(userId: $userId) {
-              _id
-              name
-            }
-          }
-        `,
-        variables: {
-          userId: 'non-existing-id',
-        },
-      });
-      expect(errors[0]?.extensions?.code).toEqual('UserNotFoundError');
-    });
   });
 
   describe('Mutation.updateUserAvatar', () => {

--- a/tests/delivery-providers.test.js
+++ b/tests/delivery-providers.test.js
@@ -192,26 +192,6 @@ describe('DeliveryProviders', () => {
       expect(deliveryProvider?.simulatedPrice?.price?.currency).toEqual('EUR');
     });
 
-    it('return not found error when passed non existing deliveryProviderId', async () => {
-      const {
-        data: { deliveryProvider },
-        errors,
-      } = await graphqlFetch({
-        query: /* GraphQL */ `
-          query DeliveryProvider($deliveryProviderId: ID!) {
-            deliveryProvider(deliveryProviderId: $deliveryProviderId) {
-              _id
-            }
-          }
-        `,
-        variables: {
-          deliveryProviderId: 'non-existing-id',
-        },
-      });
-      expect(deliveryProvider).toBe(null);
-      expect(errors[0]?.extensions?.code).toBe('DeliverProviderNotFoundError');
-    });
-
     it('return error when passed invalid deliveryProviderId', async () => {
       const {
         data: { deliveryProvider },

--- a/tests/filters.test.js
+++ b/tests/filters.test.js
@@ -134,26 +134,6 @@ describe('Filters', () => {
       expect(filter._id).toEqual(MultiChoiceFilter._id);
     });
 
-    it('return not found error when passed non existing filterId', async () => {
-      const {
-        data: { filter },
-        errors,
-      } = await graphqlFetch({
-        query: /* GraphQL */ `
-          query Filter($filterId: ID!) {
-            filter(filterId: $filterId) {
-              _id
-            }
-          }
-        `,
-        variables: {
-          filterId: 'non-existing-id',
-        },
-      });
-      expect(filter).toBe(null);
-      expect(errors[0]?.extensions?.code).toEqual('FilterNotFoundError');
-    });
-
     it('return error when passed invalid filterId', async () => {
       const {
         data: { filter },

--- a/tests/orders.test.js
+++ b/tests/orders.test.js
@@ -204,48 +204,6 @@ describe('Order: Management', () => {
       ).toEqual('EUR');
     });
 
-    it('return order not found error when passed non existing orderId and user is not admin', async () => {
-      const {
-        data: { order },
-        errors,
-      } = await graphqlFetch({
-        query: /* GraphQL */ `
-          query order($orderId: ID!) {
-            order(orderId: $orderId) {
-              _id
-            }
-          }
-        `,
-        variables: {
-          orderId: 'non-existing-id',
-        },
-      });
-
-      expect(order).toBe(null);
-      expect(errors[0]?.extensions?.code).toEqual('OrderNotFoundError');
-    });
-
-    it('return not found error when passed non existing orderId and user is admin', async () => {
-      const {
-        data: { order },
-        errors,
-      } = await adminGraphqlFetch({
-        query: /* GraphQL */ `
-          query order($orderId: ID!) {
-            order(orderId: $orderId) {
-              _id
-            }
-          }
-        `,
-        variables: {
-          orderId: 'non-existing-id',
-        },
-      });
-
-      expect(order).toBe(null);
-      expect(errors[0]?.extensions?.code).toEqual('OrderNotFoundError');
-    });
-
     it('return error when passed invalid orderId and user is admin', async () => {
       const {
         data: { order },

--- a/tests/payment-provider.test.js
+++ b/tests/payment-provider.test.js
@@ -105,28 +105,6 @@ describe('PaymentProviders', () => {
       expect(paymentProvider._id).toEqual(SimplePaymentProvider._id);
     });
 
-    it('return not found error when passed non-existing paymentProviderId', async () => {
-      const {
-        data: { paymentProvider },
-        errors,
-      } = await graphqlFetchAsAdminUser({
-        query: /* GraphQL */ `
-          query PaymentProvider($paymentProviderId: ID!) {
-            paymentProvider(paymentProviderId: $paymentProviderId) {
-              _id
-            }
-          }
-        `,
-        variables: {
-          paymentProviderId: 'non-existing-id',
-        },
-      });
-      expect(paymentProvider).toBe(null);
-      expect(errors[0]?.extensions?.code).toEqual(
-        'PaymentProviderNotFoundError',
-      );
-    });
-
     it('return error when passed invalid paymentProviderId', async () => {
       const {
         data: { paymentProvider },

--- a/tests/product-reviews.test.js
+++ b/tests/product-reviews.test.js
@@ -591,28 +591,6 @@ describe('Products: Reviews', () => {
       });
     });
 
-    it('return not found error when passed non-existing productReviewId', async () => {
-      const { data, errors } = await graphqlFetch({
-        query: /* GraphQL */ `
-          query productReview($productReviewId: ID!) {
-            productReview(productReviewId: $productReviewId) {
-              _id
-              rating
-              title
-              product {
-                _id
-              }
-            }
-          }
-        `,
-        variables: {
-          productReviewId: 'non-existing-id',
-        },
-      });
-      expect(data).toBe(null);
-      expect(errors[0]?.extensions?.code).toEqual('ProductReviewNotFoundError');
-    });
-
     it('return error when passed invalid productReviewId', async () => {
       const { data, errors } = await graphqlFetch({
         query: /* GraphQL */ `

--- a/tests/products.test.js
+++ b/tests/products.test.js
@@ -833,23 +833,6 @@ describe('Products', () => {
       expect(product._id).toEqual('simpleproduct');
     });
 
-    it('return ProductNotFound error when passed non existing product ID', async () => {
-      const { errors } = await graphqlFetchAsAdmin({
-        query: /* GraphQL */ `
-          query product($productId: ID, $slug: String) {
-            product(productId: $productId, slug: $slug) {
-              _id
-            }
-          }
-        `,
-        variables: {
-          productId: 'non-existing-ID',
-        },
-      });
-
-      expect(errors[0]?.extensions?.code).toEqual('ProductNotFoundError');
-    });
-
     it('return InvalidIdError error when passed neither productId or slug', async () => {
       const { errors } = await graphqlFetchAsAdmin({
         query: /* GraphQL */ `
@@ -935,23 +918,6 @@ describe('Products', () => {
       expect(product._id).toEqual('simpleproduct');
     });
 
-    it('return ProductNotFound error when passed non existing slug', async () => {
-      const { errors } = await graphqlFetchAsNormalUser({
-        query: /* GraphQL */ `
-          query product($productId: ID, $slug: String) {
-            product(productId: $productId, slug: $slug) {
-              _id
-            }
-          }
-        `,
-        variables: {
-          slug: 'non-existing-slug',
-        },
-      });
-
-      expect(errors[0]?.extensions?.code).toEqual('ProductNotFoundError');
-    });
-
     it('return InvalidIdError error when passed neither productId or slug', async () => {
       const { errors } = await graphqlFetchAsNormalUser({
         query: /* GraphQL */ `
@@ -1035,23 +1001,6 @@ describe('Products', () => {
       });
 
       expect(product._id).toEqual('simpleproduct');
-    });
-
-    it('return ProductNotFound error when passed non existing slug', async () => {
-      const { errors } = await graphqlFetchAsAnonymousUser({
-        query: /* GraphQL */ `
-          query product($productId: ID, $slug: String) {
-            product(productId: $productId, slug: $slug) {
-              _id
-            }
-          }
-        `,
-        variables: {
-          slug: 'non-existing-slug',
-        },
-      });
-
-      expect(errors[0]?.extensions?.code).toEqual('ProductNotFoundError');
     });
 
     it('return InvalidIdError error when passed neither productId or slug', async () => {

--- a/tests/public-queries.test.js
+++ b/tests/public-queries.test.js
@@ -70,24 +70,6 @@ describe('public queries', () => {
     expect(price.currency).toBe('CHF');
   });
 
-  it('query.productCatalogPrices return not found error when passed non existing productId', async () => {
-    const { data, errors } = await graphqlFetch({
-      query: /* GraphQL */ `
-        {
-          productCatalogPrices(productId: "invalid-product-id") {
-            price {
-              amount
-              currency
-            }
-          }
-        }
-      `,
-    });
-
-    expect(data).toEqual(null);
-    expect(errors[0]?.extensions?.code).toEqual('ProductNotFoundError');
-  });
-
   it('query.productCatalogPrices return error when passed invalid productId', async () => {
     const { data, errors } = await graphqlFetch({
       query: /* GraphQL */ `

--- a/tests/quotations.test.js
+++ b/tests/quotations.test.js
@@ -155,26 +155,6 @@ describe('TranslatedFilterTexts', () => {
       expect(quotation._id).toEqual(ProposedQuotation._id);
     });
 
-    it('return not found error when non-existing id ', async () => {
-      const {
-        data: { quotation },
-        errors,
-      } = await graphqlFetch({
-        query: /* GraphQL */ `
-          query Quotation($quotationId: ID!) {
-            quotation(quotationId: $quotationId) {
-              _id
-            }
-          }
-        `,
-        variables: {
-          quotationId: 'non-existing-id',
-        },
-      });
-      expect(quotation).toBe(null);
-      expect(errors[0]?.extensions?.code).toEqual('QuotationNotFoundError');
-    });
-
     it('return error when invalid id ', async () => {
       const {
         data: { quotation },

--- a/tests/setup-basic.test.js
+++ b/tests/setup-basic.test.js
@@ -489,19 +489,6 @@ describe('basic setup of internationalization and localization context', () => {
       await Countries.deleteOne({ _id: 'de' });
     });
 
-    it('query.country return not found when passed non existing ID', async () => {
-      const { errors } = await graphqlFetch({
-        query: /* GraphQL */ `
-          query {
-            country(countryId: "et") {
-              isoCode
-            }
-          }
-        `,
-      });
-      expect(errors[0]?.extensions?.code).toEqual('CountryNotFoundError');
-    });
-
     it('query.country return error when passed invalid ID', async () => {
       const { errors } = await graphqlFetch({
         query: /* GraphQL */ `

--- a/tests/setup-basic.test.js
+++ b/tests/setup-basic.test.js
@@ -229,19 +229,6 @@ describe('basic setup of internationalization and localization context', () => {
       await Currencies.deleteOne({ _id: 'sigt' });
     });
 
-    it('query.currency return not found error when passed non existing ID', async () => {
-      const { errors } = await graphqlFetch({
-        query: /* GraphQL */ `
-          query {
-            currency(currencyId: "etb") {
-              isoCode
-            }
-          }
-        `,
-      });
-      expect(errors[0]?.extensions?.code).toEqual('CurrencyNotFoundError');
-    });
-
     it('query.currency return error when passed invalid ID', async () => {
       const { errors } = await graphqlFetch({
         query: /* GraphQL */ `

--- a/tests/setup-basic.test.js
+++ b/tests/setup-basic.test.js
@@ -703,20 +703,6 @@ describe('basic setup of internationalization and localization context', () => {
       await Languages.deleteOne({ _id: 'pl' });
     });
 
-    it('query.language return not found error when passed non existing languageId', async () => {
-      const { data: { language } = {}, errors } = await graphqlFetch({
-        query: /* GraphQL */ `
-          query {
-            language(languageId: "amh") {
-              isoCode
-            }
-          }
-        `,
-      });
-      expect(language).toEqual(null);
-      expect(errors[0]?.extensions?.code).toEqual('LanguageNotFoundError');
-    });
-
     it('query.language return error when passed invalid languageId', async () => {
       const { data: { language } = {}, errors } = await graphqlFetch({
         query: /* GraphQL */ `

--- a/tests/subscriptions.test.js
+++ b/tests/subscriptions.test.js
@@ -999,23 +999,6 @@ describe('Subscriptions', () => {
       expect(subscription.isExpired).toBe(true);
     });
 
-    it('return SubscriptionNotFoundError when passed non existing subscription ID', async () => {
-      const { errors } = await graphqlFetchAsAdminUser({
-        query: /* GraphQL */ `
-          query subscription($subscriptionId: ID!) {
-            subscription(subscriptionId: $subscriptionId) {
-              _id
-              isExpired
-            }
-          }
-        `,
-        variables: {
-          subscriptionId: 'non-existing-id',
-        },
-      });
-      expect(errors[0]?.extensions?.code).toEqual('SubscriptionNotFoundError');
-    });
-
     it('return InvalidIdError when passed invalid subscription ID', async () => {
       const { errors } = await graphqlFetchAsAdminUser({
         query: /* GraphQL */ `

--- a/tests/warehousing-provider.test.js
+++ b/tests/warehousing-provider.test.js
@@ -98,28 +98,6 @@ describe('WarehousingProviders', () => {
       expect(warehousingProvider._id).toEqual(SimpleWarehousingProvider._id);
     });
 
-    it('return not found error when passed non existing warehousingProviderId ', async () => {
-      const {
-        data: { warehousingProvider },
-        errors,
-      } = await graphqlFetch({
-        query: /* GraphQL */ `
-          query WarehousingProvider($warehousingProviderId: ID!) {
-            warehousingProvider(warehousingProviderId: $warehousingProviderId) {
-              _id
-            }
-          }
-        `,
-        variables: {
-          warehousingProviderId: 'non-existing-id',
-        },
-      });
-      expect(warehousingProvider).toBe(null);
-      expect(errors[0]?.extensions?.code).toEqual(
-        'WarehousingProviderNotFoundError',
-      );
-    });
-
     it('return error when passed invalid warehousingProviderId ', async () => {
       const {
         data: { warehousingProvider },


### PR DESCRIPTION
i've left `PaymentProviderNotFoundError` from `query.signPaymentProviderForCredentialRegistration` because it's almost a mutation and returning null might not be enough. plus anyone who calls this endpoint should be expected to provide a correct `paymentProviderId`.