### PR TITLE
Fix token expiry assignment

### DIFF
--- a/packages/api/api.ts
+++ b/packages/api/api.ts
@@ -37,25 +37,25 @@ const UNCHAINED_API_VERSION = '1.0.0-beta12'; // eslint-disable-line
 
 export const createContextResolver =
   (unchained: UnchainedAPI) =>
-    async (apolloContext): Promise<UnchainedServerContext> => {
-      const loaders = await instantiateLoaders(apolloContext.req, unchained);
-      // const intermediateContext: Partial<UnchainedServerContext> = {
-      //   ...unchained,
-      //   ...loaders,
-      // };
-      const userContext = await getUserContext(
-        apolloContext.req /* intermediateContext */
-      );
-      const localeContext = await getLocaleContext(apolloContext.req);
-      return {
-        ...apolloContext,
-        ...unchained,
-        ...loaders,
-        ...userContext,
-        ...localeContext,
-        version: UNCHAINED_API_VERSION,
-      };
+  async (apolloContext): Promise<UnchainedServerContext> => {
+    const loaders = await instantiateLoaders(apolloContext.req, unchained);
+    // const intermediateContext: Partial<UnchainedServerContext> = {
+    //   ...unchained,
+    //   ...loaders,
+    // };
+    const userContext = await getUserContext(
+      apolloContext.req /* intermediateContext */
+    );
+    const localeContext = await getLocaleContext(apolloContext.req);
+    return {
+      ...apolloContext,
+      ...unchained,
+      ...loaders,
+      ...userContext,
+      ...localeContext,
+      version: UNCHAINED_API_VERSION,
     };
+  };
 
 let context;
 
@@ -73,8 +73,8 @@ const startUnchainedServer = (options: UnchainedServerOptions) => {
 
   context = customContext
     ? ({ req, res }) => {
-      return customContext({ req, res, unchainedContextFn: contextResolver });
-    }
+        return customContext({ req, res, unchainedContextFn: contextResolver });
+      }
     : contextResolver;
 
   const apolloGraphQLServer = createGraphQLServer({

--- a/packages/api/user-context.ts
+++ b/packages/api/user-context.ts
@@ -42,11 +42,8 @@ export default async (req): Promise<UnchainedServerUserContext> => {
         (tokenInfo) => tokenInfo.hashedToken === hashedToken
       ); // eslint-disable-line
 
-      // get an exploitable token expiration date
-      const expiresAt = accountsServer.tokenExpiration(tokenInformation.when); // eslint-disable-line
-
       // true if the token is expired
-      const isExpired = expiresAt < new Date();
+      const isExpired = new Date(tokenInformation.when) < new Date();
 
       // if the token is still valid, give access to the current user
       // information in the resolvers context

--- a/packages/core-accountsjs/accounts-server.js
+++ b/packages/core-accountsjs/accounts-server.js
@@ -31,7 +31,7 @@ const accountsServerOptions = {
 };
 
 export class UnchainedAccountsServer extends AccountsServer {
-  DEFAULT_LOGIN_EXPIRATION_DAYS = 90;
+  DEFAULT_LOGIN_EXPIRATION_DAYS = 30;
 
   LOGIN_UNEXPIRING_TOKEN_DAYS = 365 * 100;
 
@@ -87,10 +87,11 @@ export class UnchainedAccountsServer extends AccountsServer {
     );
   }
 
+  // eslint-disable-next-line class-methods-use-this
   tokenExpiration(when) {
     // We pass when through the Date constructor for backwards compatibility;
     // `when` used to be a number.
-    return new Date(new Date(when).getTime() + this.getTokenLifetimeMs());
+    return new Date(new Date(when).getTime());
   }
 
   hashLoginToken = (stampedLoginToken) => {
@@ -107,9 +108,8 @@ export class UnchainedAccountsServer extends AccountsServer {
     // Random.secret uses a default value of 43
     // https://github.com/meteor/meteor/blob/devel/packages/random/AbstractRandomGenerator.js#L78
     const date = new Date();
-    const numberOfDaysToAdd = 30;
 
-    const when = new Date(date.setDate(date.getDate() + numberOfDaysToAdd));
+    const when = new Date(date.getTime() + this.getTokenLifetimeMs());
     const stampedLoginToken = randomValueHex(43);
     const userId = user._id ? user._id : user;
     const hashedToken = this.hashLoginToken(stampedLoginToken);

--- a/packages/core-payment/plugins/datatrans-v2/api/authorize.ts
+++ b/packages/core-payment/plugins/datatrans-v2/api/authorize.ts
@@ -6,7 +6,6 @@ import type {
   AuthorizeResponse,
 } from './types';
 
-
 export default async function authorize({
   ...payload
 }: AuthorizeRequestPayload): Promise<AuthorizeResponse> {


### PR DESCRIPTION
fixes login token expiry issue in publicare. default token expiry setting was set to 30 days so no matter what token expiry was set through config parameter, when was today to 30.
I don't see the use of `tokenExpiration` in accounts-server class but it says it's for backward compatibility but it's not used in the code base anywhere but I left it there however