### PR TITLE
Test improvements

### DIFF
--- a/tests/assortment-filter.test.js
+++ b/tests/assortment-filter.test.js
@@ -47,7 +47,15 @@ describe('AssortmentFilter', () => {
         },
       });
 
-      expect(reorderAssortmentFilters[0].sortKey).toEqual(11);
+      expect(reorderAssortmentFilters[0]).toEqual(
+        {
+          _id: AssortmentFilters[0]._id,
+          sortKey: 11,
+          tags: AssortmentFilters[0].tags,
+          assortment: { _id: AssortmentFilters[0].assortmentId },
+          filter: { _id: AssortmentFilters[0].filterId }
+        }
+      );
     });
 
     it('skip when passed invalid assortment filter ID', async () => {
@@ -99,8 +107,8 @@ describe('AssortmentFilter', () => {
           ],
         },
       });
-
       expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 
@@ -139,7 +147,11 @@ describe('AssortmentFilter', () => {
         },
       });
 
-      expect(addAssortmentFilter._id).not.toBe(null);
+      expect(addAssortmentFilter).toMatchObject({
+        tags: ['assortment-filter-1'],
+        assortment: { _id: SimpleAssortment[0]._id },
+        filter: { _id: MultiChoiceFilter._id }
+      });
     });
 
     it('return error when passed assortment ID that do not exists', async () => {
@@ -166,6 +178,7 @@ describe('AssortmentFilter', () => {
         },
       });
 
+      expect(errors.length).toEqual(1);
       expect(errors[0].extensions?.code).toEqual('AssortmentNotFoundError');
     });
 
@@ -192,6 +205,7 @@ describe('AssortmentFilter', () => {
           tags: ['assortment-filter-1'],
         },
       });
+      expect(errors.length).toEqual(1);
       expect(errors[0]?.extensions?.code).toEqual('FilterNotFoundError');
     });
 
@@ -218,8 +232,10 @@ describe('AssortmentFilter', () => {
           tags: ['assortment-filter-1'],
         },
       });
+      expect(errors.length).toEqual(1);
       expect(errors[0]?.extensions?.code).toEqual('InvalidIdError');
     });
+
     it('return error when passed invalid assortment ID', async () => {
       const { errors } = await graphqlFetch({
         query: /* GraphQL */ `
@@ -244,6 +260,7 @@ describe('AssortmentFilter', () => {
         },
       });
 
+      expect(errors.length).toEqual(1);
       expect(errors[0].extensions?.code).toEqual('InvalidIdError');
     });
   });
@@ -276,6 +293,7 @@ describe('AssortmentFilter', () => {
       });
 
       expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 
@@ -317,8 +335,10 @@ describe('AssortmentFilter', () => {
           assortmentFilterId: AssortmentFilters[0]._id,
         },
       });
-
       expect(errors.length).toEqual(1);
+      expect(errors[0]?.extensions?.code).toEqual(
+        'AssortmentFilterNotFoundError',
+      );
     });
 
     it('return not found error when passed non existing assortmentFilterId', async () => {
@@ -335,6 +355,7 @@ describe('AssortmentFilter', () => {
         },
       });
 
+      expect(errors.length).toEqual(1);
       expect(errors[0]?.extensions?.code).toEqual(
         'AssortmentFilterNotFoundError',
       );
@@ -354,6 +375,7 @@ describe('AssortmentFilter', () => {
         },
       });
 
+      expect(errors.length).toEqual(1);
       expect(errors[0]?.extensions?.code).toEqual('InvalidIdError');
     });
   });
@@ -382,6 +404,7 @@ describe('AssortmentFilter', () => {
         },
       });
       expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 });

--- a/tests/assortment-links.test.js
+++ b/tests/assortment-links.test.js
@@ -77,6 +77,9 @@ describe('AssortmentLink', () => {
       });
 
       expect(reorderAssortmentLinks.length).toEqual(1);
+      expect(reorderAssortmentLinks[0]).toEqual({
+        _id: AssortmentLinks[0]._id
+      });
     });
   });
 
@@ -104,6 +107,7 @@ describe('AssortmentLink', () => {
       });
 
       expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 
@@ -142,7 +146,11 @@ describe('AssortmentLink', () => {
         },
       });
 
-      expect(addAssortmentLink._id).not.toBe(null);
+      expect(addAssortmentLink).toMatchObject({
+        parent: {_id: SimpleAssortment[0]._id},
+        child: {_id: SimpleAssortment[3]._id},
+        tags: ['assortment-link-test'],
+      });
     });
 
     it('return not found error when passed non existing parent assortment ID is passed', async () => {
@@ -168,6 +176,7 @@ describe('AssortmentLink', () => {
           tags: ['assortment-link-test'],
         },
       });
+      expect(errors.length).toEqual(1);
       expect(errors[0]?.extensions?.code).toEqual('AssortmentNotFoundError');
     });
 
@@ -194,6 +203,7 @@ describe('AssortmentLink', () => {
           tags: ['assortment-link-test'],
         },
       });
+      expect(errors.length).toEqual(1);
       expect(errors[0]?.extensions?.code).toEqual('InvalidIdError');
     });
 
@@ -220,6 +230,7 @@ describe('AssortmentLink', () => {
           tags: ['assortment-link-test'],
         },
       });
+      expect(errors.length).toEqual(1);
       expect(errors[0]?.extensions?.code).toEqual('AssortmentNotFoundError');
     });
 
@@ -246,6 +257,7 @@ describe('AssortmentLink', () => {
           tags: ['assortment-link-test'],
         },
       });
+      expect(errors.length).toEqual(1);
       expect(errors[0]?.extensions?.code).toEqual('InvalidIdError');
     });
   });
@@ -278,6 +290,7 @@ describe('AssortmentLink', () => {
       });
 
       expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 
@@ -320,6 +333,9 @@ describe('AssortmentLink', () => {
         },
       });
       expect(errors.length).toEqual(1);
+      expect(errors[0]?.extensions?.code).toEqual(
+        'AssortmentLinkNotFoundError',
+      );
     });
 
     it('return not found error when passed non existing assortmentLinkId', async () => {
@@ -335,6 +351,7 @@ describe('AssortmentLink', () => {
           assortmentLinkId: AssortmentLinks[0]._id,
         },
       });
+      expect(errors.length).toEqual(1);
       expect(errors[0]?.extensions?.code).toEqual(
         'AssortmentLinkNotFoundError',
       );
@@ -353,6 +370,7 @@ describe('AssortmentLink', () => {
           assortmentLinkId: '',
         },
       });
+      expect(errors.length).toEqual(1);
       expect(errors[0]?.extensions?.code).toEqual('InvalidIdError');
     });
   });
@@ -373,6 +391,7 @@ describe('AssortmentLink', () => {
         },
       });
       expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 });

--- a/tests/assortment-product.test.js
+++ b/tests/assortment-product.test.js
@@ -98,7 +98,7 @@ describe('AssortmentProduct', () => {
           ],
         },
       });
-      expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 
@@ -135,7 +135,11 @@ describe('AssortmentProduct', () => {
         },
       });
 
-      expect(data?.addAssortmentProduct._id).not.toBe(null);
+      expect(data?.addAssortmentProduct).toMatchObject({
+        tags: ['assortment-product-et'],
+        assortment: { _id: SimpleAssortment[1]._id },
+        product: { _id: SimpleProduct._id }
+      });
     });
 
     it('return not found error when passed non existing product id', async () => {
@@ -207,6 +211,7 @@ describe('AssortmentProduct', () => {
 
       expect(errors[0]?.extensions?.code).toEqual('InvalidIdError');
     });
+
     it('return not found error when passed non existing assortment id', async () => {
       const { errors } = await graphqlFetch({
         query: /* GraphQL */ `
@@ -286,7 +291,7 @@ describe('AssortmentProduct', () => {
         },
       });
 
-      expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 
@@ -323,7 +328,7 @@ describe('AssortmentProduct', () => {
         },
       });
 
-      expect(errors.length).toEqual(1);
+      expect(errors[0]?.extensions?.code).toEqual('AssortmentProductNotFoundError');
     });
 
     it('return not found error when passed non existing assortment product id', async () => {
@@ -378,7 +383,7 @@ describe('AssortmentProduct', () => {
           assortmentProductId: AssortmentProduct._id,
         },
       });
-      expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 });

