### PR TITLE
Fix events test

### DIFF
--- a/packages/core-events/tests/events-index.test.ts
+++ b/packages/core-events/tests/events-index.test.ts
@@ -25,7 +25,7 @@ describe('Test exports', () => {
     const events = await module.findEvents({
       limit: 10,
       offset: 0,
-      query: { type: 'TEST EVENT' },
+      type: 'TEST EVENT',
     });
 
     assert.isAtLeast(events.length, 1)


### PR DESCRIPTION
The type filtering of the test is currently useless and all events are returned. It still passes, but it can be quite confusing for documentation purposes