### PR TITLE
feat: add cartLoader to batch User.cart resolution

### DIFF
--- a/packages/api/src/loaders/cartLoader.test.ts
+++ b/packages/api/src/loaders/cartLoader.test.ts
@@ -1,0 +1,100 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import type { UnchainedCore } from '@unchainedshop/core';
+import cartLoader from './cartLoader.ts';
+
+interface TestCart {
+  _id: string;
+  userId: string;
+  countryCode: string;
+  orderNumber?: string;
+  updated: Date;
+}
+
+const CARTS: TestCart[] = [
+  { _id: 'u1-ch-new', userId: 'u1', countryCode: 'CH', updated: new Date('2026-05-03') },
+  { _id: 'u1-ch-old', userId: 'u1', countryCode: 'CH', updated: new Date('2026-05-01') },
+  { _id: 'u1-de', userId: 'u1', countryCode: 'DE', updated: new Date('2026-04-01') },
+  {
+    _id: 'u2-ch-named',
+    userId: 'u2',
+    countryCode: 'CH',
+    orderNumber: 'NAMED',
+    updated: new Date('2026-05-02'),
+  },
+];
+
+// Mirrors modules.orders.findCarts: returns the open carts for the requested
+// users, most recently updated first. Records the userIds it was called with.
+const createLoader = (carts: TestCart[] = CARTS) => {
+  const calls: string[][] = [];
+  const unchainedAPI = {
+    modules: {
+      orders: {
+        findCarts: async ({ userIds }: { userIds: string[] }) => {
+          calls.push(userIds);
+          return carts
+            .filter((cart) => userIds.includes(cart.userId))
+            .sort((a, b) => b.updated.getTime() - a.updated.getTime());
+        },
+      },
+    },
+  } as unknown as UnchainedCore;
+  return { loader: cartLoader(unchainedAPI), calls };
+};
+
+describe('cartLoader', () => {
+  it('returns the most recently updated cart for the {userId, countryCode}', async () => {
+    const { loader } = createLoader();
+    const cart = await loader.load({ userId: 'u1', countryCode: 'CH' });
+    assert.strictEqual(cart?._id, 'u1-ch-new');
+  });
+
+  it('scopes the cart to the requested countryCode', async () => {
+    const { loader } = createLoader();
+    const cart = await loader.load({ userId: 'u1', countryCode: 'DE' });
+    assert.strictEqual(cart?._id, 'u1-de');
+  });
+
+  it('returns null when the user has no cart in the requested country', async () => {
+    const { loader } = createLoader();
+    assert.strictEqual(await loader.load({ userId: 'u1', countryCode: 'US' }), null);
+  });
+
+  it('returns null when the user has no cart at all', async () => {
+    const { loader } = createLoader();
+    assert.strictEqual(await loader.load({ userId: 'ghost', countryCode: 'CH' }), null);
+  });
+
+  it('matches by orderNumber when provided', async () => {
+    const { loader } = createLoader();
+    assert.strictEqual(
+      (await loader.load({ userId: 'u2', countryCode: 'CH', orderNumber: 'NAMED' }))?._id,
+      'u2-ch-named',
+    );
+    assert.strictEqual(
+      await loader.load({ userId: 'u2', countryCode: 'CH', orderNumber: 'MISSING' }),
+      null,
+    );
+  });
+
+  it('ignores orderNumber when not provided (returns most recent cart)', async () => {
+    const { loader } = createLoader();
+    const cart = await loader.load({ userId: 'u2', countryCode: 'CH' });
+    assert.strictEqual(cart?._id, 'u2-ch-named');
+  });
+
+  it('batches concurrent loads into a single findCarts call with deduped userIds', async () => {
+    const { loader, calls } = createLoader();
+    const [a, b, c] = await Promise.all([
+      loader.load({ userId: 'u1', countryCode: 'CH' }),
+      loader.load({ userId: 'u2', countryCode: 'CH' }),
+      loader.load({ userId: 'u1', countryCode: 'CH' }),
+    ]);
+    assert.strictEqual(calls.length, 1);
+    assert.deepStrictEqual([...calls[0]].sort(), ['u1', 'u2']);
+    assert.strictEqual(a?._id, 'u1-ch-new');
+    assert.strictEqual(b?._id, 'u2-ch-named');
+    assert.strictEqual(c?._id, 'u1-ch-new');
+  });
+});

--- a/packages/api/src/loaders/cartLoader.ts
+++ b/packages/api/src/loaders/cartLoader.ts
@@ -1,0 +1,25 @@
+import type { UnchainedCore } from '@unchainedshop/core';
+import type { Order } from '@unchainedshop/core-orders';
+import DataLoader from 'dataloader';
+
+export default (unchainedAPI: UnchainedCore) =>
+  new DataLoader<{ userId: string; countryCode?: string; orderNumber?: string }, Order | null>(
+    async (queries) => {
+      const userIds = [...new Set(queries.map((q) => q.userId).filter(Boolean))];
+
+      const carts = await unchainedAPI.modules.orders.findCarts({ userIds });
+
+      // findCarts returns carts sorted by `updated` descending, so the first
+      // match per query key is the most recently updated cart, mirroring the
+      // semantics of modules.orders.cart.
+      return queries.map(
+        (q) =>
+          carts.find(
+            (cart) =>
+              cart.userId === q.userId &&
+              (!q.countryCode || cart.countryCode === q.countryCode) &&
+              (!q.orderNumber || cart.orderNumber === q.orderNumber),
+          ) || null,
+      );
+    },
+  );