--- a/tests/assortment-texts.test.js
+++ b/tests/assortment-texts.test.js
@@ -138,7 +138,7 @@ describe('AssortmentTexts', () => {
         },
       });
 
-      expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 });

--- a/tests/assortments.test.js
+++ b/tests/assortments.test.js
@@ -4,7 +4,7 @@ import {
   createAnonymousGraphqlFetch,
 } from './helpers';
 import { ADMIN_TOKEN, USER_TOKEN } from './seeds/users';
-import { SimpleAssortment } from './seeds/assortments';
+import { SimpleAssortment, GermanAssortmentText } from './seeds/assortments';
 
 let graphqlFetch;
 let graphqlFetchAsAnonymousUser;
@@ -32,7 +32,6 @@ describe('Assortments', () => {
         `,
         variables: {},
       });
-
       expect(assortments.length).toEqual(4);
     });
 
@@ -118,6 +117,7 @@ describe('Assortments', () => {
       });
       expect(result.data.assortments.length).toEqual(5);
     });
+
     it("Return all assortments and without leaves", async () => {
       const {
         data: { assortments },
@@ -147,6 +147,7 @@ describe('Assortments', () => {
 
       expect(assortments.length).toEqual(8);
     });
+
     it("Return all assortments and include leaves", async () => {
       const {
         data: { assortments },
@@ -215,6 +216,7 @@ describe('Assortments', () => {
       });
       expect(assortmentsCount).toEqual(5);
     });
+
     it('Return number assortments of without leaves including inactives', async () => {
       const {
         data: { assortmentsCount },
@@ -238,6 +240,7 @@ describe('Assortments', () => {
 
       expect(assortmentsCount).toEqual(8);
     });
+
     it('Return number of all assortments and include leaves', async () => {
       const {
         data: { assortmentsCount },
@@ -372,6 +375,7 @@ describe('Assortments', () => {
       });
       expect(assortment._id).toBe(SimpleAssortment[0]._id);
     });
+
     it('return single assortment based on slug', async () => {
       const {
         data: { assortment },
@@ -515,8 +519,16 @@ describe('Assortments', () => {
           queryString: 'simple-assortment',
         },
       });
-
-      expect(Array.isArray(assortments)).toBe(true);
+      expect(assortments.length).toBe(1);
+      expect(assortments[0]).toEqual({
+        _id: SimpleAssortment[0]._id,
+        isActive: SimpleAssortment[0].isActive,
+        texts: {
+          _id: GermanAssortmentText._id,
+          title: GermanAssortmentText.title,
+          description: GermanAssortmentText.description,
+        } 
+      });
     });
   });
 
@@ -535,8 +547,7 @@ describe('Assortments', () => {
         `,
         variables: {},
       });
-
-      expect(Array.isArray(assortments)).toBe(true);
+      expect(assortments.length).toBe(4);
     });
   });
 
@@ -562,6 +573,7 @@ describe('Assortments', () => {
                 slug
                 subtitle
                 description
+                title
               }
               productAssignments {
                 _id
@@ -606,6 +618,8 @@ describe('Assortments', () => {
         'test-assrtment-1',
         'test-assortment-2',
       ]);
+      expect(createAssortment.isRoot).toBe(true);
+      expect(createAssortment.texts.title).toBe('test assortment');
     });
   });
 
@@ -629,7 +643,7 @@ describe('Assortments', () => {
         },
       });
 
-      expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 
@@ -706,6 +720,8 @@ describe('Assortments', () => {
         'test-assrtment-1',
         'test-assortment-2',
       ]);
+      expect(updateAssortment.isRoot).toBe(false);
+      expect(updateAssortment.isActive).toBe(true);
     });
 
     it('return not found error when passed none existing assortment Id', async () => {
@@ -904,7 +920,7 @@ describe('Assortments', () => {
         },
       });
 
-      expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 
@@ -1032,7 +1048,7 @@ describe('Assortments', () => {
         },
       });
 
-      expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 });

--- a/tests/auth-anonymous.test.js
+++ b/tests/auth-anonymous.test.js
@@ -118,7 +118,6 @@ describe("Auth for anonymous users", () => {
           },
         },
       });
