### PR TITLE
Stabilize cart item & discount ordering across data loaders

### DIFF
--- a/packages/core-orders/src/db/OrderDiscountsCollection.ts
+++ b/packages/core-orders/src/db/OrderDiscountsCollection.ts
@@ -16,7 +16,7 @@ export const OrderDiscountsCollection = async (db: mongodb.Db) => {
   const OrderDiscounts = db.collection<OrderDiscount>('order_discounts');
 
   await buildDbIndexes<OrderDiscount>(OrderDiscounts, [
-    { index: { orderId: 1 } },
+    { index: { orderId: 1, created: 1 } },
     { index: { code: 1 }, options: { sparse: true } },
   ]);
 

--- a/packages/core-orders/src/db/OrderPositionsCollection.ts
+++ b/packages/core-orders/src/db/OrderPositionsCollection.ts
@@ -23,7 +23,7 @@ export const OrderPositionsCollection = async (db: mongodb.Db) => {
   const OrderPositions = db.collection<OrderPosition>('order_positions');
 
   await buildDbIndexes<OrderPosition>(OrderPositions, [
-    { index: { orderId: 1, quantity: 1 } },
+    { index: { orderId: 1, created: 1 } },
     { index: { productId: 1 } },
   ]);
 

--- a/packages/core-orders/src/module/configureOrderDiscountsModule.ts
+++ b/packages/core-orders/src/module/configureOrderDiscountsModule.ts
@@ -29,9 +29,12 @@ export const configureOrderDiscountsModule = ({
     ): Promise<OrderDiscount[]> => {
       if ('orderIds' in query) {
         if (!query.orderIds?.length) return [];
-        return OrderDiscounts.find({ orderId: { $in: query.orderIds } }).toArray();
+        return OrderDiscounts.find(
+          { orderId: { $in: query.orderIds } },
+          { sort: { created: 1 } },
+        ).toArray();
       }
-      return OrderDiscounts.find({ orderId: query.orderId }).toArray();
+      return OrderDiscounts.find({ orderId: query.orderId }, { sort: { created: 1 } }).toArray();
     },
 
     create: async (

--- a/packages/core-orders/src/module/configureOrderPositionsModule.ts
+++ b/packages/core-orders/src/module/configureOrderPositionsModule.ts
@@ -51,12 +51,18 @@ export const configureOrderPositionsModule = ({
     ): Promise<OrderPosition[]> => {
       if ('orderIds' in query) {
         if (!query.orderIds?.length) return [];
-        return OrderPositions.find({
-          orderId: { $in: query.orderIds },
-          quantity: { $gt: 0 },
-        }).toArray();
+        return OrderPositions.find(
+          {
+            orderId: { $in: query.orderIds },
+            quantity: { $gt: 0 },
+          },
+          { sort: { created: 1 } },
+        ).toArray();
       }
-      return OrderPositions.find({ orderId: query.orderId, quantity: { $gt: 0 } }).toArray();
+      return OrderPositions.find(
+        { orderId: query.orderId, quantity: { $gt: 0 } },
+        { sort: { created: 1 } },
+      ).toArray();
     },
 
     delete: async (orderPositionId: string) => {


### PR DESCRIPTION
## Summary

The order positions/discounts data loaders (introduced in 4.8.11) batch with `{ orderId: { $in: [...] } }` instead of equality. Combined with the `{ orderId: 1, quantity: 1 }` index from the index refactor, MongoDB's planner returned cart items **sorted by quantity ascending** — so bumping an item's quantity pushed it to the end of the cart in the UI.

This branch makes the loader output match the insertion order the pre-loader (equality) path produced, and aligns the indexes so the sort is served efficiently.

## Changes

- **Order positions** — sort `findOrderPositions` explicitly by `created` (both the `orderId` and `orderIds` batch variants) so insertion order is preserved regardless of which index plan MongoDB picks. *(commit: cart item reordering fix)*
- **Order discounts** — apply the same `created` sort to `findOrderDiscounts`; the discounts loader (`orderDiscountsLoader`) is the only other list-returning loader from the 4.8.11 batch.
- **Indexes** — add `created` to the `orderId` compound indexes on `order_positions` and `order_discounts`:
  - `order_positions`: `{ orderId: 1, quantity: 1 }` → `{ orderId: 1, created: 1 }`
  - `order_discounts`: `{ orderId: 1 }` → `{ orderId: 1, created: 1 }`

  With `created` as the second key, the loaders' `$in` + `sort({ created: 1 })` queries become an indexed **`SORT_MERGE`** instead of a blocking in-memory `SORT`. The dropped `quantity` key was only ever a non-selective `quantity > 0` residual filter.

## Audit of the other 4.8.11 / list loaders

| Loader | Verdict |
|---|---|
| `orderPositionsLoader` | fixed (sort + index) |
| `orderDiscountsLoader` | fixed (sort + index) |
| `orderPaymentLoader` / `orderDeliveryLoader` | by-`_id` single-doc lookups — batch order irrelevant ✓ |
| `enrollmentByOrderLoader` | "first match wins" = old `findOne`; backed by `{ 'periods.orderId': 1 }` ✓ |
| `productMediasLoader` / `assortmentMediasLoader` | sort `{ sortKey: 1 }`, backed by `{ …, sortKey: 1 }` indexes — no regression ✓ |
| `assortmentProductsLoader` | single-field `{ productId: 1 }` index → `$in` preserves per-product insertion order, identical to the old singular query ✓ |
| `productProxiesLoader` | explicit `{ sequence, published }` sort — ordering fine ✓ |

## Notes

- **Migration:** `buildDbIndexes` only does a full `dropIndexes` rebuild on a build error, so on existing deployments the old `{ orderId: 1, quantity: 1 }` / `{ orderId: 1 }` indexes will linger (harmless; the planner prefers the new one). New deployments get the clean set.
- **Follow-up (not in this PR):** `productProxiesLoader`'s filter (`$or` on the nested array fields `bundleItems.productId` / `proxy.assignments.productId`) has no supporting index → collscan. Ordering is correct; this is a pre-existing, niche performance gap that would require multikey indexes.

> Targets `v4.8.x`; the master/v5 equivalent lives on `pozylon/order-positions-stable-sort-master`.