### PR TITLE
Correct datatype for pricing.$.amount

### DIFF
--- a/packages/core-products/src/db/ProductsSchema.js
+++ b/packages/core-products/src/db/ProductsSchema.js
@@ -19,7 +19,7 @@ const ProductCommerceSchema = new SimpleSchema(
     'pricing.$.isNetPrice': Boolean,
     'pricing.$.countryCode': String,
     'pricing.$.currencyCode': String,
-    'pricing.$.amount': String,
+    'pricing.$.amount': Number,
     'pricing.$.maxQuantity': Number,
   },
   { requiredByDefault: false },


### PR DESCRIPTION
`updateProductCommerce` currently fails with a type error