-      console.log(createUser);
       expect(createUser).toMatchObject({
         user: {
           username: "newuser",

--- a/tests/auth-anonymous.test.js
+++ b/tests/auth-anonymous.test.js
@@ -53,6 +53,7 @@ describe("Auth for anonymous users", () => {
 
       expect(result.data.loginAsGuest).toMatchObject({});
     });
+
     it("user has guest flag", async () => {
       const Users = db.collection("users");
       const user = await Users.findOne({
@@ -71,6 +72,7 @@ describe("Auth for anonymous users", () => {
 
   describe("Mutation.createUser", () => {
     it("create a new user", async () => {
+      const birthday = new Date().toISOString().split('T')[0];
       const {
         data: { createUser },
       } = await graphqlFetch({
@@ -91,8 +93,12 @@ describe("Auth for anonymous users", () => {
               token
               user {
                 _id
+                username
+                email
                 profile {
                   displayName
+                  phoneMobile
+                  gender
                 }
               }
             }
@@ -104,7 +110,7 @@ describe("Auth for anonymous users", () => {
           password: "password",
           profile: {
             displayName: "New User",
-            birthday: new Date(),
+            birthday,
             phoneMobile: "+410000000",
             gender: "m",
             address: null,
@@ -112,9 +118,17 @@ describe("Auth for anonymous users", () => {
           },
         },
       });
+      console.log(createUser);
       expect(createUser).toMatchObject({
         user: {
-          profile: {},
+          username: "newuser",
+          email: "newuser@unchained.local",
+          profile: {
+            displayName: "New User",
+            birthday,
+            phoneMobile: "+410000000",
+            gender: "m",
+          },
         },
       });
     });

--- a/tests/auth-user.test.js
+++ b/tests/auth-user.test.js
@@ -52,6 +52,7 @@ describe('Auth for logged in users', () => {
         _id: User._id,
       });
     });
+
     it('does not allow a user to just retrieve data of other users', async () => {
       const { errors } = await graphqlFetch({
         query: /* GraphQL */ `
@@ -65,7 +66,7 @@ describe('Auth for logged in users', () => {
           userId: Admin._id,
         },
       });
-      expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 
@@ -104,6 +105,7 @@ describe('Auth for logged in users', () => {
         success: true,
       });
     });
+
     it('cannot send a verification e-mail to an e-mail not owned by the logged in user', async () => {
       const { data: { sendVerificationEmail } = {} } = await graphqlFetch({
         query: /* GraphQL */ `
@@ -162,6 +164,7 @@ describe('Auth for logged in users', () => {
         success: true,
       });
     });
+
     it('verifies the e-mail of user', async () => {
       // Reset the password with that token
       const Users = db.collection('users');
@@ -193,9 +196,12 @@ describe('Auth for logged in users', () => {
         },
       });
       expect(verifyEmail).toMatchObject({
-        user: {},
+        user: {
+          _id: 'userthatmustverifyemail'
+        },
       });
     });
+
     it('e-mail is tagged as verified', async () => {
       // Reset the password with that token
       const Users = db.collection('users');
@@ -276,6 +282,7 @@ describe('Auth for logged in users', () => {
       } = user;
       expect(loginTokens.length).toEqual(1);
     });
+    
     it('log out userthatlogsout without explicit token', async () => {
       const Users = db.collection('users');
       await Users.findOrInsertOne({

--- a/tests/cart-quotations.test.js
+++ b/tests/cart-quotations.test.js
@@ -2,6 +2,7 @@ import { setupDatabase, createLoggedInGraphqlFetch } from './helpers';
 import { SimpleOrder } from './seeds/orders';
 import { USER_TOKEN } from './seeds/users';
 import { ProposedQuotation } from './seeds/quotations';
+import { SimpleProduct } from './seeds/products';
 
 let graphqlFetch;
 
@@ -54,11 +55,11 @@ describe('Cart: Quotations', () => {
         },
       });
       expect(addCartQuotation).toMatchObject({
-        product: {},
-        order: {},
+        product: { _id: SimpleProduct._id },
+        order: { _id: SimpleOrder._id },
         quantity: 1,
-        originalProduct: {},
-        quotation: {},
+        originalProduct: { _id: SimpleProduct._id },
+        quotation: { _id: ProposedQuotation._id },
         unitPrice: {},
         total: {},
         configuration: null,

--- a/tests/delivery-interfaces.test.js
+++ b/tests/delivery-interfaces.test.js
@@ -31,8 +31,15 @@ describe('DeliveryInterfaces', () => {
           type: 'PICKUP',
         },
       });
-
-      expect(Array.isArray(deliveryInterfaces)).toBe(true);
+      expect(deliveryInterfaces).toMatchObject([
+        {
+          _id: 'shop.unchained.pick-mup',
+        },
+        {
+          _id: 'shop.unchained.stores',
+        }
+      ]
+      );
     });
   });
 
@@ -51,8 +58,7 @@ describe('DeliveryInterfaces', () => {
           type: 'PICKUP',
         },
       });
-
-      expect(errors.length).toEqual(1);
+      expect(errors[0].extensions.code).toEqual("NoPermissionError");
     });
   });
 });

--- a/tests/delivery-providers.test.js
+++ b/tests/delivery-providers.test.js
@@ -4,7 +4,7 @@ import {
   createAnonymousGraphqlFetch,
 } from './helpers';
 import { ADMIN_TOKEN, USER_TOKEN } from './seeds/users';
-import { SimpleDeliveryProvider } from './seeds/deliveries';
+import { PickupDeliveryProvider, SendMailDeliveryProvider, SimpleDeliveryProvider } from './seeds/deliveries';
 
 let graphqlFetch;
 let graphqlFetchAsAnonymousUser;
@@ -51,7 +51,24 @@ describe('DeliveryProviders', () => {
         `,
         variables: {},
       });
-      expect(deliveryProviders.length).toEqual(3);
+      expect(deliveryProviders).toMatchObject([
+        {
+          _id: SimpleDeliveryProvider._id,
+          configurationError: null,
+          type: 'SHIPPING',
+        },
+        {
+          _id: SendMailDeliveryProvider._id,
+          configurationError: null,
+          type: 'SHIPPING',
+        },
+        {
+          _id: PickupDeliveryProvider._id,
+          configurationError: null,
+          type: 'PICKUP',
+        },
+      ]);
+      expect(deliveryProviders.every(d => typeof d.isActive === 'boolean')).toBe(true);
     });
 
     it('return list of deliveryProviders based on the given type', async () => {
@@ -69,7 +86,10 @@ describe('DeliveryProviders', () => {
           type: 'SHIPPING',
         },
       });
-      expect(deliveryProviders.length).toEqual(2);
+      expect(deliveryProviders).toMatchObject([
+        { _id: SimpleDeliveryProvider._id },
+        { _id: SendMailDeliveryProvider._id },
+      ]);
     });
   });
 
@@ -168,7 +188,11 @@ describe('DeliveryProviders', () => {
           deliveryProviderId: SimpleDeliveryProvider._id,
         },
       });
-      expect(deliveryProvider._id).toEqual(SimpleDeliveryProvider._id);
+      expect(deliveryProvider).toMatchObject({
+        _id: SimpleDeliveryProvider._id,
+        type: 'SHIPPING',
+        configurationError: null,
+      });
     });
 
     it('return value for simulatedPrice with the country default currency when no argument is passed', async () => {
@@ -251,7 +275,7 @@ describe('DeliveryProviders', () => {
         `,
         variables: {},
       });
-      expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 });

--- a/tests/enrollment.test.js
+++ b/tests/enrollment.test.js
@@ -108,6 +108,7 @@ describe('Enrollments', () => {
       });
     });
   });
+
   describe('Mutation.createEnrollment', () => {
     it('create a new enrollment manually will not activate automatically because of missing order', async () => {
       const { data: { createEnrollment } = {} } = await graphqlFetchAsAdminUser(
@@ -181,7 +182,9 @@ describe('Enrollments', () => {
           product: {
             _id: PlanProduct._id,
           },
+          quantity: 1,
         },
+        isExpired: false,
       });
     });
 
@@ -221,6 +224,7 @@ describe('Enrollments', () => {
       expect(errors[0]?.extensions?.code).toEqual('InvalidIdError');
     });
   });
+  
   describe('Mutation.terminateEnrollment for admin user should', () => {
     it('change ACTIVE enrollment status to TERMINATED', async () => {
       const {
@@ -609,8 +613,10 @@ describe('Enrollments', () => {
           enrollmentId: 'initialenrollment',
         },
       });
-
-      expect(activateEnrollment._id).not.toBe(true);
+      expect(activateEnrollment).toMatchObject({
+        _id: InitialEnrollment._id,
+        status: 'ACTIVE',
+      });
     });
 
     it('return  EnrollmentWrongStatusError error when trying to activate ACTIVE enrollment', async () => {
@@ -875,6 +881,7 @@ describe('Enrollments', () => {
       expect(errors[0]?.extensions?.code).toEqual('NoPermissionError');
     });
   });
+
   describe('query.enrollment for admin user should', () => {
     it('return enrollment specified by Id', async () => {
       const {

--- a/tests/filter-option.test.js
+++ b/tests/filter-option.test.js
@@ -56,8 +56,14 @@ describe('FilterOption', () => {
         },
       });
       expect(
-        createFilterOption.options[createFilterOption.options.length - 1]._id,
-      ).toEqual('multichoice-filter:test-filter-option');
+        createFilterOption.options[createFilterOption.options.length - 1],
+      ).toMatchObject({
+        _id: 'multichoice-filter:test-filter-option',
+        value: 'test-filter-option',
+        texts: {
+          title: 'test-filter-option-title',
+        }
+      });
     });
 
     it('return not found error when passed non existing filterId', async () => {
@@ -129,7 +135,7 @@ describe('FilterOption', () => {
           },
         },
       });
-      expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 
@@ -172,6 +178,7 @@ describe('FilterOption', () => {
         },
       });
       expect(removeFilterOption.options.length).toEqual(3);
+      expect(removeFilterOption.options.filter(o => o.value === 'test-filter-option').length).toEqual(0);
     });
 
     it('return not found error when passed non existing filter ID', async () => {
@@ -222,7 +229,7 @@ describe('FilterOption', () => {
   });
 
   describe('mutation.removeFilterOption for anonymous users should', () => {
-    it('remove filter option successfuly when passed valid filter ID', async () => {
+    it('return error when passed valid filter ID', async () => {
       const graphqlAnonymousFetch = createAnonymousGraphqlFetch();
       const { errors } = await graphqlAnonymousFetch({
         query: /* GraphQL */ `
@@ -243,7 +250,7 @@ describe('FilterOption', () => {
           filterOptionValue: 'test-filter-option',
         },
       });
-      expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 });

--- a/tests/filters.test.js
+++ b/tests/filters.test.js
@@ -81,6 +81,7 @@ describe('Filters', () => {
               includeInactive: $includeInactive
             ) {
               _id
+              isActive
             }
           }
         `,
@@ -89,6 +90,12 @@ describe('Filters', () => {
         },
       });
       expect(filters.length).toEqual(1);
+      expect(filters).toMatchObject([
+        {
+          _id: expect.anything(),
+          isActive: false,
+        }
+      ])
     });
   });
 
@@ -176,7 +183,6 @@ describe('Filters', () => {
               }
               type
               key
-              key
               options {
                 _id
                 texts {
@@ -194,7 +200,12 @@ describe('Filters', () => {
           filterId: MultiChoiceFilter._id,
         },
       });
-      expect(filter._id).toEqual(MultiChoiceFilter._id);
+      expect(filter).toMatchObject({
+        _id: MultiChoiceFilter._id,
+        isActive: MultiChoiceFilter.isActive,
+        type: MultiChoiceFilter.type,
+        key: MultiChoiceFilter.key,
+      });
     });
 
     it('return error when passed invalid filterId', async () => {
@@ -219,7 +230,7 @@ describe('Filters', () => {
   });
 
   describe('Query.Filters for anonymous user should', () => {
-    it('return error', async () => {
+    it('return empty array', async () => {
       const graphqlAnonymousFetch = createAnonymousGraphqlFetch();
       const {
         data: { filters },
@@ -241,7 +252,7 @@ describe('Filters', () => {
         `,
         variables: {},
       });
-      expect(Array.isArray(filters)).toBe(true);
+      expect(filters.length).toBe(0);
     });
   });
 
@@ -287,11 +298,18 @@ describe('Filters', () => {
       });
 
       expect(updateFilterTexts.length).toEqual(2);
-      expect(updateFilterTexts[0]).toMatchObject({
-        locale: 'en',
-        title: 'english-filter-text',
-        subtitle: 'english-filter-text-subtitle',
-      });
+      expect(updateFilterTexts).toMatchObject([
+        {
+          locale: 'en',
+          title: 'english-filter-text',
+          subtitle: 'english-filter-text-subtitle',
+        },
+        {
+          locale: 'am',
+          title: 'amharic-filter-text',
+          subtitle: 'amharic-filter-text-subtitle',
+        },
+      ]);
     });
 
     it('return not found error when passed non existing filter ID', async () => {
@@ -391,7 +409,7 @@ describe('Filters', () => {
         },
       });
 
-      expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 
@@ -545,7 +563,10 @@ describe('Filters', () => {
         },
       });
 
-      expect(updateFilter.key).toEqual('999');
+      expect(updateFilter).toMatchObject({
+        key: '999',
+        isActive: true,
+      });
     });
 
     it('return not found error when passed non existing filter ID', async () => {
@@ -611,7 +632,7 @@ describe('Filters', () => {
         },
       });
 
-      expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 
@@ -716,7 +737,7 @@ describe('Filters', () => {
         },
       });
 
-      expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 });

--- a/tests/order-deliveries.test.js
+++ b/tests/order-deliveries.test.js
@@ -374,6 +374,10 @@ describe('Order: Deliveries', () => {
                 meta: $meta
               ) {
                 _id
+                address {
+                  firstName
+                  lastName
+                }
               }
             }
           `,
@@ -390,6 +394,10 @@ describe('Order: Deliveries', () => {
         });
       expect(updateOrderDeliveryShipping).toMatchObject({
         _id: SimpleDelivery._id,
+        address: {
+          firstName: 'Will',
+          lastName: 'Turner',
+        }
       });
     });
   });
@@ -592,6 +600,10 @@ describe('Order: Deliveries', () => {
                 meta: $meta
               ) {
                 _id
+                activePickUpLocation {
+                  _id
+                  name
+                }
               }
             }
           `,
@@ -605,6 +617,10 @@ describe('Order: Deliveries', () => {
         });
       expect(updateOrderDeliveryPickUp).toMatchObject({
         _id: PickupDelivery._id,
+        activePickUpLocation: {
+          _id: 'zurich',
+          name: 'Zurich',
+        }
       });
     });
   });

--- a/tests/order-management.test.js
+++ b/tests/order-management.test.js
@@ -24,7 +24,7 @@ describe('Order: Management', () => {
           orderId: ConfirmedOrder._id,
         },
       });
-      expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('OrderWrongStatusError');
     });
 
     it('remove a cart', async () => {
@@ -43,6 +43,7 @@ describe('Order: Management', () => {
       });
       expect(removeOrder).toMatchObject({
         _id: SimpleOrder._id,
+        status: 'OPEN',
       });
     });
 

--- a/tests/order-payments.test.js
+++ b/tests/order-payments.test.js
@@ -146,6 +146,12 @@ describe('Order: Payments', () => {
                 paymentProviderId: $paymentProviderId
               ) {
                 _id
+                payment {
+                  _id
+                  provider {
+                    _id
+                  }
+                }
               }
             }
           `,
@@ -156,6 +162,9 @@ describe('Order: Payments', () => {
         });
       expect(setOrderPaymentProvider).toMatchObject({
         _id: SimpleOrder._id,
+        payment: {
+          provider: { _id: PrePaidPaymentProvider._id },
+        }
       });
     });
   });
@@ -385,8 +394,7 @@ describe('Order: Payments', () => {
   });
 
   describe('Mutation.updateOrderPaymentGeneric for admin user should', () => {
-    // TODO: Migrate datatrans plugin
-    xit('update order payment successfuly when order payment provider type is generic', async () => {
+    it('update order payment successfuly when order payment provider type is generic', async () => {
       const { data: { updateOrderPaymentGeneric } = {} } =
         await graphqlFetchAsAdmin({
           query: /* GraphQL */ `
@@ -399,7 +407,6 @@ describe('Order: Payments', () => {
                 meta: $meta
               ) {
                 _id
-                sign
                 provider {
                   _id
                   type
@@ -416,12 +423,12 @@ describe('Order: Payments', () => {
         });
       expect(updateOrderPaymentGeneric).toMatchObject({
         _id: GenericPayment._id,
-        sign: '{"location":"https://pay.sandbox.datatrans.com/v1/start/new-transaction","transactionId":"new-transaction"}',
         provider: {
           type: 'GENERIC',
         },
       });
     });
+
     it('return error when order payment type is not GENERIC', async () => {
       const { errors } = await graphqlFetchAsAdmin({
         query: /* GraphQL */ `
@@ -515,7 +522,7 @@ describe('Order: Payments', () => {
 
   describe('Mutation.updateOrderPaymentCard', () => {
     it.todo(
-      'All test senarios tests for the other endpoints above including role based',
+      'All test senarios tests for the other endpoints above including role based', // Currently no payment provider with type CARD implemented
     );
   });
 });

--- a/tests/orders.test.js
+++ b/tests/orders.test.js
@@ -3,7 +3,7 @@ import {
   createAnonymousGraphqlFetch,
   createLoggedInGraphqlFetch,
 } from "./helpers";
-import { SimpleOrder } from "./seeds/orders";
+import { ConfirmedOrder, PendingOrder, SimpleOrder } from "./seeds/orders";
 import { USER_TOKEN, ADMIN_TOKEN } from "./seeds/users";
 
 let graphqlFetch;
@@ -121,6 +121,16 @@ describe("Order: Management", () => {
         variables: {},
       });
       expect(orders.length).toEqual(2);
+      expect(orders).toMatchObject([
+        {
+          _id: ConfirmedOrder._id,
+          status: ConfirmedOrder.status,
+        },
+        {
+          _id: PendingOrder._id,
+          status: PendingOrder.status,
+        }
+      ]);
     });
 
     it("return single user order", async () => {
@@ -178,9 +188,9 @@ describe("Order: Management", () => {
           orderId: SimpleOrder._id,
         },
       });
-
       expect(order._id).toEqual(SimpleOrder._id);
     });
+
     it("return simulatedPrice for supportedDeliveryProviders using default country currency when currency is not provided", async () => {
       const {
         data: { order },
@@ -204,10 +214,12 @@ describe("Order: Management", () => {
           orderId: SimpleOrder._id,
         },
       });
-
       expect(
-        order.supportedDeliveryProviders?.[0]?.simulatedPrice?.currency
-      ).toEqual("CHF");
+        order.supportedDeliveryProviders?.[0]?.simulatedPrice
+      ).toMatchObject({
+        currency: "CHF",
+        amount: 32145
+      });
     });
 
     it("return simulatedPrice for supportedDeliveryProviders using the provided currency when currency is provided", async () => {

--- a/tests/payment-interface.test.js
+++ b/tests/payment-interface.test.js
@@ -31,8 +31,11 @@ describe('PaymentInterface', () => {
           type: 'INVOICE',
         },
       });
-
-      expect(Array.isArray(paymentInterfaces)).toBe(true);
+      expect(paymentInterfaces.length).not.toBe(0);
+      expect(paymentInterfaces).toMatchObject([
+        { _id: 'shop.unchained.invoice' },
+        { _id: 'shop.unchained.invoice-prepaid' },
+      ]);
     });
   });
 
@@ -52,7 +55,7 @@ describe('PaymentInterface', () => {
         },
       });
 
-      expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 });

--- a/tests/payment-provider.test.js
+++ b/tests/payment-provider.test.js
@@ -129,7 +129,11 @@ describe('PaymentProviders', () => {
           paymentProviderId: SimplePaymentProvider._id,
         },
       });
-      expect(paymentProvider._id).toEqual(SimplePaymentProvider._id);
+      expect(paymentProvider).toMatchObject({
+        _id: SimplePaymentProvider._id,
+        type: SimplePaymentProvider.type,
+        configurationError: null,
+      });
     });
 
     it('return error when passed invalid paymentProviderId', async () => {

--- a/tests/product-assignment.test.js
+++ b/tests/product-assignment.test.js
@@ -383,8 +383,7 @@ describe('ProductAssignment', () => {
             vectors: [{ key: 'key-3', value: 'value-3' }],
           },
         });
-
-      expect(removeProductAssignment._id).not.toBe(null);
+      expect(removeProductAssignment._id).toBe(ConfigurableProduct._id);
     });
 
     it('return error when passed non CONFIGURABLE_PRODUCT type id', async () => {

--- a/tests/product-bundle-item.test.js
+++ b/tests/product-bundle-item.test.js
@@ -111,6 +111,7 @@ describe('ProductBundleItem', () => {
         required: 'BUNDLE_PRODUCT',
       });
     });
+
     it('return not found error when passed non existing product ID', async () => {
       const { errors } = await graphqlFetch({
         query: /* GraphQL */ `
@@ -226,7 +227,7 @@ describe('ProductBundleItem', () => {
           },
         },
       });
-      expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 
@@ -356,7 +357,7 @@ describe('ProductBundleItem', () => {
           index: 0,
         },
       });
-      expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 });

--- a/tests/product-commerce.test.js
+++ b/tests/product-commerce.test.js
@@ -54,6 +54,14 @@ describe('ProductsCommerce', () => {
                 siblings {
                   _id
                 }
+                ... on SimpleProduct {
+                  catalogPrice {
+                    amount
+                    isTaxable
+                    isNetPrice
+                    currency
+                  }
+                }
               }
             }
           `,
@@ -74,7 +82,15 @@ describe('ProductsCommerce', () => {
           },
         });
 
-      expect(updateProductCommerce._id).toEqual(SimpleProduct._id);
+      expect(updateProductCommerce).toMatchObject({
+        _id: SimpleProduct._id,
+        catalogPrice: {
+          amount: 100,
+          isTaxable: true,
+          isNetPrice: false,
+          currency: 'CHY',
+        }
+      });
     });
 
     it('return not found error when attempting to update non existing product', async () => {
@@ -173,7 +189,7 @@ describe('ProductsCommerce', () => {
         },
       });
 
-      expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 });

--- a/tests/product-media.test.js
+++ b/tests/product-media.test.js
@@ -63,7 +63,10 @@ describe('ProductsVariation', () => {
         data: { addProductMedia },
       } = await uploadFormData({ token: ADMIN_TOKEN, body });
 
-      expect(addProductMedia?.file.name).toEqual('image.jpg');
+      expect(addProductMedia?.file).toMatchObject({
+        name: 'image.jpg',
+        type: 'image/jpeg',
+      });
     }, 10000);
 
     it('return ProductNotFoundError when passed non existing product ID', async () => {
@@ -392,7 +395,7 @@ describe('ProductsVariation', () => {
         },
       });
 
-      expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 
@@ -519,7 +522,7 @@ describe('ProductsVariation', () => {
         },
       });
 
-      expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 
@@ -566,7 +569,7 @@ describe('ProductsVariation', () => {
         },
       });
 
-      expect(errors.length).toEqual(1);
+      expect(errors[0]?.extensions?.code).toEqual('ProductMediaNotFoundError');
     }, 10000);
 
     it('return not found error when passed non existing productMediaId', async () => {
@@ -621,7 +624,7 @@ describe('ProductsVariation', () => {
         },
       });
 
-      expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 });

