### PR TITLE
Fix leveled catalog price calculations

### DIFF
--- a/packages/core-products/src/module/configureProductPrices.ts
+++ b/packages/core-products/src/module/configureProductPrices.ts
@@ -69,7 +69,7 @@ export const configureProductPricesModule = ({
     });
 
     const foundPrice = pricing.reduce(
-      (current, tier) => (tier.maxQuantity != null && quantity >= tier.maxQuantity ? tier : current),
+      (current, tier) => (tier.maxQuantity && quantity >= tier.maxQuantity ? tier : current),
       pricing?.[0],
     );
     if (!foundPrice) return null;


### PR DESCRIPTION
it was not picking the right price for the current cart quantity of a product; it was defaulting to the first to the first price  because of !p.maxQuantity

let say 
```
const pricing = [
  { maxQuantity: 0, price: 300 },
  { maxQuantity: 5, price: 250 },
  { maxQuantity: 10, price: 200 },
];
```
Now the price calculation will be as follows

quantity   price
1    =>          300
4        =>        300
5          =>       250
9           =>     250
10       =>      200
15      =>      200

but before it was always 300 no matter the quantity