### PR TITLE
Fix EventHistoryAdapter

### DIFF
--- a/packages/core-events/src/module/configureEventHistoryAdapter.ts
+++ b/packages/core-events/src/module/configureEventHistoryAdapter.ts
@@ -9,11 +9,11 @@ export const configureEventHistoryAdapter = (Events: Collection<Event>) => {
       subscribe: () => {
         // Do nothing
       },
-      publish: async (eventName, payload: any) => {
+      publish: async (eventName, { payload, context = {} }) => {
         await Events.insertOne({
           type: eventName,
           payload,
-          context: {},
+          context,
           created: new Date(),
         });
       },


### PR DESCRIPTION
You currently need to dereference the inserted payload with event.payload.payload, fixes that and optionally passes context to the event.