--- a/tests/product-supply.test.js
+++ b/tests/product-supply.test.js
@@ -7,10 +7,11 @@ import { ADMIN_TOKEN } from './seeds/users';
 import { PlanProduct, SimpleProduct } from './seeds/products';
 
 let graphqlFetch;
+let db;
 
 describe('ProductsSupply', () => {
   beforeAll(async () => {
-    await setupDatabase();
+    [db] = await setupDatabase();
     graphqlFetch = createLoggedInGraphqlFetch(ADMIN_TOKEN);
   });
 
@@ -65,6 +66,13 @@ describe('ProductsSupply', () => {
       });
 
       expect(updateProductSupply._id).toEqual(SimpleProduct._id);
+      const updatedProduct = await (db.collection('products')).findOne({ _id: SimpleProduct._id });
+      expect(updatedProduct.supply).toEqual({
+        weightInGram: 100,
+        heightInMillimeters: 200,
+        lengthInMillimeters: 300,
+        widthInMillimeters: 400,
+      });
     });
 
     it('return error when passed non SIMPLE_PRODUCT type', async () => {
@@ -175,7 +183,7 @@ describe('ProductsSupply', () => {
         },
       });
 
-      expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 });

--- a/tests/product-texts.test.js
+++ b/tests/product-texts.test.js
@@ -151,7 +151,7 @@ describe("ProductText", () => {
         },
       });
 