--- a/packages/api/src/loaders/index.ts
+++ b/packages/api/src/loaders/index.ts
@@ -27,6 +27,7 @@ import deliveryProviderLoader from './deliveryProviderLoader.ts';
 import paymentProviderLoader from './paymentProviderLoader.ts';
 import warehousingProviderLoader from './warehousingProviderLoader.ts';
 import orderLoader from './orderLoader.ts';
+import cartLoader from './cartLoader.ts';
 import orderPaymentLoader from './orderPaymentLoader.ts';
 import orderDeliveryLoader from './orderDeliveryLoader.ts';
 import orderPositionsLoader from './orderPositionsLoader.ts';
@@ -76,6 +77,7 @@ const loaders = (unchainedAPI: UnchainedCore) => {
     warehousingProviderLoader: warehousingProviderLoader(unchainedAPI),
 
     orderLoader: orderLoader(unchainedAPI),
+    cartLoader: cartLoader(unchainedAPI),
     orderPaymentLoader: orderPaymentLoader(unchainedAPI),
     orderDeliveryLoader: orderDeliveryLoader(unchainedAPI),
     orderPositionsLoader: orderPositionsLoader(unchainedAPI),

--- a/packages/api/src/resolvers/type/user-types.ts
+++ b/packages/api/src/resolvers/type/user-types.ts
@@ -168,9 +168,9 @@ export const User: UserHelperTypes = {
   },
 
   async cart(user, params, context) {
-    const { modules, countryCode } = context;
+    const { loaders, countryCode } = context;
     await checkAction(context, viewUserOrders, [user, params]);
-    return modules.orders.cart({
+    return loaders.cartLoader.load({
       countryCode,
       orderNumber: params.orderNumber,
       userId: user._id,

--- a/packages/core-orders/src/module/configureOrdersModule-queries.ts
+++ b/packages/core-orders/src/module/configureOrdersModule-queries.ts
@@ -88,6 +88,19 @@ export const configureOrdersModuleQueries = ({ Orders }: { Orders: mongodb.Colle
       return Orders.findOne(selector, options);
     },
 
+    // Batched lookup of open carts (status === null) for the given users, most
+    // recently updated first. Backs the API cartLoader; per-key country/order
+    // matching is applied in the loader to mirror `cart`'s selection.
+    findCarts: async (
+      { userIds }: { userIds: string[] },
+      options?: mongodb.FindOptions,
+    ): Promise<Order[]> => {
+      return Orders.find(
+        { status: { $eq: null }, userId: { $in: userIds } },
+        { sort: { updated: -1 }, ...options },
+      ).toArray();
+    },
+
     count: async (query: OrderQuery): Promise<number> => {
       const orderCount = await Orders.countDocuments(buildFindSelector(query));
       return orderCount;


### PR DESCRIPTION
## Problem

The `cart` query in `core-orders` (`configureOrdersModule-queries.ts`) used a plain `findOne` with no batching. Resolving the `cart` field across multiple users in one GraphQL request (e.g. admin `users { cart { ... } }`) issued one DB query per user. It was the only order-related read on this branch still lacking a DataLoader — the order sub-entities (positions/payments/deliveries/discounts) already have one.

## Change

Adds a request-scoped DataLoader for carts, keyed by `{ userId, countryCode }` (plus `orderNumber`), following the existing loader conventions in `packages/api/src/loaders`.

- **`core-orders`**: add a batched, read-only `findCarts({ userIds })` query — open carts (`status === null`), most recently updated first. **`cart` itself is left byte-for-byte unchanged** (see regression note below), so every direct caller (checkout, cart migration, MCP, signPayment) is unaffected.
- **`cartLoader.ts`** (new): one `findCarts({ userIds })` query per batch, then per-key matching on `countryCode` + `orderNumber` in JS to exactly mirror `modules.orders.cart` selection (most-recent-updated wins).
- **`User.cart` resolver**: now calls `loaders.cartLoader.load(...)`, covering `me { cart }`, `user(userId) { cart }`, and `users { cart }`.
- **`cartLoader.test.ts`** (new): unit test for batching/dedup, most-recent selection, country/orderNumber filtering, and null cases.

### Regression note (why `cart` is untouched)
An earlier revision factored a shared `buildCartSelector` out of `cart`. That helper applied `countryCode` **conditionally**, whereas the original `cart` always set it. With the MongoDB driver default (`ignoreUndefined` not configured → `undefined` serializes to `null`), the original `cart({ countryCode: undefined })` matches no cart and returns `null`, while the refactor would have returned the user's most-recent cart of *any* country. This is reachable via `migrateUserData` → `migrateOrderCarts`, where `countryCode` is `user.lastLogin?.countryCode` (can be `undefined`). To avoid any behavior change on the checkout/migration path, `cart` is now left exactly as-is and `findCarts` is standalone. `User.cart` is unaffected either way — `countryCode` is always defined there (from locale context).

## Verification
- `tsc --build` + ESLint clean.
- New unit test: 7/7 pass.
- 88 integration tests pass: `heartbeat`, `auth-admin` (select `me`/cross-user `cart`), `cart-products`, `cart-migrate`, `cart-checkout`, `cart-delivery-payment`, `cart-discounts`, `cart-quotations`.

> Targets `v4.8.x`.