### PR TITLE
Fix optional assortment selector check #455

### DIFF
--- a/packages/core-assortments/src/module/configureAssortmentsModule.ts
+++ b/packages/core-assortments/src/module/configureAssortmentsModule.ts
@@ -55,7 +55,7 @@ const buildFindSelector = ({
     }
   }
 
-  if (!assortmentSelector && !includeLeaves) {
+  if (!Object.keys(assortmentSelector).length && !includeLeaves) {
     selector.isRoot = true;
   }
 
@@ -63,7 +63,7 @@ const buildFindSelector = ({
     selector.$text = { $search: queryString };
   }
 
-  if (!assortmentSelector && !includeInactive) {
+  if (!Object.keys(assortmentSelector).length && !includeInactive) {
     selector.isActive = true;
   }
   return selector;


### PR DESCRIPTION
this expression is always false
```
  if (!assortmentSelector && !includeLeaves) {
    selector.isRoot = true;
  }
```
because `!{}` is false and so is `!{key: value}`

**Updated**

 ```
  if (!Object.keys(assortmentSelector || { }).length && !includeLeaves) {
    selector.isRoot = true;
  }
```

Closes #455