### PR TITLE
Add meta on bokkmark schema

### DIFF
--- a/packages/api/src/resolvers/mutations/bookmarks/createBookmark.ts
+++ b/packages/api/src/resolvers/mutations/bookmarks/createBookmark.ts
@@ -4,7 +4,7 @@ import { BookmarkAlreadyExistsError, InvalidIdError, ProductNotFoundError } from
 
 export default async function createBookmark(
   root: Root,
-  { productId, userId }: { productId: string; userId: string },
+  { productId, userId, meta }: { productId: string; userId: string; meta?: any },
   { modules, userId: currenctUserId }: Context,
 ) {
   log(`mutation createBookmark for ${userId}`, {
@@ -25,6 +25,7 @@ export default async function createBookmark(
   const bookmarkId = await modules.bookmarks.create({
     userId,
     productId,
+    meta,
   });
 
   return modules.bookmarks.findById(bookmarkId);

--- a/packages/api/src/schema/mutation.ts
+++ b/packages/api/src/schema/mutation.ts
@@ -816,7 +816,7 @@ export default [
       """
       Create a bookmark for a specific user
       """
-      createBookmark(productId: ID!, userId: ID!): Bookmark!
+      createBookmark(productId: ID!, userId: ID!, meta: JSON): Bookmark!
 
       """
       Remove an existing bookmark by ID

--- a/packages/core-bookmarks/src/db/BookmarksSchema.ts
+++ b/packages/core-bookmarks/src/db/BookmarksSchema.ts
@@ -5,6 +5,7 @@ export const BookmarkSchema = new SimpleSchema(
   {
     userId: { type: String, required: true },
     productId: { type: String, required: true },
+    meta: { type: Object, blackbox: true, required: false },
     ...Schemas.timestampFields,
   },
   { requiredByDefault: false },

--- a/packages/core-bookmarks/src/module/configureBookmarksModule.ts
+++ b/packages/core-bookmarks/src/module/configureBookmarksModule.ts
@@ -27,7 +27,6 @@ export const configureBookmarksModule = async ({
       const filter = generateDbFilterById(bookmarkId);
       return Bookmarks.findOne(filter, {});
     },
-
     find: async (query) => Bookmarks.find(query).toArray(),
 
     existsByUserIdAndProductId: async ({ productId, userId }) => {
@@ -66,6 +65,12 @@ export const configureBookmarksModule = async ({
     deleteByProductId: async (productId) => {
       const bookmarks = await Bookmarks.find({ productId }, { projection: { _id: true } }).toArray();
       const result = await Bookmarks.deleteMany({ productId });
+      await Promise.all(bookmarks.map(async (b) => emit('BOOKMARK_REMOVE', { bookmarkId: b._id })));
+      return result.deletedCount;
+    },
+    deleteByUserIdAndMeta: async ({ userId, meta }) => {
+      const bookmarks = await Bookmarks.find({ userId, meta }, { projection: { _id: true } }).toArray();
+      const result = await Bookmarks.deleteMany({ meta, userId });
       await Promise.all(bookmarks.map(async (b) => emit('BOOKMARK_REMOVE', { bookmarkId: b._id })));
       return result.deletedCount;
     },

--- a/packages/types/bookmarks.ts
+++ b/packages/types/bookmarks.ts
@@ -12,6 +12,7 @@ export type Bookmark = {
   _id?: _ID;
   userId: string;
   productId: string;
+  meta?: any;
 } & TimestampFields;
 
 /*
@@ -27,6 +28,7 @@ export interface BookmarksModule extends ModuleMutations<Bookmark> {
   replaceUserId: (fromUserId: string, toUserId: string) => Promise<number>;
   deleteByUserId: (toUserId: string) => Promise<number>;
   deleteByProductId: (productId: string) => Promise<number>;
+  deleteByUserIdAndMeta: (meta: any) => Promise<number>;
 }
 
 /*


### PR DESCRIPTION
Includes bookmark extension that will enable projects to store and use additional bookmark information using meta fields

- Added meta on bookmarks db schema
- extend `mutation.createBookmark` to accept additional optional `meta` parameter
- extend BookmarkModule to include `deleteByUserIdAndMeta` util for performing bulk delete operation based on meta.

This PR is generic and doesn't implement the exact requirement we encountered for the favorite list on a project. Still, it will enable us to extend the functionality to the specific condition per project bases. 