-      expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 });

--- a/tests/product-variation.test.js
+++ b/tests/product-variation.test.js
@@ -43,8 +43,21 @@ describe('ProductsVariation', () => {
             productVariationId: ProductVariations[0]._id,
           },
         });
-
       expect(translatedProductVariationTexts.length).toEqual(2);
+      expect(translatedProductVariationTexts).toMatchObject([
+        {
+          _id: 'variation-color-1',
+          locale: 'en',
+          title: 'product color variation title',
+          subtitle: null
+        },
+        {
+          _id: 'variation-color-7',
+          locale: 'de',
+          title: 'product color variation title',
+          subtitle: null
+        }
+      ]);
     });
 
     it('return empty array when no match is found', async () => {
@@ -86,6 +99,9 @@ describe('ProductsVariation', () => {
                 productVariationOptionValue: $productVariationOptionValue
               ) {
                 _id
+                locale
+                title
+                subtitle
               }
             }
           `,
@@ -93,7 +109,12 @@ describe('ProductsVariation', () => {
             productVariationId: ProductVariations[1]._id,
           },
         });
-      expect(translatedProductVariationTexts.length).toEqual(1);
+      expect(translatedProductVariationTexts).toMatchObject([{
+        _id: 'variation-text-3',
+        locale: 'en',
+        subtitle: null,
+        title: 'product text variation title ',
+      }]);
     });
   });
 
@@ -233,6 +254,7 @@ describe('ProductsVariation', () => {
       expect(errors[0]?.extensions.code).toEqual('InvalidIdError');
     });
   });
+
   describe('mutation.createProductVariation for anonymous user should', () => {
     it('return error', async () => {
       const graphqlAnonymousFetch = createAnonymousGraphqlFetch();
@@ -259,7 +281,7 @@ describe('ProductsVariation', () => {
           },
         },
       });
-      expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 
@@ -284,6 +306,10 @@ describe('ProductsVariation', () => {
                 key
                 options {
                   _id
+                  value
+                  texts {
+                    title
+                  }
                 }
               }
             }
@@ -296,8 +322,14 @@ describe('ProductsVariation', () => {
             },
           },
         });
-
-      expect(createProductVariationOption._id).not.toBe(null);
+      expect(createProductVariationOption._id).toBe(ProductVariations[0]._id);
+      expect(createProductVariationOption.options[createProductVariationOption.options.length - 1]).toMatchObject({
+        _id: 'product-color-variation-1:key-1',
+        value: 'key-1',
+        texts: {
+          title: 'product variation option title',
+        }
+      })
     });
 
     it('return error when passed invalid product variation ID', async () => {
@@ -328,6 +360,7 @@ describe('ProductsVariation', () => {
       );
     });
   });
+
   describe('mutation.createProductVariationOption for anonymous user should', () => {
     it('return error', async () => {
       const graphqlAnonymousFetch = createAnonymousGraphqlFetch();
@@ -354,7 +387,7 @@ describe('ProductsVariation', () => {
         },
       });
 
-      expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 
@@ -499,7 +532,7 @@ describe('ProductsVariation', () => {
         },
       });
 
-      expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 
@@ -544,6 +577,7 @@ describe('ProductsVariation', () => {
           },
         });
       expect(removeProductVariationOption.options.length).toEqual(1);
+      expect(removeProductVariationOption.options.filter(o => o.value === 'variation-option-1-value').length).toEqual(0);
     });
 
     it('return error when passed invalid product variation ID', async () => {
@@ -618,7 +652,7 @@ describe('ProductsVariation', () => {
         },
       });
 
-      expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 
@@ -660,7 +694,7 @@ describe('ProductsVariation', () => {
           productVariationId: ProductVariations[0]._id,
         },
       });
-      expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('ProductVariationNotFoundError');
     });
 
     it('return not found error when passed non existing productVariationId', async () => {
@@ -713,7 +747,7 @@ describe('ProductsVariation', () => {
           productVariationId: ProductVariations[0]._id,
         },
       });
-      expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 });

--- a/tests/product-warehousing.test.js
+++ b/tests/product-warehousing.test.js
@@ -53,6 +53,10 @@ describe('ProductsWarehousing', () => {
               siblings {
                 _id
               }
+              ... on SimpleProduct {
+                sku
+                baseUnit
+              }
             }
           }
         `,
@@ -65,7 +69,11 @@ describe('ProductsWarehousing', () => {
         },
       });
 
-      expect(updateProductWarehousing._id).toEqual(SimpleProduct._id);
+      expect(updateProductWarehousing).toMatchObject({
+        _id: SimpleProduct._id,
+        sku: 'SKU-100',
+        baseUnit: 'Kg',
+      });
     });
 
     it('return error when passed non SIMPLE_PRODUCT type', async () => {
@@ -180,7 +188,7 @@ describe('ProductsWarehousing', () => {
         },
       });
 
-      expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 });

