### PR TITLE
Restrict enrollment to Plan_Product only

### DIFF
--- a/packages/api/src/resolvers/mutations/enrollments/createEnrollment.ts
+++ b/packages/api/src/resolvers/mutations/enrollments/createEnrollment.ts
@@ -1,7 +1,12 @@
 import { log } from '@unchainedshop/logger';
 import { Context, Root } from '@unchainedshop/types/api';
-import { ProductStatus } from '@unchainedshop/core-products';
-import { ProductNotFoundError, ProductWrongStatusError, InvalidIdError } from '../../../errors';
+import { ProductStatus, ProductTypes } from '@unchainedshop/core-products';
+import {
+  ProductNotFoundError,
+  ProductWrongStatusError,
+  InvalidIdError,
+  ProductWrongTypeError,
+} from '../../../errors';
 
 export default async function createEnrollment(
   root: Root,
@@ -26,6 +31,8 @@ export default async function createEnrollment(
   if (product.status !== ProductStatus.ACTIVE) {
     throw new ProductWrongStatusError({ status: product.status });
   }
+
+  if (product.type !== ProductTypes.PlanProduct) throw new ProductWrongTypeError({ type: product.type });
 
   return modules.enrollments.create(
     {


### PR DESCRIPTION
currently, enrollment can be created for any product and only when an adapter is when problem throws

```
No suitable enrollment plugin available for this plan configuration
```
but this should only be the case when a plan product has no configured subscription plan.