### PR TITLE
Payment fixes

### DIFF
--- a/packages/core-payment/plugins/cryptopay.ts
+++ b/packages/core-payment/plugins/cryptopay.ts
@@ -83,7 +83,14 @@ useMiddlewareWithCurrentContext(CRYPTOPAY_WEBHOOK_PATH, async (request, response
       }
     }
     if (convertedAmount && convertedAmount >= totalAmount * (1 - MAX_ALLOWED_DIFF)) {
-      await resolvedContext.modules.orders.payments.markAsPaid(orderPayment, {});
+      await resolvedContext.modules.orders.checkout(
+        order,
+        {
+          transactionContext: { address },
+          paymentContext: { address },
+        },
+        resolvedContext,
+      );
       response.end(JSON.stringify({ success: true }));
     } else {
       paymentLogger.warn(

--- a/packages/core-payment/plugins/postfinance-checkout/index.ts
+++ b/packages/core-payment/plugins/postfinance-checkout/index.ts
@@ -53,7 +53,13 @@ const PostfinanceCheckout: IPaymentAdapter = {
       // eslint-disable-next-line
       configurationError() {
         // eslint-disable-line
-        if (!PFCHECKOUT_SPACE_ID || !PFCHECKOUT_USER_ID || !PFCHECKOUT_SECRET) {
+        if (
+          !PFCHECKOUT_SPACE_ID ||
+          !PFCHECKOUT_USER_ID ||
+          !PFCHECKOUT_SECRET ||
+          !PFCHECKOUT_SUCCESS_URL ||
+          !PFCHECKOUT_FAILED_URL
+        ) {
           return PaymentError.INCOMPLETE_CONFIGURATION;
         }
         return null;

--- a/packages/core-payment/plugins/postfinance-checkout/index.ts
+++ b/packages/core-payment/plugins/postfinance-checkout/index.ts
@@ -14,7 +14,7 @@ import {
   refundTransaction,
   voidTransaction,
 } from './api';
-import { markOrderAsPaid } from './utils';
+import { orderIsPaid } from './utils';
 import './middleware';
 import { CompletionModes, IntegrationModes, SignResponse } from './types';
 
@@ -132,7 +132,7 @@ const PostfinanceCheckout: IPaymentAdapter = {
           return false;
         }
         const transaction = await getTransaction(transactionId);
-        return markOrderAsPaid(transaction, modules.orders);
+        return orderIsPaid(transaction, modules.orders);
       },
 
       cancel: async (transactionContext: any = {}) => {

--- a/packages/core-payment/plugins/postfinance-checkout/utils.ts
+++ b/packages/core-payment/plugins/postfinance-checkout/utils.ts
@@ -17,11 +17,10 @@ export const transactionIsPaid = async (
   return false;
 };
 
-export const markOrderAsPaid = async (
+export const orderIsPaid = async (
   transaction: Transaction,
   orderModule: OrdersModule,
 ): Promise<boolean> => {
-  const transactionId = transaction.id;
   const { orderPaymentId } = transaction.metaData as { orderPaymentId: string };
   if (!orderPaymentId) {
     return false;
@@ -32,9 +31,5 @@ export const markOrderAsPaid = async (
   const order = await orderModule.findOrder({ orderId: orderPayment.orderId });
   const pricing = orderModule.pricingSheet(order);
   const totalAmount = pricing.total({ useNetPrice: false }).amount / 100;
-  if (await transactionIsPaid(transaction, order.currency, totalAmount)) {
-    await orderModule.payments.markAsPaid(orderPayment, { transactionId });
-    return true;
-  }
-  return false;
+  return transactionIsPaid(transaction, order.currency, totalAmount);
 };

--- a/tests/plugins-postfinance-checkout.test.js
+++ b/tests/plugins-postfinance-checkout.test.js
@@ -4,7 +4,7 @@ import { USER_TOKEN } from './seeds/users';
 import { SimplePaymentProvider } from './seeds/payments';
 import { SimpleOrder, SimplePosition, SimplePayment } from './seeds/orders';
 import { SuccTranscationHookPayload, SuccTransactionApiResponse } from './seeds/postfinance-checkout';
-import { markOrderAsPaid } from '../packages/core-payment/plugins/postfinance-checkout/utils';
+import { orderIsPaid } from '../packages/core-payment/plugins/postfinance-checkout/utils';
 
 let db;
 let graphqlFetch;
@@ -307,10 +307,8 @@ if (PFCHECKOUT_SPACE_ID && PFCHECKOUT_USER_ID && PFCHECKOUT_SECRET) {
         }
 
         // Call function that is called by webhook with modified transaction to mock response
-        const hookRes = await markOrderAsPaid(transactionRes, mockedOrderModule);
+        const hookRes = await orderIsPaid(transactionRes, mockedOrderModule);
         expect(hookRes).toBe(true);
-        expect(mockedOrderModule.payments.markAsPaid.mock.calls.length).toBe(1);
-        expect(mockedOrderModule.payments.markAsPaid.mock.calls[0][0]).toEqual({ orderId: 'pfcheckout-order' });
       }, 10000);
 
       it('starts a new transaction with webhook call and too low payment', async () => {
@@ -349,7 +347,7 @@ if (PFCHECKOUT_SPACE_ID && PFCHECKOUT_USER_ID && PFCHECKOUT_SECRET) {
         }
 
         // Call function that is called by webhook with modified transaction to mock response
-        const hookRes = await markOrderAsPaid(transactionRes, mockedOrderModule);
+        const hookRes = await orderIsPaid(transactionRes, mockedOrderModule);
         expect(hookRes).toBe(false);
       }, 10000);
 
@@ -405,7 +403,7 @@ if (PFCHECKOUT_SPACE_ID && PFCHECKOUT_USER_ID && PFCHECKOUT_SECRET) {
         expect(orderPayment.status).not.toBe("PAID");
       }, 10000);
 
-      // Succesful case not tested here, charge calls same function (markOrderAsPaid) as webhook call
+      // Succesful case not tested here, charge calls same function (orderIsPaid) as webhook call
 
     });
   });


### PR DESCRIPTION
- `checkout` instead of `markAsPaid`
- Removed unnecessary DB query in `charge` for Postfinance plugin