--- a/tests/products.test.js
+++ b/tests/products.test.js
@@ -216,6 +216,7 @@ describe('Products', () => {
       });
       expect(errors[0]?.extensions?.code).toEqual('ProductNotFoundError');
     });
+
     it('return error for non-existing product id', async () => {
       const { errors = {} } = await graphqlFetchAsAdmin({
         query: /* GraphQL */ `
@@ -355,7 +356,7 @@ describe('Products', () => {
           productId: SimpleProductDraft._id,
         },
       });
-      expect(errors.length).toBe(1);
+      expect(errors[0]?.extensions?.code).toEqual('ProductWrongStatusError');
     });
 
     it('return not found error when passed non-existing product id', async () => {
@@ -691,8 +692,10 @@ describe('Products', () => {
           productId: 'simpleproduct',
         },
       });
-
-      expect(product?.simulatedPrice?.currency).toEqual('CHF');
+      expect(product?.simulatedPrice).toMatchObject({
+        currency: 'CHF',
+        amount: 10000,
+      });
     });
 
     it('return null when passed unsupported currency to simulatedPrice of SIMPLE_PRODUCT type', async () => {
@@ -743,7 +746,10 @@ describe('Products', () => {
           productId: 'plan-product',
         },
       });
-      expect(product?.simulatedPrice?.currency).toEqual('CHF');
+      expect(product?.simulatedPrice).toMatchObject({
+        currency: 'CHF',
+        amount: 10000,
+      });    
     });
 
     it('return null when passed unsupported currency to simulatedPrice of PLAN_PRODUCT type', async () => {
@@ -1208,6 +1214,7 @@ describe('Products', () => {
               includeDrafts: $includeDrafts
             ) {
               _id
+              status
             }
           }
         `,
@@ -1217,6 +1224,7 @@ describe('Products', () => {
       });
 
       expect(products.length).toEqual(10);
+      expect(products.filter(p => p.status === "DRAFT").length).not.toBe(0);
     });
   });
 

