### PR TITLE
feat: add cartLoader to batch User.cart resolution

### DIFF
--- a/packages/api/src/loaders/cartLoader.ts
+++ b/packages/api/src/loaders/cartLoader.ts
@@ -1,0 +1,25 @@
+import type { UnchainedCore } from '@unchainedshop/core';
+import type { Order } from '@unchainedshop/core-orders';
+import DataLoader from 'dataloader';
+
+export default (unchainedAPI: UnchainedCore) =>
+  new DataLoader<{ userId: string; countryCode?: string; orderNumber?: string }, Order | null>(
+    async (queries) => {
+      const userIds = [...new Set(queries.map((q) => q.userId).filter(Boolean))];
+
+      const carts = await unchainedAPI.modules.orders.findCarts({ userIds });
+
+      // findCarts returns carts sorted by `updated` descending, so the first
+      // match per query key is the most recently updated cart, mirroring the
+      // semantics of modules.orders.cart.
+      return queries.map(
+        (q) =>
+          carts.find(
+            (cart) =>
+              cart.userId === q.userId &&
+              (!q.countryCode || cart.countryCode === q.countryCode) &&
+              (!q.orderNumber || cart.orderNumber === q.orderNumber),
+          ) || null,
+      );
+    },
+  );

--- a/packages/api/src/loaders/index.ts
+++ b/packages/api/src/loaders/index.ts
@@ -27,6 +27,7 @@ import deliveryProviderLoader from './deliveryProviderLoader.ts';
 import paymentProviderLoader from './paymentProviderLoader.ts';
 import warehousingProviderLoader from './warehousingProviderLoader.ts';
 import orderLoader from './orderLoader.ts';
+import cartLoader from './cartLoader.ts';
 import quotationLoader from './quotationLoader.ts';
 import tokenExportStatusLoader from './tokenExportStatusLoader.ts';
 
@@ -71,6 +72,8 @@ const loaders = (unchainedAPI: UnchainedCore) => {
     warehousingProviderLoader: warehousingProviderLoader(unchainedAPI),
 
     orderLoader: orderLoader(unchainedAPI),
+
+    cartLoader: cartLoader(unchainedAPI),
 
     quotationLoader: quotationLoader(unchainedAPI),
 

--- a/packages/api/src/resolvers/type/user-types.ts
+++ b/packages/api/src/resolvers/type/user-types.ts
@@ -168,9 +168,9 @@ export const User: UserHelperTypes = {
   },
 
   async cart(user, params, context) {
-    const { modules, countryCode } = context;
+    const { loaders, countryCode } = context;
     await checkAction(context, viewUserOrders, [user, params]);
-    return modules.orders.cart({
+    return loaders.cartLoader.load({
       countryCode,
       orderNumber: params.orderNumber,
       userId: user._id,

--- a/packages/core-orders/src/module/configureOrdersModule-queries.ts
+++ b/packages/core-orders/src/module/configureOrdersModule-queries.ts
@@ -35,6 +35,36 @@ export interface DateRange {
 
 export type StatisticsDateField = 'created' | 'ordered' | 'rejected' | 'confirmed' | 'fulfilled';
 
+function buildCartSelector({
+  countryCode,
+  orderNumber,
+  userId,
+  userIds,
+}: {
+  countryCode?: string;
+  orderNumber?: string;
+  userId?: string;
+  userIds?: string[];
+}): mongodb.Filter<Order> {
+  const selector: mongodb.Filter<Order> = {
+    status: { $eq: null },
+  };
+
+  if (userIds) {
+    selector.userId = { $in: userIds };
+  } else if (userId) {
+    selector.userId = userId;
+  }
+  if (countryCode) {
+    selector.countryCode = countryCode;
+  }
+  if (orderNumber) {
+    selector.orderNumber = orderNumber;
+  }
+
+  return selector;
+}
+
 function buildDateMatch(dateField: string, dateRange?: DateRange) {
   if (!dateRange?.start && !dateRange?.end) return { [dateField]: { $exists: true } };
 
@@ -70,22 +100,36 @@ export const configureOrdersModuleQueries = ({ Orders }: { Orders: mongodb.Colle
       orderNumber?: string;
       userId: string;
     }) => {
-      const selector: mongodb.Filter<Order> = {
-        countryCode,
-        status: { $eq: null },
-        userId,
-      };
-
-      if (orderNumber) {
-        selector.orderNumber = orderNumber;
-      }
-
+      const selector = buildCartSelector({ countryCode, orderNumber, userId });
       const options: mongodb.FindOptions = {
         sort: {
           updated: -1,
         },
       };
       return Orders.findOne(selector, options);
+    },
+
+    // Batched variant of `cart`, used by the API cartLoader. Returns the open
+    // carts (status === null) for the given users, most recently updated first.
+    findCarts: async (
+      {
+        countryCode,
+        orderNumber,
+        userId,
+        userIds,
+      }: {
+        countryCode?: string;
+        orderNumber?: string;
+        userId?: string;
+        userIds?: string[];
+      },
+      options?: mongodb.FindOptions,
+    ): Promise<Order[]> => {
+      const selector = buildCartSelector({ countryCode, orderNumber, userId, userIds });
+      return Orders.find(selector, {
+        sort: { updated: -1 },
+        ...options,
+      }).toArray();
     },
 
     count: async (query: OrderQuery): Promise<number> => {


### PR DESCRIPTION
## Problem

The `cart` query in `core-orders` (`configureOrdersModule-queries.ts`) used a plain `findOne` with no batching. Resolving the `cart` field across multiple users in a single GraphQL request (e.g. admin `users { cart { ... } }`) issued one DB query per user.

## Change

Adds a request-scoped DataLoader for carts, keyed by `{ userId, countryCode }` (plus `orderNumber`), following the existing loader conventions in `packages/api/src/loaders`.

- **`core-orders`**: extract a shared `buildCartSelector` helper and add a batched `findCarts({ userIds, ... })` query (`userId: { $in }`, sorted `updated: -1`). `cart` now reuses the helper (behavior unchanged — every caller already supplies `countryCode`). The loader lives in the API layer and can't query MongoDB directly (layer boundary), and `findOrders`/`buildFindSelector` only support a single `userId`, so a dedicated batched method was needed.
- **`cartLoader.ts`** (new): batches all keys into one `findCarts({ userIds })` query, then resolves each key in JS by matching `userId` + `countryCode` + `orderNumber` against the most-recently-updated-first list — mirroring `modules.orders.cart` semantics.
- **`User.cart` resolver**: now calls `loaders.cartLoader.load(...)`, covering `me { cart }`, `user(userId) { cart }`, and `users { cart }`.

### Intentionally left on the direct `modules.orders.cart` call
- Core services (`nextUserCart`, `migrateOrderCart`) and platform/worker — no request-scoped loaders there.
- `signPaymentProviderForCheckout` mutation — avoids loader-cache staleness in the write path.
- `getUserCart` MCP tool — single read, no batching benefit.

## Verification
- `npm run build` (full typecheck) passes; ESLint clean on changed files.
- 88 integration tests pass: `heartbeat`, `cart-products`, `cart-migrate`, `auth-admin` (all select `me`/cross-user `cart`), plus `cart-checkout`, `cart-delivery-payment`, `cart-discounts`, `cart-quotations` (exercise the refactored `cart`/`findCarts` path via checkout services).