--- a/tests/public-queries.test.js
+++ b/tests/public-queries.test.js
@@ -1,4 +1,5 @@
 import { setupDatabase, createAnonymousGraphqlFetch } from './helpers';
+import { SimpleProduct } from './seeds/products';
 
 let graphqlFetch;
 
@@ -23,8 +24,9 @@ describe('public queries', () => {
     expect(data.products.length).toBeGreaterThan(0);
 
     const [product] = data.products;
-    expect(product).toBeTruthy();
-    expect(product._id).toBe('simpleproduct');
+    expect(product).toMatchObject({
+      _id: SimpleProduct._id,
+    });
   });
 
   it('product', async () => {
@@ -40,8 +42,9 @@ describe('public queries', () => {
 
     expect(errors).toEqual(undefined);
     const { product } = data;
-    expect(product).toBeTruthy();
-    expect(product._id).toBe('simpleproduct');
+    expect(product).toMatchObject({
+      _id: SimpleProduct._id,
+    });
   });
 
   it('query.productCatalogPrices', async () => {
@@ -60,9 +63,12 @@ describe('public queries', () => {
     });
 
     expect(errors).toEqual(undefined);
-    const { amount, currency } = data.productCatalogPrices[0];
-    expect(amount).toBe(10000);
-    expect(currency.isoCode).toBe('CHF');
+    expect(data.productCatalogPrices[0]).toMatchObject({
+      amount: 10000,
+      currency: {
+        isoCode: 'CHF',
+      }
+    });
   });
 
   it('query.productCatalogPrices return error when passed invalid productId', async () => {
@@ -97,14 +103,16 @@ describe('public queries', () => {
     });
 
     expect(errors).toEqual(undefined);
-    const de = data.translatedProductTexts.find(
-      (texts) => texts.locale === 'de',
-    );
-    const fr = data.translatedProductTexts.find(
-      (texts) => texts.locale === 'fr',
-    );
-    expect(de.slug).toBe('slug-de');
-    expect(fr.slug).toBe('slug-fr');
+    expect(data.translatedProductTexts).toMatchObject([
+      {
+        locale: 'de',
+        slug: 'slug-de',
+      },
+      {
+        locale: 'fr',
+        slug: 'slug-fr',
+      }
+    ]);
   });
 
   it('translatedProductMediaTexts', async () => {
@@ -120,13 +128,15 @@ describe('public queries', () => {
     });
 
     expect(errors).toEqual(undefined);
-    const de = data.translatedProductMediaTexts.find(
-      (texts) => texts.locale === 'de',
-    );
-    const fr = data.translatedProductMediaTexts.find(
-      (texts) => texts.locale === 'fr',
-    );
-    expect(de.title).toBe('product-media-title-de');
-    expect(fr.title).toBe('product-media-title-fr');
+    expect(data.translatedProductMediaTexts).toMatchObject([
+      {
+        locale: 'de',
+        title: 'product-media-title-de',
+      },
+      {
+        locale: 'fr',
+        title: 'product-media-title-fr',
+      }
+    ]);
   });
 });

--- a/tests/quotations.test.js
+++ b/tests/quotations.test.js
@@ -5,6 +5,7 @@ import {
 } from './helpers';
 import { ADMIN_TOKEN } from './seeds/users';
 import { ProposedQuotation } from './seeds/quotations';
+import { SimpleProduct } from './seeds/products';
 
 let graphqlFetch;
 let graphqlAnonymousFetch;
@@ -61,6 +62,18 @@ describe('TranslatedFilterTexts', () => {
         variables: {},
       });
       expect(quotations.length).toEqual(2);
+      expect(quotations).toMatchObject([
+        {
+          quotationNumber: 'K271P03',
+          status: 'PROCESSING',
+          product: { _id: SimpleProduct._id },
+        },
+        {
+          quotationNumber: 'WGE9DLE7',
+          status: 'PROPOSED',
+          product: { _id: SimpleProduct._id },
+        },
+      ]);
     });
   });
 

--- a/tests/setup-basic.test.js
+++ b/tests/setup-basic.test.js
@@ -185,6 +185,7 @@ describe("basic setup of internationalization and localization context", () => {
           query {
             currencies {
               isoCode
+              isActive
             }
           }
         `,
@@ -193,9 +194,11 @@ describe("basic setup of internationalization and localization context", () => {
       expect(currencies).toEqual([
         {
           isoCode: "CHF",
+          isActive: true,
         },
         {
           isoCode: "LTC",
+          isActive: true,
         },
       ]);
       await Currencies.deleteOne({ _id: "ltc" });

--- a/tests/translated-assortments.test.js
+++ b/tests/translated-assortments.test.js
@@ -35,8 +35,26 @@ describe('TranslatedAssortmentsText', () => {
           assortmentId: SimpleAssortment[0]._id,
         },
       });
-
+      console.log(translatedAssortmentTexts);
       expect(translatedAssortmentTexts.length).toEqual(2);
+      expect(translatedAssortmentTexts).toMatchObject([
+        {
+          _id: 'german',
+          title: 'simple assortment de',
+          description: 'text-de',
+          locale: 'de',
+          subtitle: 'subsimple assortment de',
+          slug: 'slug-de'
+        },
+        {
+          _id: 'french',
+          title: 'title-fr',
+          description: 'text-fr-1',
+          locale: 'fr',
+          subtitle: 'subtitle-fr',
+          slug: 'slug-fr'
+        }
+      ]);
     });
 
     it('return empty array when non-existing id is passed', async () => {
@@ -58,6 +76,7 @@ describe('TranslatedAssortmentsText', () => {
       expect(translatedAssortmentTexts.length).toEqual(0);
     });
   });
+
   describe('Query.translatedAssortmentTexts for anonymous user should', () => {
     it('return error', async () => {
       const graphqlAnonymousFetch = createAnonymousGraphqlFetch();
@@ -73,7 +92,7 @@ describe('TranslatedAssortmentsText', () => {
           assortmentId: SimpleAssortment[0]._id,
         },
       });
-      expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 });

--- a/tests/translated-assortments.test.js
+++ b/tests/translated-assortments.test.js
@@ -35,7 +35,6 @@ describe('TranslatedAssortmentsText', () => {
           assortmentId: SimpleAssortment[0]._id,
         },
       });
-      console.log(translatedAssortmentTexts);
       expect(translatedAssortmentTexts.length).toEqual(2);
       expect(translatedAssortmentTexts).toMatchObject([
         {

--- a/tests/translated-filter-texts.test.js
+++ b/tests/translated-filter-texts.test.js
@@ -39,8 +39,11 @@ describe('TranslatedFilterTexts', () => {
           filterId: MultiChoiceFilter._id,
         },
       });
-
       expect(translatedFilterTexts.length).toEqual(2);
+      expect(translatedFilterTexts).toMatchObject([
+        { _id: 'german', locale: 'de', title: 'Special', subtitle: null },
+        { _id: 'french', locale: 'fr', title: null, subtitle: null }
+      ]);
     });
 
     it('return empty array for non-existing id is passed', async () => {
@@ -90,7 +93,7 @@ describe('TranslatedFilterTexts', () => {
           filterId: 'non-existing-id',
         },
       });
-      expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 });

--- a/tests/user-bookmarks.test.js
+++ b/tests/user-bookmarks.test.js
@@ -1,5 +1,5 @@
 import { setupDatabase, createLoggedInGraphqlFetch } from './helpers';
-import { UnpublishedProduct, SimpleProduct } from './seeds/products';
+import { UnpublishedProduct, SimpleProduct, PlanProduct } from './seeds/products';
 import { ADMIN_TOKEN, User, Admin } from './seeds/users';
 
 let db;
@@ -22,6 +22,9 @@ describe('User Bookmarks', () => {
               user {
                 _id
               }
+              product {
+                _id
+              }
             }
           }
         `,
@@ -34,6 +37,9 @@ describe('User Bookmarks', () => {
         user: {
           _id: User._id,
         },
+        product: {
+          _id: UnpublishedProduct._id,
+        }
       });
     });
 
@@ -109,7 +115,7 @@ describe('User Bookmarks', () => {
           bookmarkId: bookmark._id,
         },
       });
-      expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('BookmarkNotFoundError');
     });
 
     it('return not found error when passed non existin bookmarkId', async () => {
@@ -156,6 +162,9 @@ describe('User Bookmarks', () => {
               user {
                 _id
               }
+              product {
+                _id
+              }
             }
           }
         `,
@@ -167,6 +176,9 @@ describe('User Bookmarks', () => {
       expect(bookmark).toMatchObject({
         user: {
           _id: Admin._id,
+        },
+        product: {
+          _id: SimpleProduct._id,
         },
       });
     });
@@ -226,6 +238,10 @@ describe('User Bookmarks', () => {
         },
       });
       expect(bookmarks.length).toEqual(2);
+      expect(bookmarks).toMatchObject([
+        { product: { _id: SimpleProduct._id } },
+        { product: { _id: PlanProduct._id } },
+      ])
     });
   });
 });

--- a/tests/warehousing-interface.test.js
+++ b/tests/warehousing-interface.test.js
@@ -31,8 +31,12 @@ describe('WarehousingInterfaces', () => {
           type: 'PHYSICAL',
         },
       });
-
-      expect(Array.isArray(warehousingInterfaces)).toBe(true);
+      expect(warehousingInterfaces).toMatchObject([
+        {
+          _id: 'shop.unchained.warehousing.google-sheets',
+          label: 'Google Sheets',
+        }
+      ]);
     });
   });
 
@@ -52,7 +56,7 @@ describe('WarehousingInterfaces', () => {
         },
       });
 
-      expect(errors.length).toEqual(1);
+      expect(errors[0].extensions?.code).toEqual('NoPermissionError');
     });
   });
 });

--- a/tests/warehousing-provider.test.js
+++ b/tests/warehousing-provider.test.js
@@ -42,7 +42,15 @@ describe('WarehousingProviders', () => {
         `,
         variables: {},
       });
-      expect(Array.isArray(warehousingProviders)).toBe(true);
+      expect(warehousingProviders).toMatchObject([
+        {
+          _id: SimpleWarehousingProvider._id,
+          type: SimpleWarehousingProvider.type,
+          configuration: [],
+          configurationError: null,
+          isActive: true
+        }
+      ]);
     });
 
     it('return list of warehousingProviders based on the given type', async () => {
@@ -76,7 +84,7 @@ describe('WarehousingProviders', () => {
         `,
         variables: {},
       });
-      expect(warehousingProvidersCount > 0).toBe(true);
+      expect(warehousingProvidersCount).toEqual(1);
     });
 
     it('return total number of warehousingProviders based on the given type', async () => {
@@ -96,7 +104,7 @@ describe('WarehousingProviders', () => {
     });
   });
 
-  describe('Query.warehousingProvider when loged in should', () => {
+  describe('Query.warehousingProvider when logged in should', () => {
     it('return single warehousingProvider when ID is provided', async () => {
       const {
         data: { warehousingProvider },

--- a/tests/worker.test.js
+++ b/tests/worker.test.js
@@ -36,6 +36,7 @@ describe('Worker Module', () => {
         },
       });
 
+      expect(addWorkResult.data.addWork.type).toBe('HEARTBEAT');
       expect(addWorkResult.errors).toBeUndefined();
 
       const { data: { workQueue } = {} } = await graphqlFetchAsAdminUser({
@@ -182,6 +183,7 @@ describe('Worker Module', () => {
 
       expect(finishWork.status).toBe('SUCCESS');
     });
+
     it('return error when passed invalid workId', async () => {
       const { errors } = await graphqlFetchAsAdminUser({
         query: /* GraphQL */ `
@@ -244,6 +246,7 @@ describe('Worker Module', () => {
         },
       });
 
+      expect(addWorkResult.data.addWork.type).toBe('EXTERNAL');
       expect(addWorkResult.errors).toBeUndefined();
 
       const allocateWorkResult = await graphqlFetchAsAdminUser({
@@ -333,6 +336,7 @@ describe('Worker Module', () => {
         },
       });
 
+      expect(addWorkResult.data.addWork.type).toBe('HEARTBEAT');
       expect(addWorkResult.errors).toBeUndefined();
 
       const { data: { workQueue: workQueueBefore } = {} } =


### PR DESCRIPTION
Various improvements for the tests:
- Instead of only checking length of returned values, always check the values itself
- Always check the returned error code, not only if an error was returned
- For mutations where the success cannot be directly determined by the reply, use alternative methods. E.g. download the file and compare SHA-256 hashes or query the database where it is sensible.

After the changes, there are now 8 failing tests. I haven't looked at them in detail yet, some of them might also be a false positive.