### PR TITLE
feat: leveled minQuantity pricing, registerX plugin factories, events cleanup + docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,9 +61,13 @@
 - **REMOVED**: PayPal Checkout plugin entirely (due to deprecated `@paypal/checkout-server-sdk`). Implement a custom PayPal integration using `@paypal/paypal-server-sdk`.
 - **REMOVED**: Braintree payment plugin.
 
-### Dependencies
-- **CHANGED**: ESLint upgraded to v10 (flat config only; the lint script no longer accepts `--ext`).
-- **CHANGED**: `@fastify/multipart` peer raised to `>= 10 < 11`; `@parse/node-apn` to `^8` (ticketing/Apple Wallet); `nodemailer` peer widened to `>= 6.9 < 9`; Stripe SDK peer widened to `>= 19 < 23` (API version `2026-04-22.dahlia`). All major bumps drop Node 18 (the engine already requires Node 22+).
+### Leveled Pricing
+- **CHANGED**: Product catalog price tiers are now keyed by **`minQuantity`** (inclusive lower bound; base tier `= 0`; the highest tier is open-ended) instead of v4's `maxQuantity` (inclusive upper bound). GraphQL: `UpdateProductCommercePricingInput.maxQuantity` **removed** (use `minQuantity`); `PriceLevel.minQuantity` added and `PriceLevel.maxQuantity` is now derived/nullable for display; `ProductCatalogPrice.minQuantity` replaces `maxQuantity`. Bulk-import/export product price columns use `minQuantity`.
+- **AUTOMATIC MIGRATION**: an idempotent startup migration (`20260611120000-pricing-maxquantity-to-minquantity`) converts existing `commerce.pricing` per `(countryCode, currencyCode)` — no operator action required; safe to re-run. **Update any storefront/client/import code that wrote `maxQuantity` to write `minQuantity`.**
+
+### Event System
+- **CHANGED**: the Redis and AWS EventBridge emit adapters no longer self-register on import. Register the transport explicitly before `startPlatform`: `import { setEmitAdapter } from '@unchainedshop/events'; import { RedisEventEmitter } from '@unchainedshop/plugins/events/redis'; setEmitAdapter(RedisEventEmitter());`
+- **NEW**: optional `EmitAdapter.shutdown()` — implemented by the redis/eventbridge adapters to close long-lived connections; called by `startPlatform` on graceful shutdown.
 
 ## New Features & Improvements
 
@@ -75,6 +79,7 @@
 - **CHANGED**: Admin impersonation now travels inside the JWT (`imp` claim) instead of session state.
 
 ### Developer Experience
+- **NEW**: `registerX(...)` plugin authoring factories (re-exported from `@unchainedshop/core`) — author a custom adapter of any director type in one typed call (`registerPaymentProvider`, `registerDeliveryProvider`, `registerProductPricing`, `registerOrderDiscount`, `registerWorker`, `registerFileAdapter`, `registerQuotation`, `registerEnrollment`, …). They build and register the `IPlugin` for you; `pluginRegistry.register()` remains the low-level primitive. See the [Plugin Factories](https://docs.unchained.shop/extend/plugin-factories) docs.
 - **NEW**: `@unchainedshop/client` package — installable React/Apollo GraphQL hooks with per-module subpath imports (e.g. `@unchainedshop/client/product`), generated from the admin-ui hooks, for building custom storefronts and admin tools. Peer dependencies: `@apollo/client` ^4, `graphql` ^16, `react` >=18.
 - **NEW**: Pluggable logger context — `setLogContextProvider()` merges request-scoped fields (e.g. OpenTelemetry `trace_id` / `span_id`) into every JSON log line (prototype-pollution-safe; provider errors are swallowed so telemetry never breaks logging).
 - **NEW**: `Query.registeredEventTypes: [String!]!` lists all registered event type names (gated by `viewEvents`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,14 +29,62 @@
   - `updateOrderPaymentInvoice` → use `updateCartPaymentInvoice`
   - `updateOrderPaymentGeneric` → use `updateCartPaymentGeneric`
 
-- **REMOVED**: `OrderDeliveryPickUp.pickUpLocations` field. Use `DeliveryProvider.pickupLocations` instead.
+- **REMOVED**: `OrderDeliveryPickUp.pickUpLocations` field. Use `DeliveryProviderPickUp.pickUpLocations` instead.
 
 - **REMOVED**: Router export aliases:
   - `expressRouter` → use `adminUIRouter` from `@unchainedshop/api/express`
   - `fastifyRouter` → use `adminUIRouter` from `@unchainedshop/api/fastify`
 
+### Authentication (Stateless JWT)
+- **CHANGED**: Authentication moved from stateful Express/Passport sessions to stateless JWTs (HS256, signed/verified with `jose`). Server-side session storage — `express-session`, `@fastify/session`, `passport`, and the bundled MongoDB session store — has been removed. **All existing sessions are invalidated on upgrade; clients must re-authenticate.**
+- **REMOVED**: `express-session`, `@fastify/session`, `passport`, and `jsonwebtoken` dependencies. `cookie-parser` is now a required peer dependency. The `sessions` collection is no longer used.
+- **NEW (required)**: `UNCHAINED_TOKEN_SECRET` must be set and be at least 32 characters (256 bits) or token signing/verification throws. Optional `UNCHAINED_TOKEN_EXPIRY_SECONDS` (default `3600`, previously effectively 7 days) and `UNCHAINED_TOKEN_ISSUER` (default `unchained-engine`).
+- **CHANGED**: Token revocation is stateless via a `User.tokenVersion` counter — incrementing it invalidates every outstanding token for that user. `modules.users.markDeleted` now bumps `tokenVersion` instead of deleting session rows.
+- **CHANGED**: Default cookie `SameSite` changed from `none` to `lax` (CSRF hardening). Set `UNCHAINED_COOKIE_SAMESITE=none` if you rely on cross-site/embedded auth flows.
+- **CHANGED**: `signAccessToken()` and `verifyLocalToken()` are now async.
+- **CHANGED**: `Mutation.logoutAllSessions` return type changed from `LogoutAllSessionsResponse!` to `SuccessResponse` (no longer exposes `tokenVersion`).
+- **CHANGED**: `changePassword` is no longer self-permitted by the default ACL — review custom roles if you relied on this.
+
+### Roles
+- **CHANGED**: The global `Roles` singleton is replaced by a `createRoles()` factory that returns an isolated instance (removes shared global state across server instances). The `Role` constructor no longer auto-registers into a global registry and no longer throws on duplicate names; register explicitly via `addRole()` / `configureRoles()`. Default `admin` / `__loggedIn__` / `__all__` roles are no longer created at module import. `UnchainedServerOptions.roles` and `Context.roles` are now typed `RolesInterface` (was `any`).
+
+### Admin UI
+- **CHANGED**: Permissions moved from a build-time generated artifact (`generate-permissions.js`, `window.AdminUiPermissions`) to a typed runtime model in `src/modules/Auth/permissionConfig.ts`. The build no longer runs `generate-permissions.js` or emits `public/admin-ui-permissions.js`.
+- **CHANGED**: Access control is now **deny-by-default** — routes absent from `ROUTE_ROLES` are denied. Custom pages must be added to `ROUTE_ROLES` or `UNRESTRICTED_PAGES`. Dashboard widgets, mutating controls, and form fields gate on `hasRole()` / `isAdmin()`, and data hooks skip GraphQL queries the user is not authorized for.
+- **CHANGED**: 54 UI primitives consolidated into a canonical `src/components/ui/` kit (with `@/components/ui` and `@/components/ui/form` barrels). Importing them from the old `**/common/components/*` / `**/forms/components/*` paths is now an ESLint error. `DeleteButton`, `HeaderDeleteButton`, and `EditIcon` were removed (use `<Button>` variants). The per-domain `use*StatusTypes` hooks were replaced by a generic `useStatusTypes(enumName)`. `classnames` was replaced by `clsx`.
+
+### Server Adapters (Express & Fastify)
+- **CHANGED**: `connect()` is now async; its `db` argument and `initPluginMiddlewares` callback were removed in favor of `authConfig` (JWT/OIDC) and `trustProxy` options. Proxy header trust (`x-forwarded-for` / `x-real-ip`) is now opt-in via `trustProxy`. Plugin HTTP routes mount automatically from the plugin registry (`pluginRegistry.getRoutes()`) via WHATWG-Fetch handlers, replacing the per-framework `handler-express.ts` / `handler-fastify.ts` files.
+- **REMOVED**: `GRAPHQL_API_PATH` environment variable is no longer read. Configure the GraphQL endpoint path through Yoga options (`graphqlHandler.graphqlEndpoint`). `MCP_API_PATH` is retained.
+
 ### Plugins
-- **REMOVED**: PayPal Checkout plugin entirely (due to deprecated `@paypal/checkout-server-sdk`). Migrate to Braintree or implement custom PayPal integration using `@paypal/paypal-server-sdk`.
+- **REMOVED**: PayPal Checkout plugin entirely (due to deprecated `@paypal/checkout-server-sdk`). Implement a custom PayPal integration using `@paypal/paypal-server-sdk`.
+- **REMOVED**: Braintree payment plugin.
+
+### Dependencies
+- **CHANGED**: ESLint upgraded to v10 (flat config only; the lint script no longer accepts `--ext`).
+- **CHANGED**: `@fastify/multipart` peer raised to `>= 10 < 11`; `@parse/node-apn` to `^8` (ticketing/Apple Wallet); `nodemailer` peer widened to `>= 6.9 < 9`; Stripe SDK peer widened to `>= 19 < 23` (API version `2026-04-22.dahlia`). All major bumps drop Node 18 (the engine already requires Node 22+).
+
+## New Features & Improvements
+
+### Authentication & Security
+- **NEW**: `Mutation.logoutAllSessions` invalidates all of a user's JWTs by bumping the token version.
+- **NEW**: OIDC inbound token verification (remote JWKS) and an OpenID Connect Back-Channel Logout 1.0 endpoint (`POST /backchannel-logout`) with full `logout_token` signature verification.
+- **NEW**: Token-sidejacking protection — a fingerprint hash is embedded in the JWT and matched against a hardened `__Secure-fgp` cookie using a timing-safe compare.
+- **NEW**: Security audit events `ACL_DENIED` and `ACL_GRANTED_SENSITIVE` for monitoring denied and sensitive permission grants.
+- **CHANGED**: Admin impersonation now travels inside the JWT (`imp` claim) instead of session state.
+
+### Developer Experience
+- **NEW**: `@unchainedshop/client` package — installable React/Apollo GraphQL hooks with per-module subpath imports (e.g. `@unchainedshop/client/product`), generated from the admin-ui hooks, for building custom storefronts and admin tools. Peer dependencies: `@apollo/client` ^4, `graphql` ^16, `react` >=18.
+- **NEW**: Pluggable logger context — `setLogContextProvider()` merges request-scoped fields (e.g. OpenTelemetry `trace_id` / `span_id`) into every JSON log line (prototype-pollution-safe; provider errors are swallowed so telemetry never breaks logging).
+- **NEW**: `Query.registeredEventTypes: [String!]!` lists all registered event type names (gated by `viewEvents`).
+
+### Admin UI
+- Added Cypress e2e suites for enrollments, quotations, and tokens, and reduced flakiness (lower retries, real support entrypoint, `cy.selectLocale()` command).
+
+### Documentation
+- **NEW**: AI Integration docs section (MCP server reference with 9 tool categories, Admin Copilot setup, AI FAQ) and auto-generated `/llms.txt` + `/llms-full.txt` for LLM/crawler consumption.
+- Added a comprehensive GraphQL API reference and an RBAC permissions reference (126 actions documented), plus server-setup, testing, seed-data, and contributing guides.
 
 ## Migration Guide
 See [MIGRATION.md](./MIGRATION.md#v4--v5-breaking-changes) for detailed migration instructions.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -238,6 +238,43 @@ import { PaypalCheckoutPlugin } from '@unchainedshop/plugins/payment/paypal-chec
 
 If you were calling this method, simply remove it. Adapters are now registered via `pluginRegistry.register()` or preset functions.
 
+### Plugin Authoring Factories (new, recommended)
+
+Custom adapters can now be registered with a single typed call instead of a hand-built `IPlugin`. The factories are re-exported from `@unchainedshop/core` (`registerPaymentProvider`, `registerDeliveryProvider`, `registerProductPricing`, `registerOrderDiscount`, `registerWorker`, `registerFileAdapter`, `registerQuotation`, `registerEnrollment`, …). `pluginRegistry.register()` with a hand-built `IPlugin` remains the low-level path for custom keys/versions, routes, modules or lifecycle hooks. See the [Plugin Factories](https://docs.unchained.shop/extend/plugin-factories) documentation.
+
+### Leveled Pricing: `maxQuantity` → `minQuantity`
+
+**BREAKING CHANGE (with automatic data migration).** Product catalog price tiers are now keyed by **`minQuantity`** — an inclusive *lower* bound — instead of v4's `maxQuantity` (inclusive *upper* bound). The base tier is `minQuantity: 0` and the highest tier is open-ended (no upper cap).
+
+- **GraphQL:** `UpdateProductCommercePricingInput.maxQuantity` is removed — use `minQuantity` (omit it for the base tier). `PriceLevel.minQuantity` is added; `PriceLevel.maxQuantity` is now derived (the next tier's floor − 1; `null` on the open-ended tier). `ProductCatalogPrice.minQuantity` replaces `maxQuantity`.
+- **Data:** an idempotent startup migration (`20260611120000-pricing-maxquantity-to-minquantity`) converts existing `commerce.pricing` per `(countryCode, currencyCode)` automatically. **No operator action is required** and re-running is safe.
+- **Action for integrators:** update any storefront query, client codegen, or bulk-import/export payload that wrote `maxQuantity` to write `minQuantity`.
+
+```jsonc
+// commerce.pricing — before (v4)            // after (v5, auto-migrated)
+[                                            [
+  { "amount": 1000, "maxQuantity": 4 },        { "amount": 1000, "minQuantity": 0 },
+  { "amount": 900,  "maxQuantity": 9 },        { "amount": 900,  "minQuantity": 5 },
+  { "amount": 800 }  /* open-ended top */      { "amount": 800,  "minQuantity": 10 }
+]                                            ]
+```
+
+### Events: explicit emit-adapter registration
+
+**BREAKING CHANGE for Redis / AWS EventBridge users.** These transports no longer self-register as a side effect of being imported. Register the emit adapter explicitly before `startPlatform`:
+
+```ts
+// ❌ Before: importing the module had the side effect of registering it
+import '@unchainedshop/plugins/events/redis';
+
+// ✅ After: register explicitly
+import { setEmitAdapter } from '@unchainedshop/events';
+import { RedisEventEmitter } from '@unchainedshop/plugins/events/redis';
+setEmitAdapter(RedisEventEmitter());
+```
+
+The Node.js in-memory emitter is still wired automatically by `registerBasePlugins()`. `EmitAdapter` also gained an optional `shutdown()` (the redis/eventbridge adapters implement it to close connections; `startPlatform` calls it on graceful shutdown).
+
 ---
 
 ## v3 → v4

--- a/admin-ui/src/gql/types.ts
+++ b/admin-ui/src/gql/types.ts
@@ -2564,7 +2564,7 @@ export type IProductCatalogPrice = {
   currency: ICurrency;
   isNetPrice: Scalars['Boolean']['output'];
   isTaxable: Scalars['Boolean']['output'];
-  maxQuantity?: Maybe<Scalars['Int']['output']>;
+  minQuantity?: Maybe<Scalars['Int']['output']>;
 };
 
 export type IProductConfigurationParameter = {
@@ -2886,6 +2886,8 @@ export type IQuery = {
   quotations: Array<IQuotation>;
   /** Returns total number of quotations */
   quotationsCount: Scalars['Int']['output'];
+  /** Get all registered event types */
+  registeredEventTypes: Array<Scalars['String']['output']>;
   /** Search assortments */
   searchAssortments: IAssortmentSearchResult;
   /** Search products */
@@ -3803,7 +3805,7 @@ export type IUpdateProductCommercePricingInput = {
   currencyCode: Scalars['String']['input'];
   isNetPrice?: InputMaybe<Scalars['Boolean']['input']>;
   isTaxable?: InputMaybe<Scalars['Boolean']['input']>;
-  maxQuantity?: InputMaybe<Scalars['Int']['input']>;
+  minQuantity?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type IUpdateProductInput = {
@@ -3977,7 +3979,7 @@ export enum IWarehousingProviderType {
 
 export type IWeb3Address = {
   address: Scalars['String']['output'];
-  nonce?: Maybe<Scalars['Int']['output']>;
+  nonce?: Maybe<Scalars['String']['output']>;
   verified: Scalars['Boolean']['output'];
 };
 
@@ -4253,7 +4255,7 @@ export type IUserFragment = {
   emails?: Array<{ verified: boolean; address: string }> | null;
   web3Addresses: Array<{
     address: string;
-    nonce?: number | null;
+    nonce?: string | null;
     verified: boolean;
   }>;
   webAuthnCredentials: Array<{
@@ -4368,7 +4370,7 @@ export type IAddEmailMutation = {
     emails?: Array<{ verified: boolean; address: string }> | null;
     web3Addresses: Array<{
       address: string;
-      nonce?: number | null;
+      nonce?: string | null;
       verified: boolean;
     }>;
     webAuthnCredentials: Array<{
@@ -4477,7 +4479,7 @@ export type IAddWeb3AddressMutation = {
     emails?: Array<{ verified: boolean; address: string }> | null;
     web3Addresses: Array<{
       address: string;
-      nonce?: number | null;
+      nonce?: string | null;
       verified: boolean;
     }>;
     webAuthnCredentials: Array<{
@@ -4607,7 +4609,7 @@ export type IAddWebAuthnCredentialsMutation = {
     emails?: Array<{ verified: boolean; address: string }> | null;
     web3Addresses: Array<{
       address: string;
-      nonce?: number | null;
+      nonce?: string | null;
       verified: boolean;
     }>;
     profile?: {
@@ -4730,7 +4732,7 @@ export type ICurrentUserQuery = {
     emails?: Array<{ verified: boolean; address: string }> | null;
     web3Addresses: Array<{
       address: string;
-      nonce?: number | null;
+      nonce?: string | null;
       verified: boolean;
     }>;
     webAuthnCredentials: Array<{
@@ -4847,7 +4849,7 @@ export type IEnrollUserMutation = {
     emails?: Array<{ verified: boolean; address: string }> | null;
     web3Addresses: Array<{
       address: string;
-      nonce?: number | null;
+      nonce?: string | null;
       verified: boolean;
     }>;
     webAuthnCredentials: Array<{
@@ -4991,7 +4993,7 @@ export type IRemoveEmailMutation = {
     emails?: Array<{ verified: boolean; address: string }> | null;
     web3Addresses: Array<{
       address: string;
-      nonce?: number | null;
+      nonce?: string | null;
       verified: boolean;
     }>;
     webAuthnCredentials: Array<{
@@ -5100,7 +5102,7 @@ export type IRemoveWeb3AddressMutation = {
     emails?: Array<{ verified: boolean; address: string }> | null;
     web3Addresses: Array<{
       address: string;
-      nonce?: number | null;
+      nonce?: string | null;
       verified: boolean;
     }>;
     webAuthnCredentials: Array<{
@@ -5209,7 +5211,7 @@ export type IRemoveWebAuthCredentialsMutation = {
     emails?: Array<{ verified: boolean; address: string }> | null;
     web3Addresses: Array<{
       address: string;
-      nonce?: number | null;
+      nonce?: string | null;
       verified: boolean;
     }>;
     webAuthnCredentials: Array<{
@@ -5336,7 +5338,7 @@ export type ISetPasswordMutation = {
     emails?: Array<{ verified: boolean; address: string }> | null;
     web3Addresses: Array<{
       address: string;
-      nonce?: number | null;
+      nonce?: string | null;
       verified: boolean;
     }>;
     webAuthnCredentials: Array<{
@@ -5446,7 +5448,7 @@ export type ISetRolesMutation = {
     emails?: Array<{ verified: boolean; address: string }> | null;
     web3Addresses: Array<{
       address: string;
-      nonce?: number | null;
+      nonce?: string | null;
       verified: boolean;
     }>;
     webAuthnCredentials: Array<{
@@ -5565,7 +5567,7 @@ export type ISetUsernameMutation = {
     emails?: Array<{ verified: boolean; address: string }> | null;
     web3Addresses: Array<{
       address: string;
-      nonce?: number | null;
+      nonce?: string | null;
       verified: boolean;
     }>;
     webAuthnCredentials: Array<{
@@ -5684,7 +5686,7 @@ export type IUpdateUserProfileMutation = {
     emails?: Array<{ verified: boolean; address: string }> | null;
     web3Addresses: Array<{
       address: string;
-      nonce?: number | null;
+      nonce?: string | null;
       verified: boolean;
     }>;
     webAuthnCredentials: Array<{
@@ -5793,7 +5795,7 @@ export type IUserQuery = {
     emails?: Array<{ verified: boolean; address: string }> | null;
     web3Addresses: Array<{
       address: string;
-      nonce?: number | null;
+      nonce?: string | null;
       verified: boolean;
     }>;
     webAuthnCredentials: Array<{
@@ -5940,7 +5942,7 @@ export type IUsersQuery = {
     emails?: Array<{ verified: boolean; address: string }> | null;
     web3Addresses: Array<{
       address: string;
-      nonce?: number | null;
+      nonce?: string | null;
       verified: boolean;
     }>;
     webAuthnCredentials: Array<{
@@ -6077,7 +6079,7 @@ export type IVerifyEmailMutation = {
       emails?: Array<{ verified: boolean; address: string }> | null;
       web3Addresses: Array<{
         address: string;
-        nonce?: number | null;
+        nonce?: string | null;
         verified: boolean;
       }>;
       webAuthnCredentials: Array<{
@@ -6188,7 +6190,7 @@ export type IVerifyWeb3AddressMutation = {
     emails?: Array<{ verified: boolean; address: string }> | null;
     web3Addresses: Array<{
       address: string;
-      nonce?: number | null;
+      nonce?: string | null;
       verified: boolean;
     }>;
     webAuthnCredentials: Array<{
@@ -7623,6 +7625,16 @@ export type IShopInfoQuery = {
   };
 };
 
+export type IStatusTypesQueryVariables = Exact<{
+  enumName: Scalars['String']['input'];
+}>;
+
+export type IStatusTypesQuery = {
+  statusTypes?: {
+    options?: Array<{ value: string; label?: string | null }> | null;
+  } | null;
+};
+
 export type ISystemRolesQueryVariables = Exact<{ [key: string]: never }>;
 
 export type ISystemRolesQuery = {
@@ -7982,16 +7994,6 @@ export type IDeliveryProvidersQuery = {
   >;
 };
 
-export type IOrderDeliveryStatusQueryVariables = Exact<{
-  [key: string]: never;
-}>;
-
-export type IOrderDeliveryStatusQuery = {
-  deliveryStatusType?: {
-    options?: Array<{ value: string; label?: string | null }> | null;
-  } | null;
-};
-
 export type IRemoveDeliveryProviderMutationVariables = Exact<{
   deliveryProviderId: Scalars['ID']['input'];
 }>;
@@ -8316,14 +8318,6 @@ export type IEnrollmentQuery = {
   } | null;
 };
 
-export type IEnrollmentStatusQueryVariables = Exact<{ [key: string]: never }>;
-
-export type IEnrollmentStatusQuery = {
-  enrollmentStatusTypes?: {
-    options?: Array<{ value: string; label?: string | null }> | null;
-  } | null;
-};
-
 export type IEnrollmentsQueryVariables = Exact<{
   offset?: InputMaybe<Scalars['Int']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -8447,12 +8441,12 @@ export type IEventQuery = {
   } | null;
 };
 
-export type IEventsTypeQueryVariables = Exact<{ [key: string]: never }>;
+export type IRegisteredEventTypesQueryVariables = Exact<{
+  [key: string]: never;
+}>;
 
-export type IEventsTypeQuery = {
-  eventTypes?: {
-    options?: Array<{ value: string; label: string }> | null;
-  } | null;
+export type IRegisteredEventTypesQuery = {
+  registeredEventTypes: Array<string>;
 };
 
 export type IEventsQueryVariables = Exact<{
@@ -10036,14 +10030,6 @@ export type IOrderQuery = {
   } | null;
 };
 
-export type IOrderStatusQueryVariables = Exact<{ [key: string]: never }>;
-
-export type IOrderStatusQuery = {
-  orderStatusType?: {
-    options?: Array<{ value: string; label?: string | null }> | null;
-  } | null;
-};
-
 export type IOrdersQueryVariables = Exact<{
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
@@ -10261,14 +10247,6 @@ export type IPaymentProvidersQuery = {
       version?: string | null;
     } | null;
   }>;
-};
-
-export type IOrderPaymentStatusQueryVariables = Exact<{ [key: string]: never }>;
-
-export type IOrderPaymentStatusQuery = {
-  paymentStatusTypes?: {
-    options?: Array<{ value: string; label?: string | null }> | null;
-  } | null;
 };
 
 export type IRemovePaymentProviderMutationVariables = Exact<{
@@ -11303,7 +11281,7 @@ export type IProductCatalogPriceFragment = {
   isTaxable: boolean;
   isNetPrice: boolean;
   amount: number;
-  maxQuantity?: number | null;
+  minQuantity?: number | null;
   country: {
     _id: string;
     isoCode?: string | null;
@@ -12824,7 +12802,7 @@ export type IProductCatalogPricesQuery = {
     isTaxable: boolean;
     isNetPrice: boolean;
     amount: number;
-    maxQuantity?: number | null;
+    minQuantity?: number | null;
     country: {
       _id: string;
       isoCode?: string | null;
@@ -14847,7 +14825,7 @@ export type IUserTokensQuery = {
     _id: string;
     web3Addresses: Array<{
       address: string;
-      nonce?: number | null;
+      nonce?: string | null;
       verified: boolean;
     }>;
     tokens: Array<{
@@ -15305,14 +15283,6 @@ export type IQuotationQuery = {
             file?: { _id: string; type: string; url?: string | null } | null;
           }>;
         };
-  } | null;
-};
-
-export type IQuotationStatusQueryVariables = Exact<{ [key: string]: never }>;
-
-export type IQuotationStatusQuery = {
-  quotationStatusType?: {
-    options?: Array<{ value: string; label?: string | null }> | null;
   } | null;
 };
 
@@ -16076,14 +16046,6 @@ export type IAllocateWorkMutationVariables = Exact<{
 }>;
 
 export type IAllocateWorkMutation = { allocateWork?: { _id: string } | null };
-
-export type IWorkTypesQueryVariables = Exact<{ [key: string]: never }>;
-
-export type IWorkTypesQuery = {
-  registeredWorkTypes?: {
-    options?: Array<{ value: string; label: string }> | null;
-  } | null;
-};
 
 export type IRemoveWorkMutationVariables = Exact<{
   workId: Scalars['ID']['input'];

--- a/admin-ui/src/modules/forms/lib/validators.ts
+++ b/admin-ui/src/modules/forms/lib/validators.ts
@@ -122,9 +122,9 @@ export const validateProductCommerce = (currentIndex, values): Validator => {
       const others = values.filter((_, index) => index !== currentIndex);
 
       const isSame = others.every(
-        ({ maxQuantity, countryCode, currencyCode }) => {
+        ({ minQuantity, countryCode, currencyCode }) => {
           return (
-            maxQuantity !== current?.maxQuantity ||
+            minQuantity !== current?.minQuantity ||
             countryCode !== current?.countryCode ||
             currencyCode !== current?.currencyCode
           );
@@ -144,17 +144,16 @@ export const validateProductCommerce = (currentIndex, values): Validator => {
 const isEmpty = (value) =>
   value === null || value === '' || value === undefined;
 
-export const validateProductCommerceOneNull = (values): Validator => {
+export const validateProductCommerceOneZero = (values): Validator => {
   return {
     isValid: () => {
-      if (
-        values?.length &&
-        values?.length === 1 &&
-        !isEmpty(values[0].maxQuantity)
-      )
+      if (!values?.length) return true;
+      const isZeroOrEmpty = (v) => isEmpty(v) || Number(v) === 0;
+      if (values.length === 1 && !isZeroOrEmpty(values[0].minQuantity))
         return false;
       if (
-        values.filter(({ maxQuantity }) => isEmpty(maxQuantity))?.length !== 1
+        values.filter(({ minQuantity }) => isZeroOrEmpty(minQuantity))
+          ?.length !== 1
       )
         return false;
       return true;
@@ -163,7 +162,7 @@ export const validateProductCommerceOneNull = (values): Validator => {
     intlMessageDescriptor: {
       id: 'error_commerce_quantity_null_required',
       defaultMessage:
-        '{label} should have one price with null /empty max quantity',
+        '{label} should have one price with min quantity of 0 or empty',
     },
   };
 };
@@ -237,6 +236,6 @@ const useInitializeDefaultErrorMessages = () => {
   formatMessage({
     id: 'error_commerce_quantity_null_required',
     defaultMessage:
-      '{label} should have one price with null /empty max quantity',
+      '{label} should have one price with min quantity of 0 or empty',
   });
 };

--- a/admin-ui/src/modules/product/components/CommerceForm.tsx
+++ b/admin-ui/src/modules/product/components/CommerceForm.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { IRoleAction } from '../../../gql/types';
 
 import { FieldArray } from 'formik';
@@ -19,12 +18,11 @@ import Button from '@/components/ui/Button';
 import useForm, { OnSubmitType } from '../../forms/hooks/useForm';
 import {
   validateProductCommerce,
-  validateProductCommerceOneNull,
+  validateProductCommerceOneZero,
 } from '../../forms/lib/validators';
 import useProductCatalogPrices from '../hooks/useProductCatalogPrices';
 import useUpdateProductCommerce from '../hooks/useUpdateProductCommerce';
 import { fromMinorUnit } from '../utils/price.utils';
-import { has } from 'cypress/types/lodash';
 
 const normalizeCatalogPrices = (prices = [], currencies = []) => {
   if (!currencies.length) return [];
@@ -39,7 +37,7 @@ const normalizeCatalogPrices = (prices = [], currencies = []) => {
       isTaxable: !!price.isTaxable,
       isNetPrice: !!price.isNetPrice,
       amount: fromMinorUnit(price.amount, currency?.decimals),
-      maxQuantity: price.maxQuantity,
+      minQuantity: price.minQuantity,
     };
   });
 };
@@ -80,7 +78,7 @@ const CommerceForm = ({ productId, disabled = false }) => {
           ? normalizedCatalogPrices
           : [
               {
-                maxQuantity: '',
+                minQuantity: '',
                 amount: null,
                 isTaxable: false,
                 isNetPrice: false,
@@ -110,8 +108,8 @@ const CommerceForm = ({ productId, disabled = false }) => {
                 <span className="flex w-full">
                   <span className="w-full">
                     {formatMessage({
-                      id: 'max_quantity',
-                      defaultMessage: 'Max Quantity',
+                      id: 'min_quantity',
+                      defaultMessage: 'Min Quantity',
                     })}
                   </span>
                   <span className="w-full lg:ml-5">
@@ -166,16 +164,16 @@ const CommerceForm = ({ productId, disabled = false }) => {
                               disabled={!hasRole(IRoleAction.ManageProducts)}
                               validators={[
                                 validateProductCommerce(index, pricing),
-                                validateProductCommerceOneNull(pricing),
+                                validateProductCommerceOneZero(pricing),
                               ]}
-                              name={`pricing[${index}].maxQuantity`}
-                              id={`pricing[${index}].maxQuantity`}
+                              name={`pricing[${index}].minQuantity`}
+                              id={`pricing[${index}].minQuantity`}
                               type="number"
                               min={0}
                               hideLabel
                               label={formatMessage({
-                                id: 'max_quantity',
-                                defaultMessage: 'Max Quantity',
+                                id: 'min_quantity',
+                                defaultMessage: 'Min Quantity',
                               })}
                             />
                             <TextField
@@ -306,7 +304,7 @@ const CommerceForm = ({ productId, disabled = false }) => {
                           className="w-full items-center justify-center"
                           onClick={() =>
                             push({
-                              maxQuantity: '',
+                              minQuantity: '',
                               amount: null,
                               isTaxable: false,
                               isNetPrice: false,
@@ -340,7 +338,7 @@ const CommerceForm = ({ productId, disabled = false }) => {
           {formatMessage({
             id: 'product_commerce_info',
             defaultMessage:
-              'One price list should have a max quantity field empty and no price should have the same max quantity along with currency and country specified',
+              'One price should have a min quantity of 0 (or empty) and no two prices should share the same min quantity, currency and country',
           })}
         </p>
       </div>

--- a/admin-ui/src/modules/product/fragments/ProductCatalogPriceFragment.ts
+++ b/admin-ui/src/modules/product/fragments/ProductCatalogPriceFragment.ts
@@ -16,7 +16,7 @@ const ProductCatalogPriceFragment = gql`
       isActive
     }
     amount
-    maxQuantity
+    minQuantity
   }
 `;
 

--- a/admin-ui/src/modules/product/hooks/usePrepareProductImport.ts
+++ b/admin-ui/src/modules/product/hooks/usePrepareProductImport.ts
@@ -301,12 +301,12 @@ const usePrepareProductImport = () => {
       let variations = undefined;
       if (prices.length)
         price = prices.map(
-          ({ amount, maxQuantity, isNetPrice, isTaxable, ...restPrice }) => ({
+          ({ amount, minQuantity, isNetPrice, isTaxable, ...restPrice }) => ({
             ...restPrice,
             amount: parseInt(amount) ?? 0,
             isNetPrice: isNetPrice === 'true',
             isTaxable: isTaxable === 'true',
-            maxQuantity: parseInt(maxQuantity, 2) || 0,
+            minQuantity: parseInt(minQuantity, 10) || 0,
           }),
         );
 

--- a/admin-ui/src/modules/product/hooks/useProductExport.ts
+++ b/admin-ui/src/modules/product/hooks/useProductExport.ts
@@ -29,7 +29,7 @@ export const PRODUCT_CSV_SCHEMA = {
     'countryCode',
     'isTaxable',
     'isNetPrice',
-    'maxQuantity',
+    'minQuantity',
   ],
   bundleItemHeaders: [
     'productId',

--- a/admin-ui/src/modules/product/types.ts
+++ b/admin-ui/src/modules/product/types.ts
@@ -20,7 +20,7 @@ export type ProductVariationCSVRow = {
 export type ProductPriceCSVRow = {
   productId: string;
   amount: string;
-  maxQuantity: string;
+  minQuantity: string;
   isTaxable?: string;
   isNetPrice?: string;
   currencyCode: string;

--- a/docs/docs/concepts/director-adapter-pattern.md
+++ b/docs/docs/concepts/director-adapter-pattern.md
@@ -1,19 +1,17 @@
 ---
 sidebar_position: 3
-title: Director/Adapter Pattern
-sidebar_label: Director/Adapter Pattern
+title: Plugin System
+sidebar_label: Plugin System
 description: Understanding Unchained Engine's plugin architecture
 ---
 
-# Director/Adapter Pattern
+# Plugin System (Directors & Adapters)
 
-The Director/Adapter pattern is the foundation of Unchained Engine's extensibility. Understanding this pattern is essential for customizing payment processing, delivery, pricing, and other behaviors.
+The Director/Adapter pattern is the foundation of Unchained Engine's extensibility. Understanding it is essential for customizing payment processing, delivery, pricing, and other behaviors.
 
 ## Overview
 
-**Directors** are singleton factories that manage collections of adapters. They provide methods to register, unregister, and retrieve adapters.
-
-**Adapters** implement specific behaviors and are registered with directors. When functionality is needed, the director selects and invokes the appropriate adapter(s).
+**Adapters** implement a specific behavior (a payment gateway, a pricing rule, a delivery method…). **Directors** are the internal machinery that holds the adapters for a domain and selects/invokes the right one(s) at runtime. In v5 you rarely touch a director directly — adapters self-route to their director via an `adapterType` symbol when you register the plugin.
 
 ```mermaid
 flowchart LR
@@ -24,606 +22,118 @@ flowchart LR
     end
 ```
 
+## How to register a plugin
+
+There are three ways, recommended-first:
+
+| Layer | When to use | API |
+|---|---|---|
+| **Presets** | The built-in plugins | `registerBasePlugins()` / `registerAllPlugins()` — see [Plugin Presets](../platform-configuration/plugin-presets.md) |
+| **`registerX(...)` factories** | Your own custom adapters (**recommended**) | `registerPaymentProvider({ … })` etc. — see [Plugin Factories](../extend/plugin-factories.md) |
+| **Hand-built `IPlugin`** | Custom key/version, HTTP routes, a module, lifecycle hooks | `pluginRegistry.register(MyPlugin)` |
+
+All three are imported from `@unchainedshop/core`. Register **before** calling `startPlatform()`.
+
+```ts
+import { registerPaymentProvider, pluginRegistry } from '@unchainedshop/core';
+
+// Recommended: a factory builds and registers the plugin for you
+registerPaymentProvider({ adapterId: 'acme', charge: async (c, ctx) => ({ transactionId: '…' }) });
+
+// Low-level: hand-built IPlugin (custom key/version, routes, lifecycle hooks)
+pluginRegistry.register({ key: 'com.acme.payment', label: 'Acme', version: '1.0.0', adapters: [AcmeAdapter] });
+```
+
+:::info `IPlugin` shape
+A plugin bundles one or more adapters with optional infrastructure:
+
+```ts
+interface IPlugin {
+  key: string;
+  label: string;
+  version: string;
+  adapters?: IBaseAdapter[];                  // self-route to their director
+  module?: PluginModuleFactory;               // DB-backed module
+  routes?: PluginHttpRoute[];                 // WHATWG Fetch handlers (e.g. webhooks)
+  onRegister?: (api) => void | boolean | Promise<…>; // return false / throw to skip
+  onShutdown?: (api) => void | Promise<void>;
+}
+```
+:::
+
 ## Available Directors
 
-| Director | Purpose | Example Adapters |
-|----------|---------|------------------|
-| `PaymentDirector` | Payment processing | Stripe, PayPal, Invoice |
-| `DeliveryDirector` | Shipping/delivery | Post, Store Pickup, Digital |
-| `WarehousingDirector` | Inventory management | Stock, NFT Minting |
-| `WorkerDirector` | Background jobs | Email, SMS, HTTP Webhooks |
-| `FilterDirector` | Product search | Full-text, Strict Equal |
-| `ProductPricingDirector` | Product prices | Base price, Tax, Discount |
-| `OrderPricingDirector` | Order totals | Items, Delivery, Payment |
-| `DeliveryPricingDirector` | Delivery fees | Flat rate, Weight-based |
-| `PaymentPricingDirector` | Payment fees | Card fees, Invoice fees |
-| `OrderDiscountDirector` | Order discounts | Coupon codes, Auto-discounts |
-| `ProductDiscountDirector` | Product discounts | Bulk pricing, Member pricing |
-| `MessagingDirector` | Notifications | Email templates, SMS |
-| `QuotationDirector` | RFQ processing | Manual quotes, Auto quotes |
-| `EnrollmentDirector` | Subscriptions | Recurring billing |
-
-## Base Classes
-
-All adapters extend from base classes provided by `@unchainedshop/utils`:
-
-```typescript
-import { BaseAdapter, BaseDirector } from '@unchainedshop/utils';
-```
-
-- **BaseDirector**: Factory function creating a director with adapter management
-- **BaseAdapter**: Base implementation with logging and utility methods
-
-## Creating a Custom Adapter
-
-All adapters share a common structure:
-
-```typescript
-const MyAdapter = {
-  key: 'my-adapter',           // Unique identifier
-  label: 'My Custom Adapter',  // Human-readable label
-  version: '1.0.0',            // Adapter version
-
-  // Optional: order of execution (lower = first)
-  orderIndex: 10,
-
-  // Adapter-specific methods...
-};
-
-// Register with the appropriate director
-SomeDirector.registerAdapter(MyAdapter);
-```
-
-## Payment Director
-
-Manages payment processing and orchestrates payment adapters.
-
-```typescript
-import { PaymentDirector, type IPaymentAdapter } from '@unchainedshop/core';
-
-const MyPaymentAdapter: IPaymentAdapter = {
-  key: 'my-payment',
-  label: 'My Payment Gateway',
-  version: '1.0.0',
-
-  // Which payment types this adapter supports
-  typeSupported(type) {
-    return type === 'CARD'; // CARD, INVOICE, or GENERIC
-  },
-
-  actions(config, context) {
-    return {
-      // Return configuration errors (e.g., missing API key)
-      configurationError() {
-        if (!process.env.PAYMENT_API_KEY) {
-          return { code: 'MISSING_API_KEY' };
-        }
-        return null;
-      },
-
-      // Is this adapter active for the current context?
-      isActive() { return true; },
-
-      // Can order be confirmed before payment completes?
-      isPayLaterAllowed() { return false; },
-
-      // Process payment charge
-      async charge() {
-        // Return { transactionId } on success
-        // Return false if payment not yet complete
-        // Throw error to abort checkout
-        return { transactionId: '...' };
-      },
-
-      // Confirm a previously authorized payment
-      async confirm() {
-        return { transactionId: '...' };
-      },
-
-      // Cancel/refund a payment
-      async cancel() {
-        return true;
-      },
-
-      // Register a payment method (e.g., save card)
-      async register() {
-        return { token: '...' };
-      },
-
-      // Sign payment request for client-side SDK
-      async sign() {
-        return '...';
-      },
-
-      // Validate a payment token
-      async validate(token) {
-        return true;
-      },
-    };
-  },
-};
-
-PaymentDirector.registerAdapter(MyPaymentAdapter);
-```
-
-## Delivery Director
-
-Manages delivery operations and coordinates shipping adapters.
-
-```typescript
-import { DeliveryDirector, type IDeliveryAdapter } from '@unchainedshop/core';
-
-const MyDeliveryAdapter: IDeliveryAdapter = {
-  key: 'my-delivery',
-  label: 'My Shipping Provider',
-  version: '1.0.0',
-
-  // Which delivery types this adapter supports
-  typeSupported(type) {
-    return type === 'SHIPPING'; // SHIPPING, PICKUP, or DELIVERY
-  },
-
-  actions(config, context) {
-    return {
-      configurationError() { return null; },
-      isActive() { return true; },
-
-      // Can order be auto-released for delivery?
-      isAutoReleaseAllowed() { return false; },
-
-      // Trigger delivery
-      async send() {
-        return { trackingNumber: '...' };
-      },
-
-      // Estimated delivery time in milliseconds
-      estimatedDeliveryThroughput(warehousingTime) {
-        return 3 * 24 * 60 * 60 * 1000; // 3 days
-      },
-
-      // For PICKUP type: available locations
-      async pickUpLocations() {
-        return [];
-      },
-
-      async pickUpLocationById(locationId) {
-        return null;
-      },
-    };
-  },
-};
-
-DeliveryDirector.registerAdapter(MyDeliveryAdapter);
-```
-
-## Warehousing Director
-
-Manages inventory and stock operations, including NFT/token support.
-
-```typescript
-import { WarehousingDirector, type IWarehousingAdapter } from '@unchainedshop/core';
-
-const MyWarehousingAdapter: IWarehousingAdapter = {
-  key: 'my-warehouse',
-  label: 'My Inventory System',
-  version: '1.0.0',
-
-  typeSupported(type) {
-    return type === 'PHYSICAL';
-  },
-
-  actions(config, context) {
-    return {
-      configurationError() { return null; },
-      isActive() { return true; },
-
-      // Current stock quantity
-      async stock(referenceDate) {
-        return 100;
-      },
-
-      // Production time in ms (for made-to-order)
-      async productionTime(quantity) {
-        return 0;
-      },
-
-      // Time to prepare for shipping in ms
-      async commissioningTime(quantity) {
-        return 24 * 60 * 60 * 1000; // 1 day
-      },
-
-      async estimatedStock() {
-        return 100;
-      },
-
-      async estimatedDispatch() {
-        return new Date();
-      },
-
-      // For tokenized products (NFTs):
-      async tokenize() { return []; },
-      async tokenMetadata(serial, date) { return {}; },
-      async isInvalidateable(serial, date) { return false; },
-    };
-  },
-};
-
-WarehousingDirector.registerAdapter(MyWarehousingAdapter);
-```
-
-## Worker Director
-
-Manages background job processing and scheduled tasks.
-
-```typescript
-import { WorkerDirector, type IWorkerAdapter } from '@unchainedshop/core';
-
-interface MyInput { email: string; subject: string; }
-interface MyOutput { messageId: string; }
-
-const MyWorkerAdapter: IWorkerAdapter<MyInput, MyOutput> = {
-  key: 'my-worker',
-  label: 'My Background Worker',
-  version: '1.0.0',
-  type: 'MY_WORK_TYPE',          // Work type identifier
-  external: false,                // Runs in-process
-  maxParallelAllocations: 10,     // Max concurrent executions
-
-  async doWork(input, unchainedAPI, workId) {
-    const { email, subject } = input;
-
-    // Process the work item
-    // ...
-
-    return {
-      success: true,
-      result: { messageId: 'msg-123' },
-    };
-  },
-};
-
-WorkerDirector.registerAdapter(MyWorkerAdapter);
-```
-
-### Scheduling Recurring Work
-
-```typescript
-WorkerDirector.configureAutoscheduling({
-  type: 'MY_WORK_TYPE',
-  input: { email: 'test@example.com', subject: 'Test' },
-  schedule: '0 * * * *', // Every hour (cron syntax)
-});
-```
-
-## Pricing Directors
-
-Pricing directors calculate prices using a **chain of adapters**. Each adapter can add, modify, or discount prices. Adapters execute in order of their `orderIndex`.
-
-```typescript
-import { ProductPricingDirector, type IProductPricingAdapter } from '@unchainedshop/core';
-
-const MyPricingAdapter: IProductPricingAdapter = {
-  key: 'my-pricing',
-  label: 'My Pricing Logic',
-  version: '1.0.0',
-  orderIndex: 10, // Lower numbers run first
-
-  // Should this adapter run for the current context?
-  isActivatedFor(context) {
-    return true;
-  },
-
-  actions(params, pricingAdapter) {
-    return {
-      calculate() {
-        // Access existing calculations
-        const { calculation } = pricingAdapter;
-
-        // Add price item
-        pricingAdapter.resultSheet().addItem({
-          category: 'BASE',
-          amount: 1000, // in smallest currency unit (cents)
-          isTaxable: true,
-          isNetPrice: true,
-        });
-
-        // Continue chain
-        return pricingAdapter.calculate();
-      },
-    };
-  },
-};
-
-ProductPricingDirector.registerAdapter(MyPricingAdapter);
-```
-
-### Pricing Categories
-
-| Category | Description |
-|----------|-------------|
-| `BASE` | Base product price |
-| `TAX` | Tax amount |
-| `DISCOUNT` | Discount amount (negative) |
-| `DELIVERY` | Delivery fee |
-| `PAYMENT` | Payment fee |
-
-## Discount Directors
-
-Discount directors manage coupon codes and automatic discounts.
-
-```typescript
-import { OrderDiscountDirector, type IDiscountAdapter } from '@unchainedshop/core';
-
-const MyDiscountAdapter: IDiscountAdapter = {
-  key: 'my-discount',
-  label: 'My Discount System',
-  version: '1.0.0',
-  orderIndex: 10,
-
-  // Allow manual code entry starting with 'PROMO'
-  isManualAdditionAllowed(code) {
-    return code.startsWith('PROMO');
-  },
-
-  isManualRemovalAllowed() {
-    return true;
-  },
-
-  actions(context) {
-    return {
-      // Auto-apply discount without code?
-      isValidForSystemTriggering() {
-        return false;
-      },
-
-      // Apply when specific code entered?
-      isValidForCodeTriggering(code) {
-        return code === 'PROMO10';
-      },
-
-      // Return discount configuration
-      discountForPricingAdapterKey(params) {
-        return {
-          isNetPrice: false,
-          rate: 0.1, // 10% off
-        };
-      },
-
-      // Reserve discount (e.g., decrement coupon balance)
-      async reserve(code) {},
-
-      // Release reservation on order cancellation
-      async release() {},
-    };
-  },
-};
-
-OrderDiscountDirector.registerAdapter(MyDiscountAdapter);
-```
-
-## Filter Director
-
-Manages product filtering and search functionality.
-
-```typescript
-import { FilterDirector, type IFilterAdapter } from '@unchainedshop/core';
-
-const MyFilterAdapter: IFilterAdapter = {
-  key: 'my-filter',
-  label: 'My Search Filter',
-  version: '1.0.0',
-  orderIndex: 10,
-
-  actions(context) {
-    return {
-      // Return product IDs matching filter
-      async aggregateProductIds(params) {
-        return ['product-1', 'product-2'];
-      },
-
-      // Search products
-      async searchProducts(params, options) {
-        return { productIds: [], totalCount: 0 };
-      },
-
-      // Search assortments
-      async searchAssortments(params, options) {
-        return { assortmentIds: [], totalCount: 0 };
-      },
-
-      // Modify MongoDB product selector
-      transformProductSelector(selector, options) {
-        return selector;
-      },
-
-      // Modify MongoDB filter selector
-      transformFilterSelector(selector, options) {
-        return selector;
-      },
-
-      // Modify MongoDB sort stage
-      transformSortStage(sort, options) {
-        return sort;
-      },
-    };
-  },
-};
-
-FilterDirector.registerAdapter(MyFilterAdapter);
-```
-
-## Messaging Director
-
-The Messaging Director uses a template resolver pattern for notifications.
-
-```typescript
-import { MessagingDirector } from '@unchainedshop/core';
-
-// Register a message template
-MessagingDirector.registerTemplate('ORDER_CONFIRMATION', async (context) => {
-  const { order, user } = context;
-
-  return [
-    {
-      type: 'EMAIL',
-      input: {
-        to: user.email,
-        subject: `Order Confirmation #${order.orderNumber}`,
-        html: '<h1>Thank you for your order!</h1>',
-      },
-    },
-    {
-      type: 'SMS',
-      input: {
-        to: user.phone,
-        text: `Order #${order.orderNumber} confirmed!`,
-      },
-    },
-  ];
-});
-```
-
-## Quotation Director
-
-Handles quotation/RFQ (Request for Quote) operations.
-
-```typescript
-import { QuotationDirector, type IQuotationAdapter } from '@unchainedshop/core';
-
-const MyQuotationAdapter: IQuotationAdapter = {
-  key: 'my-quotation',
-  label: 'My Quote System',
-  version: '1.0.0',
-
-  isActivatedFor(quotationContext, unchainedAPI) {
-    return true;
-  },
-
-  actions(context) {
-    return {
-      configurationError() { return null; },
-
-      // Require manual quote creation?
-      isManualProposalRequired() { return true; },
-
-      // Require manual request verification?
-      isManualRequestVerificationRequired() { return false; },
-
-      // Generate quote
-      async quote() {
-        return { price: 1000, currency: 'CHF' };
-      },
-
-      async submitRequest(quotationContext) {},
-      async verifyRequest(quotationContext) {},
-      async rejectRequest(quotationContext) {},
-
-      transformItemConfiguration(params) {
-        return params.configuration;
-      },
-    };
-  },
-};
-
-QuotationDirector.registerAdapter(MyQuotationAdapter);
-```
-
-## Enrollment Director
-
-Manages subscription/enrollment plans and recurring billing.
-
-```typescript
-import { EnrollmentDirector, type IEnrollmentAdapter } from '@unchainedshop/core';
-
-const MyEnrollmentAdapter: IEnrollmentAdapter = {
-  key: 'my-enrollment',
-  label: 'My Subscription System',
-  version: '1.0.0',
-
-  isActivatedFor(productPlan) {
-    return productPlan.type === 'PLAN_PRODUCT';
-  },
-
-  transformOrderItemToEnrollmentPlan(orderPosition, unchainedAPI) {
-    return {
-      configuration: orderPosition.configuration,
-    };
-  },
-
-  actions(context) {
-    return {
-      // Calculate next billing period
-      async nextPeriod() {
-        return {
-          start: new Date(),
-          end: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
-        };
-      },
-
-      isValidForActivation() {
-        return true;
-      },
-
-      isOverdue() {
-        return false;
-      },
-
-      // Order configuration for billing period
-      async configurationForOrder(period) {
-        return {};
-      },
-    };
-  },
-};
-
-EnrollmentDirector.registerAdapter(MyEnrollmentAdapter);
-```
+You don't register *with* these — they're the internal dispatch targets. Listed for reference (and for cross-module work):
+
+| Director | Purpose | Authoring factory |
+|----------|---------|-------------------|
+| `PaymentDirector` | Payment processing | [`registerPaymentProvider`](../extend/plugin-factories.md#payment) |
+| `DeliveryDirector` | Shipping/delivery | [`registerDeliveryProvider`](../extend/plugin-factories.md#delivery) |
+| `WarehousingDirector` | Inventory / tokenization | [`registerPhysicalWarehousing`](../extend/plugin-factories.md#warehousing) |
+| `WorkerDirector` | Background jobs | [`registerWorker`](../extend/plugin-factories.md#workers) |
+| `FilterDirector` | Product/assortment search | [`registerProductSearchFilter`](../extend/plugin-factories.md#filters--search) |
+| `ProductPricingDirector` | Product prices | [`registerProductPricing`](../extend/plugin-factories.md#pricing) |
+| `OrderPricingDirector` | Order totals | [`registerOrderPricing`](../extend/plugin-factories.md#pricing) |
+| `DeliveryPricingDirector` | Delivery fees | [`registerDeliveryPricing`](../extend/plugin-factories.md#pricing) |
+| `PaymentPricingDirector` | Payment fees | [`registerPaymentPricing`](../extend/plugin-factories.md#pricing) |
+| `OrderDiscountDirector` | Order discounts | [`registerOrderDiscount`](../extend/plugin-factories.md#discounts) |
+| `ProductDiscountDirector` | Product discounts | [`registerProductDiscount`](../extend/plugin-factories.md#discounts) |
+| `QuotationDirector` | RFQ processing | [`registerQuotation`](../extend/plugin-factories.md#quotations) |
+| `EnrollmentDirector` | Subscriptions | [`registerEnrollment`](../extend/plugin-factories.md#enrollments) |
+| `FileDirector` | File storage | [`registerFileAdapter`](../extend/plugin-factories.md#files) |
+
+## Adapter contracts
+
+An adapter is a plain object: identity fields (`key`, `label`, `version`) plus the behavior the director expects. Payment/delivery/warehousing expose their behavior through an `actions(config, context)` factory; pricing/discount adapters expose a `calculate`; file adapters expose storage methods directly. The matching [`registerX` factory](../extend/plugin-factories.md) lets you supply just the behavior without writing the wrapper.
+
+| Domain | Adapter interface | Key behavior to implement | Deep dive |
+|---|---|---|---|
+| Payment | `IPaymentAdapter` | `typeSupported`, `actions().{charge, isActive, isPayLaterAllowed, sign, validate, cancel, confirm}` | [Payment](../extend/order-fulfilment/fulfilment-plugins/payment.md) |
+| Delivery | `IDeliveryAdapter` | `typeSupported`, `actions().{send, isActive, isAutoReleaseAllowed, estimatedDeliveryThroughput}` | [Delivery](../extend/order-fulfilment/fulfilment-plugins/delivery.md) |
+| Warehousing | `IWarehousingAdapter` | `actions().{stock, productionTime, commissioningTime}` (physical) / `{tokenize, tokenMetadata}` (virtual) | [Warehousing](../extend/order-fulfilment/fulfilment-plugins/warehousing.md) |
+| Pricing | `I*PricingAdapter` | `isActivatedFor`, `actions().calculate` (push rows onto the sheet) | [Pricing](./pricing-system.md) |
+| Discount | `IDiscountAdapter` | `isValidForSystemTriggering`/`isValidForCodeTriggering`, `discountForPricingAdapterKey` | [Order discounts](../extend/pricing/order-discounts.md) |
+| Filter | `IFilterAdapter` | `actions().{searchProducts, searchAssortments, transformProductSelector, …}` | [Filters](../extend/catalog/filter.md) |
+| Worker | `IWorkerAdapter` | `type`, `doWork(input, api, workId)` | [Work Queue](../extend/worker.md) |
+| File | `IFileAdapter` | `createSignedURL`, `uploadFileFromStream`, `createDownloadURL`, `removeFiles` | [Files](../plugins/files/index.md) |
+| Quotation | `IQuotationAdapter` | `actions().{quote, transformItemConfiguration, submitRequest, …}` | [Quotation](../extend/quotation.md) |
+| Enrollment | `IEnrollmentAdapter` | `isActivatedFor`, `transformOrderItemToEnrollmentPlan`, `actions().{configurationForOrder, nextPeriod}` | [Enrollment](../extend/enrollment.md) |
+
+Each deep-dive page shows the full method signatures and a worked example — leading with the [`registerX` factory](../extend/plugin-factories.md) and falling back to the hand-built form.
 
 ## Best Practices
 
-### 1. Unique Keys
-Always use unique, namespaced keys for your adapters:
-```typescript
-key: 'com.mycompany.payment.stripe-custom'
-```
+### 1. Use stable, namespaced keys
+Factories namespace keys for you (`shop.unchained.<domain>.<adapterId>`). For hand-built plugins, use a reverse-DNS key like `com.mycompany.payment.gateway`. A stable key makes registration idempotent (the registry dedupes by key).
 
-### 2. Error Handling
-Return `configurationError()` for missing configuration rather than throwing:
+### 2. Report configuration errors, don't throw
+Return a `configurationError()` for missing configuration rather than throwing — the provider is then surfaced as misconfigured instead of crashing checkout:
+
 ```typescript
 configurationError() {
-  if (!process.env.API_KEY) {
-    return { code: 'MISSING_API_KEY', message: 'API key required' };
-  }
+  if (!process.env.API_KEY) return { code: 'MISSING_API_KEY', message: 'API key required' };
   return null;
 }
 ```
 
-### 3. Async Operations in Workers
-For long-running operations, use the Worker system instead of blocking adapters:
+For plugins, you can also fail fast in `onRegister` (return `false` or throw to skip registration).
+
+### 3. Offload long work to the Worker queue
+For slow external calls, enqueue work instead of blocking the adapter:
+
 ```typescript
-// In delivery adapter
 async send() {
-  // Queue work instead of blocking
-  await context.modules.worker.addWork({
-    type: 'EXTERNAL_SHIPPING_API',
-    input: { orderId: order._id },
-  });
-  return false; // Not complete yet
+  await context.modules.worker.addWork({ type: 'EXTERNAL_SHIPPING_API', input: { orderId: order._id } });
+  return false; // not complete yet
 }
 ```
 
-### 4. Order Index
-Use appropriate `orderIndex` values for pricing adapters:
-- 0-10: Base price calculation
-- 10-20: Discounts
-- 20-30: Tax calculation
-- 30+: Final adjustments
+### 4. Mind the pricing `orderIndex`
+Pricing/discount adapters run in ascending `orderIndex`: base price (0–9) → discounts (10–19) → tax (20–29) → adjustments (30+).
 
 ## Related
 
-- [Payment Plugins](../plugins/payment/stripe) - Payment adapters
-- [Delivery Plugins](../plugins/) - Delivery adapters
-- [Filter Plugins](../plugins/) - Filter adapters
-- [Warehousing Plugins](../plugins/) - Warehousing adapters
-- [Pricing System](../concepts/pricing-system) - Pricing adapters and chain
-- [Worker](../extend/worker.md) - Background job processing
+- [Plugin Factories](../extend/plugin-factories.md) — the recommended `registerX()` authoring layer
+- [Plugin Presets](../platform-configuration/plugin-presets.md) — registering the built-ins
+- [Pricing System](./pricing-system.md) — the pricing chain and leveled tiers
+- [Work Queue](../extend/worker.md) — background job processing

--- a/docs/docs/concepts/pricing-system.md
+++ b/docs/docs/concepts/pricing-system.md
@@ -41,9 +41,9 @@ flowchart LR
 ```
 
 Each adapter:
-1. Receives the current calculation state
-2. Can add items to the calculation
-3. Passes control to the next adapter via `super.calculate()`
+1. Receives the current calculation state (a pricing `sheet`)
+2. Adds items/fees/discounts to the sheet
+3. Hands control to the next adapter in the chain
 
 ### Order Index Guidelines
 
@@ -97,6 +97,67 @@ const payment = pricingSheet.payment();
 // Sum specific items
 const taxableAmount = pricingSheet.sum({ isTaxable: true });
 const baseAmount = pricingSheet.sum({ category: 'BASE' });
+```
+
+## Leveled (Quantity-Tier) Catalog Pricing
+
+A product's catalog price can have several **quantity tiers** per `(countryCode, currencyCode)` — for example a lower unit price when buying 10 or more.
+
+Each tier is keyed by **`minQuantity`**, the *inclusive lower bound* of the quantity range it applies to:
+
+- The **base tier** is `minQuantity: 0` (applies from the first unit).
+- Tiers are sorted ascending by `minQuantity`. The applicable tier for a requested quantity `q` is the **highest tier whose `minQuantity ≤ q`**.
+- The **highest tier is open-ended** — it applies to every quantity at or above its floor (there is no upper cap).
+
+### Example — three tiers (CHF / CH)
+
+| `minQuantity` | `amount` | Applies to |
+|---|---|---|
+| `0` | `1000` | quantity 1–4 → 10.00 each |
+| `5` | `900` | quantity 5–9 → 9.00 each |
+| `10` | `800` | quantity ≥ 10 → 8.00 each |
+
+:::info Upgrading from v4: `maxQuantity` → `minQuantity`
+Before v5, tiers were keyed by `maxQuantity` (an inclusive *upper* bound). v5 uses `minQuantity` (a *lower* bound). An **automatic, idempotent migration runs on startup** and converts existing `commerce.pricing` data per `(countryCode, currencyCode)` — no operator action is required, and re-running is safe. If you write product prices from a storefront, import pipeline, or client codegen, switch those payloads from `maxQuantity` to `minQuantity`.
+:::
+
+### Set tiers (GraphQL)
+
+`UpdateProductCommercePricingInput` takes `minQuantity` (omit it for the base tier):
+
+```graphql
+mutation SetTiers($productId: ID!) {
+  updateProductCommerce(
+    productId: $productId
+    commerce: {
+      pricing: [
+        { amount: 1000, currencyCode: "CHF", countryCode: "CH" }
+        { amount: 900, minQuantity: 5, currencyCode: "CHF", countryCode: "CH" }
+        { amount: 800, minQuantity: 10, currencyCode: "CHF", countryCode: "CH" }
+      ]
+    }
+  ) {
+    _id
+  }
+}
+```
+
+### Read tiers (GraphQL)
+
+`leveledCatalogPrices` returns each tier as a `PriceLevel`. `minQuantity` is the stored floor; `maxQuantity` is **derived for display** (the next tier's floor − 1; `null` on the open-ended top tier):
+
+```graphql
+query Tiers($productId: ID!) {
+  product(productId: $productId) {
+    ... on SimpleProduct {
+      leveledCatalogPrices(currencyCode: "CHF") {
+        minQuantity
+        maxQuantity
+        price { amount currencyCode }
+      }
+    }
+  }
+}
 ```
 
 ## GraphQL Price Fields
@@ -159,18 +220,21 @@ query CartPricing {
 
 ## Best Practices
 
-### 1. Always Call super.calculate()
+### 1. Author with the pricing factories
+
+Use [`registerProductPricing` / `registerOrderPricing` / `registerPaymentPricing` / `registerDeliveryPricing`](../extend/plugin-factories.md#pricing). You push rows onto the `sheet` and the factory continues the chain for you:
 
 ```typescript
-async calculate() {
-  // Your logic here
+import { registerProductPricing } from '@unchainedshop/core';
 
-  // IMPORTANT: Continue the chain
-  return super.calculate();
-}
+registerProductPricing({
+  adapterId: 'my-surcharge',
+  calculate: async (sheet, context) => {
+    sheet.addItem({ amount: 100, isTaxable: true, isNetPrice: true, meta: { adapter: 'my-surcharge' } });
+    // Do NOT continue the chain yourself — the factory does it.
+  },
+});
 ```
-
-Returning without calling `super.calculate()` stops the pricing chain.
 
 ### 2. Handle Currency Properly
 
@@ -189,11 +253,12 @@ const amount = 19.99; // Floating point issues
 Add metadata for debugging and reporting:
 
 ```typescript
-this.result.addItem({
+sheet.addItem({
   amount: 100,
-  category: 'TAX',
+  isTaxable: false,
+  isNetPrice: true,
   meta: {
-    adapter: this.constructor.key,
+    adapter: 'shop.unchained.pricing.product-tax',
     rate: 0.081,
   },
 });

--- a/docs/docs/extend/catalog/filter.md
+++ b/docs/docs/extend/catalog/filter.md
@@ -141,9 +141,9 @@ In order to make use of the filter we need to register it on the FilterDirector.
 
 ```typescript
 
-import { FilterDirector } from '@unchainedshop/core-filters';
+import { pluginRegistry } from '@unchainedshop/core-filters';
 ...
-FilterDirector.registerAdapter(ShopAttributeFilter);
+pluginRegistry.register({ key: ShopAttributeFilter.key, label: ShopAttributeFilter.label, version: ShopAttributeFilter.version, adapters: [ShopAttributeFilter] });
 
 ```
 
@@ -185,6 +185,6 @@ const ShopAttributeFilter: IFilterAdapter = {
 
 }
 
-FilterDirector.registerAdapter(ShopAttributeFilter);
+pluginRegistry.register({ key: ShopAttributeFilter.key, label: ShopAttributeFilter.label, version: ShopAttributeFilter.version, adapters: [ShopAttributeFilter] });
 
 ```

--- a/docs/docs/extend/catalog/filter.md
+++ b/docs/docs/extend/catalog/filter.md
@@ -7,184 +7,125 @@ description: Customize filter and search
 
 # Custom Filter Plugins
 
-Filter plugins are useful when you want to have a tailored filter functionality based on some requirements. you can have more than one FilterAdapter implementations and all of them will be executed sequentially based on there `orderIndex` index. Filter adapter with lower `orderIndex` will be first on the execution order and any modifications made on the previous Filter adapter will be available to filter that are executed after it. This is useful when you want to modularize your business logic.
+Filter adapters let you customize catalog search, filter visibility, MongoDB selectors, and sort behavior. Multiple filters can be active; they run in ascending `orderIndex`, and each filter receives the selector or result set produced by earlier filters.
 
-When creating a filter make sure you don't use the same key for different filters.
+## External Search
 
-To implement a custom filter plugin you need to implement `IFilterAdapter`
-and register it on the `FilterDirector`
-
-
-Below is a simple filter plugin that will filter products based on there attribute values.
+Use the search factories when an external engine such as Algolia, Meilisearch, or Elasticsearch should decide the matching ids. The factory builds the adapter and registers it immediately.
 
 ```typescript
+import { registerProductSearchFilter } from '@unchainedshop/core';
 
-import { IFilterAdapter, FilterAdapterActions, FilterContext } from '@unchainedshop/core-filters';
-import { Context } from '../../../context.ts';
+registerProductSearchFilter({
+  adapterId: 'elasticsearch',
+  orderIndex: 5,
+  search: async ({ queryString, locale }) => {
+    const results = await elasticsearch.search({
+      index: 'products',
+      body: buildProductQuery(queryString, locale),
+    });
 
-const ShopAttributeFilter: IFilterAdapter = {
-  key: 'ch.shop.filter',
-  label: 'Filters products by metadata attributes',
-  version: '1.0.0',
-  orderIndex: 10,
-
-  actions: (params: FilterContext & Context): FilterAdapterActions => {
-    return {
-      aggregateProductIds(params: { productIds: Array<string> }) {
-        return productIds;
-      },
-      searchAssortments(
-        params: {
-          assortmentIds: Array<string>;
-        },
-        options?: {
-          filterSelector: Filter;
-          assortmentSelector: Filter;
-          sortStage: FindOptions['sort'];
-        },
-      ) {
-        return assortmentIds;
-      },
-      searchProducts(
-        params: {
-          productIds: Array<string>;
-        },
-        options?: {
-          filterSelector: Query;
-          productSelector: Query;
-          sortStage: FindOptions['sort'];
-        },
-      ) {
-        return productIds;
-      },
-      transformProductSelector(
-        query: Query,
-        options?: { key?: string; value?: any },
-      ) {
-        return {...query, inStock: true};
-      },
-      async transformSortStage(
-        sort: FindOptions['sort'],
-        options?: { key: string; value?: any },
-      ) {
-        return {...sort, created: -1 };
-      },
-      async transformFilterSelector(
-        query: Query,
-        options?: any,
-      ): Promise<Query> {
-        if (!last || Object.keys(last).length === 0) {
-          return null;
-        }
-        return last;
-      },
-
-      async transformProductSelector(
-        query: Query,
-        options?: { key?: string; value?: any },
-      ): Promise<Query> {
-        if (!key) return last;
-        return {
-          status: 'ACTIVE',
-          'shop.attributes': {
-            $elemMatch: {
-              key,
-              value: value !== undefined ? value : { $exists: true },
-            },
-          },
-        };
-      },
-    };
+    return results.hits.hits.map((hit) => hit._id);
   },
-};
-
-
+});
 ```
 
-### Breakdown
-Lets look into each `field` & `function` defined by `IFilterAdapter` and what the function of each.
-- `key`: Unique identification of adapter, identical to ID.
-- `label`: Human readable label of the filter.
-- `version`
-- `orderIndex`: defines the execution order of a particular filter adapter. filter adapters lower value will be executed first
-
-- `transformProductSelector`: modifies selectors that are going to be used to filter products list. it gets filters that are added by filter adapters with lowe `orderIndex` as it's argument and is expected to return valid mongodb selector expression.
-In the above example we are adding `status: 'ACTIVE'` selector if there is any filter configuration key provided on the filter, also expect the attribute value to match the configuration key: value.
-Note: filters with higher `orderIndex` will get this value as there argument
-  default value: `{ status: { '$in': [ 'ACTIVE', null ] } }`
-- `transformFilterSelector`: This transform fn allows you to customize the selector that returns the filters that should show up for a given search query. By default it uses the assortment's filter links to return those filters. Sometimes there is no assortment scope (global search for products) or you want to make a specific filter appear just everywhere. In those cases this can be helpful by returning additional filters through the selector.
-- `transformSortStage`: Used to modify sort options that will to be applied for filter. default sort option value is `{ index: 1 }` which is for mongodb automatically assigned index value, but it can be changed to use any field in a collection.
-in the example above we are adding a sort `{ created: -1 }` to the previous sort option and filter adapters with higher `orderIndex` will get this value as there parameter.
-
-  default value:  `{ _id: { '$in': [] }, isActive: true }`
-
-- `searchAssortments`: Triggered when searching for assortments, It is required to return array of assortment Ids that pass the filter checks or empty array if none is found. it gets `assortmentIds` that have been matched so far by filters with lower `orderIndex`.
-- `searchProducts`: Triggered when searching for products, It is required to return array of product Ids that pass the filter checks or empty array if none is found. it gets `productIds` that have been matched so far by filters with lower `orderIndex`.
-- `aggregateProductIds`: Executed when searching products, it holds array of the final matching productIds found so far. It is required to return array of product ids.
-
-
-
-### Order of execution
-
-1. `transformFilterSelector`
-2. `transformProductSelector` if current operation is search product, else, skip to step 3
-3. `transformSortStage`
-4. `searchProducts` or `searchAssortments` depending on the operation. i.e when searching for products or searching for assortments.
-5. `aggregateProductIds` if current operation is search product
-
-
-
-### Final Step
-
-In order to make use of the filter we need to register it on the FilterDirector.
-
+For assortment search, use `registerAssortmentSearchFilter` with the same callback shape:
 
 ```typescript
+import { registerAssortmentSearchFilter } from '@unchainedshop/core';
 
-import { pluginRegistry } from '@unchainedshop/core-filters';
-...
-pluginRegistry.register({ key: ShopAttributeFilter.key, label: ShopAttributeFilter.label, version: ShopAttributeFilter.version, adapters: [ShopAttributeFilter] });
+registerAssortmentSearchFilter({
+  adapterId: 'elasticsearch',
+  search: async ({ queryString, locale }) => {
+    const results = await elasticsearch.search({
+      index: 'assortments',
+      body: buildAssortmentQuery(queryString, locale),
+    });
 
+    return results.hits.hits.map((hit) => hit._id);
+  },
+});
 ```
 
+`adapterId` is optional for filter factories. If you pass one, the plugin key is stable and duplicate registrations dedupe. If you omit it, Unchained generates a unique key so several instances of the same filter type can run side by side.
 
-### Shorthand
+## Hide Products From Search
 
-Incase you only want to change implementation of only few functions and keep the other default implementation, you can do so by importing `FilterAdapter` from `@unchainedshop/core-filters` and override the that specific functions implementation. 
-
-Below is a simplified implementation of the `ShopAttributeFilter` above, this time it will use the default implantation and override `transformProductSelector` function only.
+Use `registerProductDiscoverabilityFilter` to hide products with a tag from regular search results:
 
 ```typescript
-import { IFilterAdapter, FilterAdapterActions, FilterContext } from '@unchainedshop/core-filters';
-import { Context } from '../../../context.ts';
+import { registerProductDiscoverabilityFilter } from '@unchainedshop/core';
+
+registerProductDiscoverabilityFilter({
+  adapterId: 'hide-internal-products',
+  hiddenTagValue: 'internal',
+});
+```
+
+Register several discoverability filters when different tag conventions should all hide products.
+
+## Custom Selector Logic
+
+Use a hand-written adapter only when you need behavior the factories do not expose, such as changing MongoDB selectors or sort stages. Spread `FilterAdapter`, override the specific methods, then register the resulting plugin.
+
+```typescript
+import { FilterAdapter, pluginRegistry, type IFilterAdapter } from '@unchainedshop/core';
 
 const ShopAttributeFilter: IFilterAdapter = {
   ...FilterAdapter,
-  key: 'ch.shop.filter',
-  label: 'Filters products by metadata attributes',
+
+  key: 'ch.shop.filter.attributes',
+  label: 'Shop attribute filter',
   version: '1.0.0',
   orderIndex: 10,
 
-  actions: (params: FilterContext & Context): FilterAdapterActions => {
-    return {
-      ...FilterAdapter.actions(params),
-      async transformProductSelector(query, options) {
-        if (!key) return last;
-        return {
-          status: 'ACTIVE',
-          'shop.attributes': {
-            $elemMatch: {
-              key,
-              value: value !== undefined ? value : { $exists: true },
-            },
+  actions: (params) => ({
+    ...FilterAdapter.actions(params),
+
+    async transformProductSelector(selector, options) {
+      const { key, value } = options || {};
+      if (!key) return selector;
+
+      return {
+        ...selector,
+        status: 'ACTIVE',
+        'shop.attributes': {
+          $elemMatch: {
+            key,
+            value: value !== undefined ? value : { $exists: true },
           },
-        };
-      },
-    }
-  }
+        },
+      };
+    },
 
-}
+    async transformSortStage(sort) {
+      return { ...sort, created: -1 };
+    },
+  }),
+};
 
-pluginRegistry.register({ key: ShopAttributeFilter.key, label: ShopAttributeFilter.label, version: ShopAttributeFilter.version, adapters: [ShopAttributeFilter] });
-
+pluginRegistry.register({
+  key: ShopAttributeFilter.key,
+  label: ShopAttributeFilter.label,
+  version: ShopAttributeFilter.version,
+  adapters: [ShopAttributeFilter],
+});
 ```
+
+## Callback Reference
+
+| Method | Purpose |
+|---|---|
+| `transformFilterSelector(selector, options)` | changes which filter definitions are available for the current search |
+| `transformProductSelector(selector, options)` | changes the MongoDB product selector |
+| `transformSortStage(sort, options)` | changes the MongoDB sort stage |
+| `searchProducts({ productIds }, options)` | narrows or replaces matching product ids |
+| `searchAssortments({ assortmentIds }, options)` | narrows or replaces matching assortment ids |
+| `aggregateProductIds(params)` | post-processes the final product id set |
+
+## Related
+
+- [Plugin Factories](../plugin-factories.md#filters--search) - search and discoverability factories
+- [Plugin System](../../concepts/director-adapter-pattern.md) - low-level plugin registration
+- [Search and Filtering Guide](../../guides/search-and-filtering.md) - search UX and query examples

--- a/docs/docs/extend/enrollment.md
+++ b/docs/docs/extend/enrollment.md
@@ -7,287 +7,72 @@ description: Customizing subscription and enrollment handling
 
 # Enrollment Adapters
 
-Enrollment adapters handle subscription-based products and recurring billing. They control how subscriptions are created, when orders are generated, and whether access should be granted.
+Enrollment adapters handle subscription products (`PLAN_PRODUCT`) and recurring billing — how subscriptions are created, when orders are generated, and whether access should be granted. Multiple adapters can be registered; the first whose `isActivatedFor` returns `true` for the product's plan is used.
 
-## EnrollmentAdapter
+## Creating an adapter
 
-For every subscription product (PLAN_PRODUCT), an enrollment adapter processes the subscription lifecycle. To handle subscriptions, create an enrollment adapter that implements the `IEnrollmentAdapter` interface and register it with the EnrollmentDirector.
-
-Multiple enrollment adapters can be registered. The first adapter where `isActivatedFor` returns `true` for the product's plan configuration will be used.
-
-## Adapter Interface
+Use the [`registerEnrollment`](./plugin-factories.md#enrollments) factory. `configurationForOrder` is required; the rest are optional. The callbacks receive an enrollment `context` containing `enrollment` and `product`.
 
 ```typescript
-import {
-  EnrollmentDirector,
-  EnrollmentAdapter,
-  type IEnrollmentAdapter
-} from '@unchainedshop/core';
+import { registerEnrollment } from '@unchainedshop/core';
 
-const CustomEnrollmentAdapter: IEnrollmentAdapter = {
-  ...EnrollmentAdapter,
+registerEnrollment({
+  adapterId: 'custom',
+  isActivatedFor: (productPlan) => productPlan?.usageCalculationType === 'METERED',
 
-  key: 'my-shop.enrollments.custom',
-  version: '1.0.0',
-  label: 'Custom Subscription Handler',
+  transformOrderItem: async (orderPosition, unchainedAPI) => ({
+    configuration: orderPosition.configuration,
+    productId: orderPosition.productId,
+    quantity: orderPosition.quantity,
+  }),
 
-  isActivatedFor: (productPlan) => {
-    // Activate for specific usage calculation types
-    return productPlan?.usageCalculationType === 'METERED';
+  isValidForActivation: async (context) => {
+    const now = Date.now();
+    return (context.enrollment?.periods ?? []).some(
+      (p) => new Date(p.start).getTime() <= now && new Date(p.end).getTime() >= now,
+    );
   },
 
-  transformOrderItemToEnrollmentPlan: async (orderPosition, unchainedAPI) => {
-    // Transform order item into enrollment configuration
+  nextPeriod: async (context) => {
+    const last = context.enrollment?.periods?.at(-1);
+    const start = last ? new Date(last.end) : new Date();
+    return { start, end: addDays(start, 30), isTrial: false };
+  },
+
+  configurationForOrder: async ({ period }, context) => {
+    const { enrollment } = context;
+    if (!enrollment) throw new Error('Enrollment missing');
+    if (period.start.getTime() > Date.now()) return null;
     return {
-      configuration: orderPosition.configuration,
-      productId: orderPosition.productId,
-      quantity: orderPosition.quantity,
+      orderPositionTemplates: [
+        {
+          quantity: enrollment.quantity ?? 1,
+          productId: enrollment.productId,
+          originalProductId: enrollment.productId,
+          configuration: enrollment.configuration,
+        },
+      ],
     };
   },
-
-  actions: (params) => {
-    const { enrollment, product } = params;
-
-    return {
-      ...EnrollmentAdapter.actions(params),
-
-      isValidForActivation: async () => {
-        // Check if the subscription should grant access
-        const periods = enrollment?.periods || [];
-        const now = Date.now();
-
-        return periods.some(period => {
-          const start = new Date(period.start).getTime();
-          const end = new Date(period.end).getTime();
-          return start <= now && end >= now;
-        });
-      },
-
-      isOverdue: async () => {
-        // Check if payment is overdue
-        return false;
-      },
-
-      nextPeriod: async () => {
-        // Calculate the next billing period
-        // Returns null if no more periods should be created
-        const plan = product?.plan;
-        if (!plan) return null;
-
-        const lastPeriod = enrollment?.periods?.[enrollment.periods.length - 1];
-        const startDate = lastPeriod
-          ? new Date(lastPeriod.end)
-          : new Date();
-
-        return {
-          start: startDate,
-          end: addDays(startDate, 30), // 30-day period
-          isTrial: false,
-        };
-      },
-
-      configurationForOrder: async ({ period }) => {
-        // Generate order configuration for a billing period
-        // Return null to skip order generation
-
-        if (!enrollment) throw new Error('Enrollment missing');
-
-        const beginningOfPeriod = period.start.getTime() <= Date.now();
-        if (!beginningOfPeriod) return null;
-
-        return {
-          period,
-          orderContext: {
-            // Additional context passed to the order
-          },
-          orderPositionTemplates: [{
-            quantity: enrollment.quantity || 1,
-            productId: enrollment.productId,
-            originalProductId: enrollment.productId,
-            configuration: enrollment.configuration,
-          }],
-        };
-      },
-    };
-  },
-};
+});
 ```
 
-## Method Reference
+## Callback reference
 
-### Static Methods
+| Option | Description |
+|---|---|
+| `isActivatedFor(productPlan)` | does this adapter handle the given plan? (check `usageCalculationType`) |
+| `transformOrderItem(orderPosition, api)` | turn the purchased item into enrollment data when the subscription is created |
+| `configurationForOrder({ period }, context)` | **required** — generate the order for a billing period; return `null` to skip |
+| `nextPeriod(context)` | the next billing window; `null` ends the subscription |
+| `isValidForActivation(context)` | should the subscription currently grant access? |
+| `isOverdue(context)` | is payment overdue? (drives dunning/suspension) |
 
-- **isActivatedFor(productPlan)**: Determines if this adapter handles a specific product plan. Check `usageCalculationType` or other plan properties.
+Plans expose a `usageCalculationType` of `LICENSED` (period-based access) or `METERED` (usage-based billing).
 
-- **transformOrderItemToEnrollmentPlan(orderPosition, unchainedAPI)**: Transforms an order item into enrollment data when a subscription is first created from a purchase.
-
-### Action Methods
-
-- **isValidForActivation()**: Returns `true` if the subscription should currently grant access. Typically checks if the current date falls within an active period.
-
-- **isOverdue()**: Returns `true` if payment is overdue. Used to trigger dunning workflows or suspend access.
-
-- **nextPeriod()**: Calculates the next billing period. Returns `null` to indicate no more periods should be created (subscription ended).
-
-- **configurationForOrder(\{ period \})**: Generates the order configuration for a billing period. Return `null` to skip order generation for this period.
-
-## Usage Calculation Types
-
-Product plans can have different `usageCalculationType` values:
-
-| Type | Description |
-|------|-------------|
-| `LICENSED` | Period-based access (e.g., monthly subscription) |
-| `METERED` | Usage-based billing (e.g., API calls, storage) |
-
-## Example: Metered Subscription
-
-```typescript
-import {
-  EnrollmentDirector,
-  EnrollmentAdapter,
-  type IEnrollmentAdapter
-} from '@unchainedshop/core';
-
-const MeteredEnrollmentAdapter: IEnrollmentAdapter = {
-  ...EnrollmentAdapter,
-
-  key: 'my-shop.enrollments.metered',
-  version: '1.0.0',
-  label: 'Metered Usage Subscription',
-
-  isActivatedFor: (productPlan) => {
-    return productPlan?.usageCalculationType === 'METERED';
-  },
-
-  actions: (params) => {
-    const { enrollment, product } = params;
-
-    return {
-      ...EnrollmentAdapter.actions(params),
-
-      isValidForActivation: async () => {
-        // Always active as long as enrollment exists
-        return enrollment?.status === 'ACTIVE';
-      },
-
-      configurationForOrder: async ({ period }) => {
-        if (!enrollment) throw new Error('Enrollment missing');
-
-        // Calculate usage for the period
-        const usage = await calculateUsageForPeriod(
-          enrollment._id,
-          period.start,
-          period.end
-        );
-
-        if (usage.units === 0) return null; // No usage, no order
-
-        return {
-          period,
-          orderContext: {
-            usageUnits: usage.units,
-            usageDetails: usage.details,
-          },
-          orderPositionTemplates: [{
-            quantity: usage.units,
-            productId: enrollment.productId,
-            originalProductId: enrollment.productId,
-            configuration: [
-              { key: 'usageUnits', value: String(usage.units) },
-              { key: 'periodStart', value: period.start.toISOString() },
-              { key: 'periodEnd', value: period.end.toISOString() },
-            ],
-          }],
-        };
-      },
-    };
-  },
-};
-
-pluginRegistry.register({ key: MeteredEnrollmentAdapter.key, label: MeteredEnrollmentAdapter.label, version: MeteredEnrollmentAdapter.version, adapters: [MeteredEnrollmentAdapter] });
-```
-
-## Example: Trial with Grace Period
-
-```typescript
-import {
-  EnrollmentDirector,
-  EnrollmentAdapter,
-  type IEnrollmentAdapter
-} from '@unchainedshop/core';
-
-const TrialEnrollmentAdapter: IEnrollmentAdapter = {
-  ...EnrollmentAdapter,
-
-  key: 'my-shop.enrollments.trial',
-  version: '1.0.0',
-  label: 'Trial Subscription with Grace Period',
-
-  isActivatedFor: (productPlan) => {
-    return productPlan?.usageCalculationType === 'LICENSED' &&
-           productPlan?.trialIntervalCount > 0;
-  },
-
-  actions: (params) => {
-    const { enrollment, product, modules } = params;
-    const GRACE_PERIOD_DAYS = 7;
-
-    return {
-      ...EnrollmentAdapter.actions(params),
-
-      isValidForActivation: async () => {
-        const periods = enrollment?.periods || [];
-        const now = Date.now();
-
-        // Check if within any period (including grace period for non-trial)
-        return periods.some(period => {
-          const start = new Date(period.start).getTime();
-          let end = new Date(period.end).getTime();
-
-          // Add grace period for paid periods
-          if (!period.isTrial) {
-            end += GRACE_PERIOD_DAYS * 24 * 60 * 60 * 1000;
-          }
-
-          return start <= now && end >= now;
-        });
-      },
-
-      isOverdue: async () => {
-        const periods = enrollment?.periods || [];
-        const currentPeriod = periods.find(p => !p.isTrial && p.orderId);
-
-        if (!currentPeriod?.orderId) return false;
-
-        const order = await modules.orders.findOrder({
-          orderId: currentPeriod.orderId,
-        });
-
-        if (order?.status !== 'PENDING') return false;
-
-        const dueDate = new Date(currentPeriod.start);
-        dueDate.setDate(dueDate.getDate() + GRACE_PERIOD_DAYS);
-
-        return Date.now() > dueDate.getTime();
-      },
-    };
-  },
-};
-
-pluginRegistry.register({ key: TrialEnrollmentAdapter.key, label: TrialEnrollmentAdapter.label, version: TrialEnrollmentAdapter.version, adapters: [TrialEnrollmentAdapter] });
-```
-
-## Registering an Enrollment Adapter
-
-```typescript
-import { pluginRegistry } from '@unchainedshop/core';
-
-pluginRegistry.register({ key: CustomEnrollmentAdapter.key, label: CustomEnrollmentAdapter.label, version: CustomEnrollmentAdapter.version, adapters: [CustomEnrollmentAdapter] });
-```
+> For full control of every `IEnrollmentAdapter` method, build the adapter directly (spread `EnrollmentAdapter`) and register it via `pluginRegistry.register()` — see [Plugin System](../concepts/director-adapter-pattern.md#adapter-contracts).
 
 ## Related
 
-- [Enrollment Plugins](../plugins/enrollments/) - Built-in enrollment adapters
-- [Licensed Enrollments Plugin](../plugins/enrollments/enrollment-licensed.md) - Default implementation
-- [Enrollment Order Generator Worker](../plugins/workers/worker-enrollment-order-generator.md) - Automatic order generation
+- [Plugin Factories](./plugin-factories.md#enrollments) — `registerEnrollment`
+- [Licensed Enrollments Plugin](../plugins/enrollments/enrollment-licensed.md) — the default implementation

--- a/docs/docs/extend/enrollment.md
+++ b/docs/docs/extend/enrollment.md
@@ -205,7 +205,7 @@ const MeteredEnrollmentAdapter: IEnrollmentAdapter = {
   },
 };
 
-EnrollmentDirector.registerAdapter(MeteredEnrollmentAdapter);
+pluginRegistry.register({ key: MeteredEnrollmentAdapter.key, label: MeteredEnrollmentAdapter.label, version: MeteredEnrollmentAdapter.version, adapters: [MeteredEnrollmentAdapter] });
 ```
 
 ## Example: Trial with Grace Period
@@ -275,15 +275,15 @@ const TrialEnrollmentAdapter: IEnrollmentAdapter = {
   },
 };
 
-EnrollmentDirector.registerAdapter(TrialEnrollmentAdapter);
+pluginRegistry.register({ key: TrialEnrollmentAdapter.key, label: TrialEnrollmentAdapter.label, version: TrialEnrollmentAdapter.version, adapters: [TrialEnrollmentAdapter] });
 ```
 
 ## Registering an Enrollment Adapter
 
 ```typescript
-import { EnrollmentDirector } from '@unchainedshop/core';
+import { pluginRegistry } from '@unchainedshop/core';
 
-EnrollmentDirector.registerAdapter(CustomEnrollmentAdapter);
+pluginRegistry.register({ key: CustomEnrollmentAdapter.key, label: CustomEnrollmentAdapter.label, version: CustomEnrollmentAdapter.version, adapters: [CustomEnrollmentAdapter] });
 ```
 
 ## Related

--- a/docs/docs/extend/events.md
+++ b/docs/docs/extend/events.md
@@ -154,12 +154,29 @@ const RedisEventEmitter = (): EmitAdapter => {
         subscribedEvents.add(eventName);
       }
     },
+    // Optional: close long-lived connections on platform shutdown
+    shutdown: async () => {
+      await Promise.allSettled([redisPublisher.close(), redisSubscriber.close()]);
+    },
   };
 };
 
 // Set the adapter before starting the platform
 setEmitAdapter(RedisEventEmitter());
 ```
+
+:::note Built-in transports must be registered explicitly
+Unchained ships Redis and AWS EventBridge transports, but they **do not auto-register on import**. Register them yourself before `startPlatform`:
+
+```typescript
+import { setEmitAdapter } from '@unchainedshop/events';
+import { RedisEventEmitter } from '@unchainedshop/plugins/events/redis';
+
+setEmitAdapter(RedisEventEmitter());
+```
+
+The Node.js in-memory emitter is wired automatically by `registerBasePlugins()`. The optional `EmitAdapter.shutdown()` is called by `startPlatform` on graceful shutdown.
+:::
 
 ## Use Cases
 

--- a/docs/docs/extend/order-fulfilment/fulfilment-plugins/delivery.md
+++ b/docs/docs/extend/order-fulfilment/fulfilment-plugins/delivery.md
@@ -7,95 +7,72 @@ description: Customize delivery
 
 # Delivery Provider Plugins
 
-In order to register available delivery options, you either have to use the builtin ones or have to add a plugin to the supported delivery provider by implementing the `IDeliveryAdapter` interface and registering the adapter on the global `DeliveryDirector`
+Register custom delivery options by using a delivery factory. There can be multiple delivery adapters; they run in ascending `orderIndex`.
 
-There can be multiple delivery adapter implementation for a shop and all of them will be executed based on their `orderIndex` value. Delivery adapters with lowe `orderIndex` are executed first.
+The factories are:
 
-Below we have sample delivery adapter 
+| Factory | For |
+|---|---|
+| [`registerShippingDelivery`](../../plugin-factories.md#delivery) | a `SHIPPING` provider |
+| [`registerPickUpDelivery`](../../plugin-factories.md#delivery) | a `PICKUP` provider (with `locations`) |
+| [`registerDeliveryProvider`](../../plugin-factories.md#delivery) | a generic provider — pick the `type` |
+
+## Example: pickup provider
 
 ```typescript
-import {
-  DeliveryDirector,
-  DeliveryProviderType,
-} from "@unchainedshop/core-delivery";
+import { registerPickUpDelivery } from '@unchainedshop/core';
 
-
-const ShopPickUp: IDeliveryAdapter = {
-  key: 'ch.shop.delivery.pickup',
-  label: 'Pickup at Clerk',
-  version: '1.0.0',
-  orderIndex: 1
-  initialConfiguration: (DeliveryConfiguration = []),
-
-  typeSupported: (type: DeliveryProviderType): boolean => {
-    return type === DeliveryProviderType.PICKUP;
+registerPickUpDelivery({
+  adapterId: 'shop-pickup',
+  locations: [
+    {
+      _id: 'first-location-id',
+      name: 'first-location',
+      address: { addressLine: 'address-line', postalCode: '1234', countryCode: 'CH', city: 'Zurich' },
+      geoPoint: { latitude: 47.3769, longitude: 8.5417 },
+    },
+  ],
+  // Trigger fulfilment; return a Work item to defer to the work queue
+  send: async (configuration, context) => {
+    await enqueueDeliveryWork({
+      type: 'MARK_ORDER_DELIVERED',
+      scheduled: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      input: { orderDeliveryId: context.orderDelivery?._id },
+    });
+    return false; // not delivered yet
   },
-
-  actions: (config: DeliveryConfiguration, context: DeliveryAdapterContext, unchainedAPI: UnchainedCore): DeliveryAdapterActions => {
-    return {
-      isAutoReleaseAllowed(): boolean {
-        return false;
-      },
-
-      isActive(): boolean {
-        return true;
-      },
-
-      configurationError(transactionContext?: any) {
-        return null;
-      },
-
-      pickUpLocationById(locationId: string): Promise<DeliveryLocation> {
-        return this.pickUpLocations().filter(({ _id }) => _id === locationId);
-      },
-
-      estimatedDeliveryThroughput: (warehousingThroughputTime: number) : Promise<number>  => {
-        return 0;
-      },
-
-      pickUpLocations(): Promise<Array<DeliveryLocation>> {
-        return [
-          {
-            _id: 'first-location-id',
-            name: 'first-location',
-            address: {
-              addressLine: 'address-line',
-              postalCode: '1234',
-              countryCode: 'CH',
-              city: 'Zurich',
-            },
-            geoPoint: {
-              latitude: 123456789,
-              longitude: 987654321,
-            },
-          },
-        ];
-      },
-      send: async (): Promise<boolean | Work> => {
-        const { modules, order } = context as typeof context;
-        await modules.worker.addWork(
-          {
-            type: 'MARK_ORDER_DELIVERED',
-            retries: 0,
-            scheduled: new Date(new Date().getTime() + 1000 * (24 * 60 * 60)),
-            input: {
-              orderDeliveryId: order.deliveryId,
-            },
-          },
-        );
-
-        return false;
-      },
-    };
-  },
-};
+});
 ```
 
-- **typeSupported(type: DeliveryProviderType)**: Defines which type of delivery providers this adapter support.
-- **configurationError(transactionContext: any): DeliveryError**: returns any issue found with the delivery adapter configuration.  its passed current transaction object that lets you check if everything is working for proper functioning of the adapter.
-- **estimatedDeliveryThroughput(warehousingThroughputTime: number)**: Used to send an estimation delivery time of the adapter.
-- **isActive**: Used to enable or disable the adapter.
-- **isAutoReleaseAllowed**: Determined if the delivery provider should change status automatically or if manual confirmation of delivery is required.
-- **pickUpLocationById(locationId: string): DeliveryLocation**: returns a delivery location with the specified ID from the list of locations returned from `pickUpLocations`.
-- **pickUpLocations: DeliveryLocation[]** returns list of delivery locations available with a particular delivery adapter
-- **send: any**: Determines the if an order is delivered or not. if this function returns a trueish value the order delivery status will be changed to **DELIVERED**, if it returns false order delivery status stays the same (PENDING) but the order status can be changed but if it throws an error the order will be canceled.
+## Example: shipping provider
+
+```typescript
+import { registerShippingDelivery } from '@unchainedshop/core';
+
+registerShippingDelivery({
+  adapterId: 'acme-courier',
+  estimatedDeliveryThroughput: async (warehousingThroughputTime) =>
+    warehousingThroughputTime + 2 * 24 * 60 * 60 * 1000,
+  send: async (configuration, context) => {
+    await acme.createShipment(context.order);
+    return true; // dispatched
+  },
+});
+```
+
+## Callback reference
+
+| Option | Behavior |
+|---|---|
+| `send` | `true` → delivery status becomes **DELIVERED**; `false` → stays **PENDING** (order can still progress); throwing → the order is cancelled. Return a `Work` item to defer to the work queue. |
+| `active` | enable/disable the adapter (default `true`) |
+| `autoReleaseAllowed` | auto-advance status vs require manual delivery confirmation |
+| `estimatedDeliveryThroughput` | estimated delivery time in ms |
+| `locations` *(pickup)* | available pickup points |
+
+> For full control of every `IDeliveryAdapter` method, build the adapter directly and register it via `pluginRegistry.register()` — see [Plugin System](../../../concepts/director-adapter-pattern.md#adapter-contracts).
+
+## Related
+
+- [Plugin Factories](../../plugin-factories.md#delivery) — the delivery factories
+- [Delivery plugins](../../../plugins/delivery/delivery-post) — shipped delivery adapters

--- a/docs/docs/extend/order-fulfilment/fulfilment-plugins/payment.md
+++ b/docs/docs/extend/order-fulfilment/fulfilment-plugins/payment.md
@@ -2,12 +2,12 @@
 sidebar_position: 8
 sidebar_label: Payment
 title: Write a Payment Provider Plugin
-description: Guide to writing a custom payment provider plugin for Unchained Engine with the PaymentAdapter interface.
+description: Guide to writing a custom payment provider plugin for Unchained Engine.
 ---
 
 # Payment Provider Plugins
 
-Payment adapters handle payment processing for orders. Unchained supports multiple payment types (`CARD`, `INVOICE`, `GENERIC`) and you can implement custom adapters for any payment gateway.
+Payment adapters handle payment processing for orders. Unchained supports `INVOICE` and `GENERIC` providers; card gateways such as Stripe use the generic provider type.
 
 For an overview of how payment fits into the order lifecycle, see [Order Lifecycle](../../../concepts/order-lifecycle).
 
@@ -15,158 +15,85 @@ For an overview of how payment fits into the order lifecycle, see [Order Lifecyc
 
 | Type | Description | Use Cases |
 |------|-------------|-----------|
-| `CARD` | Credit/debit card payments | Stripe, PayPal, Braintree |
 | `INVOICE` | Invoice-based payments | Pre-paid or post-paid invoices |
-| `GENERIC` | Other payment methods | Crypto, bank transfer, cash |
+| `GENERIC` | Gateway-backed and other payment methods | Stripe, Datatrans, crypto, bank transfer, cash |
 
-## Creating a Payment Adapter
+## Creating a payment provider
 
-Implement the `IPaymentAdapter` interface and register it with the `PaymentDirector`.
+The recommended way is the [`registerPaymentProvider`](../../plugin-factories.md#payment) factory (or [`registerInvoicePayment`](../../plugin-factories.md#payment) for invoices). You supply only the behavior callbacks; the factory builds and registers the plugin.
 
-### Example: Pre-Paid Invoice
+### Example: pre-paid invoice
 
-This example shows a pre-paid invoice provider that blocks order confirmation until payment is received:
+A pre-paid invoice blocks order confirmation until payment is received — `charge: false` keeps the order `PENDING`, and `payLaterAllowed: false` requires payment before confirmation.
 
 ```typescript
+import { registerInvoicePayment } from '@unchainedshop/core';
+
+registerInvoicePayment({
+  adapterId: 'prepaid-invoice',
+  payLaterAllowed: false,
+  charge: false, // payment is collected out of band; order stays PENDING
+});
+```
+
+### Example: card payment with Stripe
+
+```typescript
+import Stripe from 'stripe';
 import {
-  PaymentDirector,
-  type IPaymentAdapter,
-  type PaymentChargeActionResult,
+  OrderPricingSheet,
+  PaymentError,
+  registerPaymentProvider,
 } from '@unchainedshop/core';
 
-const PrePaidInvoice: IPaymentAdapter = {
-  key: 'shop.example.payment.prepaid-invoice',
-  label: 'Pre-Paid Invoice',
-  version: '1.0.0',
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
 
-  // Initial configuration (optional)
-  initialConfiguration: [],
+registerPaymentProvider({
+  adapterId: 'stripe-card',
+  type: 'GENERIC',
+  configurationError: process.env.STRIPE_SECRET_KEY
+    ? null
+    : PaymentError.INCOMPLETE_CONFIGURATION,
 
-  // Which payment types this adapter supports
-  typeSupported(type) {
-    return type === 'INVOICE';
+  // Client-side SDK initialization
+  sign: async (configuration, context) => {
+    if (!context.order) return null;
+    const pricing = OrderPricingSheet({
+      calculation: context.order.calculation,
+      currencyCode: context.order.currencyCode,
+    });
+    const intent = await stripe.paymentIntents.create({
+      amount: pricing.total().amount,
+      currency: context.order.currencyCode.toLowerCase(),
+      metadata: { orderId: context.order._id },
+    });
+    return intent.client_secret;
   },
 
-  actions(params) {
-    const { context, paymentContext } = params;
-    const { order } = paymentContext;
-    const { modules } = context;
-
-    return {
-      // Return configuration errors (e.g., missing API keys)
-      configurationError() {
-        return null;
-      },
-
-      // Is this adapter active for the current context?
-      isActive() {
-        return true;
-      },
-
-      // Can the order be confirmed before payment?
-      // false = payment must complete first (pre-paid)
-      // true = order can proceed without payment (post-paid)
-      isPayLaterAllowed() {
-        return false;
-      },
-
-      // Process payment charge
-      async charge(): Promise<PaymentChargeActionResult | false> {
-        // For pre-paid invoice:
-        // - Return false: payment not yet received, stay in PENDING
-        // - Return { transactionId }: payment received, proceed
-        // - Throw error: abort checkout entirely
-        return false;
-      },
-
-      // Register a payment method (e.g., save card for future use)
-      async register() {
-        return { token: '' };
-      },
-
-      // Sign a payment request (e.g., for client-side SDK initialization)
-      async sign() {
-        return '';
-      },
-
-      // Validate a payment token
-      async validate(token) {
-        return true;
-      },
-
-      // Cancel/refund payment
-      async cancel() {
-        return true;
-      },
-
-      // Confirm a previously authorized payment
-      async confirm() {
-        return { transactionId: '' };
-      },
-    };
+  // Confirm the charge (here, validated via webhook)
+  charge: async (configuration, context) => {
+    const intentId = context.orderPayment?.context?.paymentIntentId;
+    if (!intentId) return false;
+    const intent = await stripe.paymentIntents.retrieve(intentId);
+    return intent.status === 'succeeded' ? { transactionId: intent.id } : false;
   },
-};
 
-// Register the adapter
-pluginRegistry.register({ key: PrePaidInvoice.key, label: PrePaidInvoice.label, version: PrePaidInvoice.version, adapters: [PrePaidInvoice] });
+  cancel: async (configuration, context) => {
+    if (context.orderPayment?.transactionId) {
+      await stripe.refunds.create({ payment_intent: context.orderPayment.transactionId });
+    }
+    return true;
+  },
+});
 ```
 
-## Adapter Methods Reference
+## Callback reference
 
-### `typeSupported(type)`
+These are the callbacks you pass to `registerPaymentProvider` (each receives `(configuration, context)`).
 
-Determines which payment types this adapter handles.
+### `charge`
 
-```typescript
-typeSupported(type) {
-  return type === 'CARD';
-}
-```
-
-### `configurationError()`
-
-Return any configuration errors. Called when validating the provider setup.
-
-```typescript
-configurationError() {
-  if (!process.env.PAYMENT_API_KEY) {
-    return { code: 'MISSING_API_KEY', message: 'Payment API key is required' };
-  }
-  return null;
-}
-```
-
-### `isActive()`
-
-Determines if the adapter is active for the current transaction context.
-
-```typescript
-isActive() {
-  // Disable for specific countries
-  const { order } = this.paymentContext;
-  return order.countryCode !== 'BLOCKED_COUNTRY';
-}
-```
-
-### `isPayLaterAllowed()`
-
-Controls whether order confirmation can proceed before payment completes.
-
-| Return Value | Behavior |
-|--------------|----------|
-| `true` | Order can be confirmed without payment (post-paid) |
-| `false` | Payment must complete before order confirmation (pre-paid) |
-
-```typescript
-isPayLaterAllowed() {
-  // Post-paid invoice: allow order to proceed
-  return true;
-}
-```
-
-### `charge()`
-
-Process the payment charge. This is called during checkout.
+Process the payment charge. Called during checkout.
 
 | Return Value | Behavior |
 |--------------|----------|
@@ -174,196 +101,31 @@ Process the payment charge. This is called during checkout.
 | `false` | Payment not complete yet, order stays in PENDING |
 | Throws error | Abort checkout, order stays in OPEN (cart) |
 
-```typescript
-async charge() {
-  try {
-    const result = await paymentGateway.charge({
-      amount: order.pricing().total().amount,
-      currency: order.currency,
-    });
-    return { transactionId: result.id };
-  } catch (error) {
-    // Throw to abort checkout
-    throw new Error('Payment failed: ' + error.message);
-  }
-}
-```
+Pass `false` (not a function) for providers where payment is collected out of band.
 
-### `register()`
+### `isActive` / `isPayLaterAllowed`
 
-Register a payment method for future use (e.g., save a credit card).
+`isActive` (boolean, default `true`) toggles availability. `isPayLaterAllowed` (boolean, default `false`) controls whether order confirmation can proceed before payment completes — `true` = post-paid, `false` = pre-paid.
 
-```typescript
-async register() {
-  const token = await paymentGateway.createCustomer(user);
-  return { token };
-}
-```
+### `sign` / `validate`
 
-### `sign()`
+`sign(configuration, context)` returns a client token (e.g. a Stripe `client_secret`) for the front-end SDK. `validate(configuration, context)` validates a stored credential.
 
-Sign a payment request for client-side SDK initialization.
+### `cancel` / `confirm`
 
-```typescript
-async sign() {
-  // Create a client token for Stripe Elements, PayPal buttons, etc.
-  const clientSecret = await paymentGateway.createPaymentIntent({
-    amount: order.pricing().total().amount,
-  });
-  return clientSecret;
-}
-```
+`cancel` refunds/voids a payment (called on order rejection); `confirm` captures a previously-authorized payment (called on `CONFIRMED`).
 
-### `validate(token)`
+### `configurationError`
 
-Validate a payment token.
+A `PaymentError | null` surfaced when the provider is misconfigured (for example `PaymentError.INCOMPLETE_CONFIGURATION`) so it is marked invalid instead of crashing checkout.
 
-```typescript
-async validate(token) {
-  const isValid = await paymentGateway.validateToken(token);
-  return isValid;
-}
-```
+## Webhooks & low-level adapters
 
-### `cancel()`
-
-Cancel or refund a payment. Called when an order is rejected.
-
-```typescript
-async cancel() {
-  const { orderPayment } = this.paymentContext;
-  if (orderPayment.transactionId) {
-    await paymentGateway.refund(orderPayment.transactionId);
-  }
-  return true;
-}
-```
-
-### `confirm()`
-
-Confirm a previously authorized payment. Called when order transitions to CONFIRMED.
-
-```typescript
-async confirm() {
-  const { orderPayment } = this.paymentContext;
-  const result = await paymentGateway.capturePayment(orderPayment.transactionId);
-  return { transactionId: result.id };
-}
-```
-
-## Webhook Integration
-
-Most payment gateways require webhooks for async payment confirmations. Create an endpoint to handle these:
-
-```typescript
-import express from 'express';
-
-const app = express();
-
-app.post('/webhooks/payment', async (req, res) => {
-  const event = req.body;
-
-  if (event.type === 'payment_intent.succeeded') {
-    const { orderId } = event.data.metadata;
-
-    // Confirm the order
-    await modules.orders.checkout(orderId, {
-      transactionId: event.data.id,
-    });
-  }
-
-  res.json({ received: true });
-});
-```
-
-## Example: Card Payment with Stripe
-
-```typescript
-import Stripe from 'stripe';
-import { pluginRegistry, type IPaymentAdapter } from '@unchainedshop/core';
-
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
-
-const StripePayment: IPaymentAdapter = {
-  key: 'shop.example.payment.stripe',
-  label: 'Stripe Card Payment',
-  version: '1.0.0',
-
-  typeSupported(type) {
-    return type === 'CARD';
-  },
-
-  actions(params) {
-    const { paymentContext } = params;
-    const { order, orderPayment } = paymentContext;
-
-    return {
-      configurationError() {
-        if (!process.env.STRIPE_SECRET_KEY) {
-          return { code: 'STRIPE_KEY_MISSING' };
-        }
-        return null;
-      },
-
-      isActive() {
-        return true;
-      },
-
-      isPayLaterAllowed() {
-        return false;
-      },
-
-      async sign() {
-        const paymentIntent = await stripe.paymentIntents.create({
-          amount: order.pricing().total().amount,
-          currency: order.currency.toLowerCase(),
-          metadata: { orderId: order._id },
-        });
-        return paymentIntent.client_secret;
-      },
-
-      async charge() {
-        // Payment is confirmed via webhook
-        if (orderPayment.context?.paymentIntentId) {
-          const intent = await stripe.paymentIntents.retrieve(
-            orderPayment.context.paymentIntentId
-          );
-          if (intent.status === 'succeeded') {
-            return { transactionId: intent.id };
-          }
-        }
-        return false;
-      },
-
-      async cancel() {
-        if (orderPayment.transactionId) {
-          await stripe.refunds.create({
-            payment_intent: orderPayment.transactionId,
-          });
-        }
-        return true;
-      },
-
-      async confirm() {
-        return { transactionId: orderPayment.transactionId };
-      },
-
-      async register() {
-        return { token: '' };
-      },
-
-      async validate() {
-        return true;
-      },
-    };
-  },
-};
-
-pluginRegistry.register({ key: StripePayment.key, label: StripePayment.label, version: StripePayment.version, adapters: [StripePayment] });
-```
+Most gateways confirm payments asynchronously via a webhook. To attach a webhook route (and for any behavior the factory doesn't expose), build a hand-written `IPlugin` with a `routes` entry and `pluginRegistry.register()` — see the shipped [Stripe plugin](../../../plugins/payment/stripe) and [Plugin System](../../../concepts/director-adapter-pattern.md#adapter-contracts).
 
 ## Related
 
-- [Director/Adapter Pattern](../../../concepts/director-adapter-pattern) - Understanding the plugin architecture
-- [Order Lifecycle](../../../concepts/order-lifecycle) - How payment fits into checkout
-- [Stripe Plugin](../../../plugins/payment/stripe) - Stripe payment adapter
+- [Plugin Factories](../../plugin-factories.md#payment) — `registerPaymentProvider` / `registerInvoicePayment`
+- [Plugin System](../../../concepts/director-adapter-pattern.md) — the plugin architecture
+- [Order Lifecycle](../../../concepts/order-lifecycle) — how payment fits into checkout
+- [Stripe Plugin](../../../plugins/payment/stripe) — a complete shipped adapter

--- a/docs/docs/extend/order-fulfilment/fulfilment-plugins/payment.md
+++ b/docs/docs/extend/order-fulfilment/fulfilment-plugins/payment.md
@@ -108,7 +108,7 @@ const PrePaidInvoice: IPaymentAdapter = {
 };
 
 // Register the adapter
-PaymentDirector.registerAdapter(PrePaidInvoice);
+pluginRegistry.register({ key: PrePaidInvoice.key, label: PrePaidInvoice.label, version: PrePaidInvoice.version, adapters: [PrePaidInvoice] });
 ```
 
 ## Adapter Methods Reference
@@ -280,7 +280,7 @@ app.post('/webhooks/payment', async (req, res) => {
 
 ```typescript
 import Stripe from 'stripe';
-import { PaymentDirector, type IPaymentAdapter } from '@unchainedshop/core';
+import { pluginRegistry, type IPaymentAdapter } from '@unchainedshop/core';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
 
@@ -359,7 +359,7 @@ const StripePayment: IPaymentAdapter = {
   },
 };
 
-PaymentDirector.registerAdapter(StripePayment);
+pluginRegistry.register({ key: StripePayment.key, label: StripePayment.label, version: StripePayment.version, adapters: [StripePayment] });
 ```
 
 ## Related

--- a/docs/docs/extend/order-fulfilment/fulfilment-plugins/warehousing.md
+++ b/docs/docs/extend/order-fulfilment/fulfilment-plugins/warehousing.md
@@ -7,82 +7,58 @@ description: Customize warehousing
 
 # Warehousing Provider Plugins
 
-## WarehousingAdapter
+A warehousing adapter models stock availability and fulfilment timing. A store can have several; they run in ascending `orderIndex`.
 
-You can define a custom Warehousing adapter to simulate the stock availability. In order to define a warehousing adapter you should implement the 
-`IWarehousingAdapter` and register it to the global warehousing director that implements the `IWarehousingDirector` interface. 
+| Factory | For |
+|---|---|
+| [`registerPhysicalWarehousing`](../../plugin-factories.md#warehousing) | physical goods (stock / production / commissioning time) |
+| [`registerVirtualWarehousing`](../../plugin-factories.md#warehousing) | tokenized / NFT products (`tokenize`) |
 
-A store can have multiple Warehousing adapters configured and all of them are executed ordered by there `orderIndex` value. Warehousing adapters with lower `orderIndex` are executed first.
-
-Below is a simple warehousing adapter implementation that will always show a stock is always available for all products.
-
-```typescript
-
-import { WarehousingAdapter, WarehousingProviderType } from '@unchainedshop/core-warehousing';
-import {
-  IWarehousingAdapter,
-  WarehousingError,
-  WarehousingAdapterActions,
-  WarehousingContext,
-  WarehousingProviderType,
-} from '@unchainedshop/core-warehousing';
-import { Context } from '../../../context.ts';
-
-const Store: IWarehousingAdapter = {
-  key: 'shop.unchained.warehousing.store',
-  version: '1.0.0',
-  label: 'Store',
-  orderIndex: 0,
-  initialConfiguration = [{ key: 'name', value: 'Flagship Store' }],
-
-  typeSupported: (type: WarehousingProviderType): boolean => {
-    return type === WarehousingProviderType.PHYSICAL;
-  },
-
-  actions: (
-    config: WarehousingConfiguration,
-    context: WarehousingContext & Context,
-  ): WarehousingAdapterActions => {
-    return {
-      isActive: async (): boolean => {
-        return true;
-      },
-
-      configurationError: async () => {
-        return null;
-      },
-
-      stock: async (referenceDate: Date): Promise<number> => {
-        return 99999;
-      },
-
-      productionTime: async (quantityToProduce: number): Promise<number> => {
-        return 0;
-      },
-
-      commissioningTime: async (quantity: number): Promise<number> => {
-        return 0;
-      },
-    };
-  },
-};
-
-
-```
-
-- **typeSupported(type: WarehousingProviderType)**: Defines the warehousing provider type an adapter is valid for.
-- **isActive**: Defines if the adapter is valid or not based any conditions you set.
-- **configurationError(): WarehousingError**: Any error that occurred during the initialization of an adapter. it can be a missing env or any value missing for a proper functioning of the adapter.
-- **stock(referenceDate: Date)**: It should return the available stock of a product for the provided reference date. in the example above we are simply returning `99999` as stock count.
-- **productionTime(quantityToProduct: number)**: Returns an estimate to produce number of product passed as an argument.
-- **commissioningTime(quantity: number)**: number of days required to product a quantity passed as an argument 
-
-
-
-## Register warehousing adapter
+## Example: physical store stock
 
 ```typescript
-import { pluginRegistry } from '@unchainedshop/core-warehousing';
+import { registerPhysicalWarehousing } from '@unchainedshop/core';
 
-pluginRegistry.register({ key: Store.key, label: Store.label, version: Store.version, adapters: [Store] });
+registerPhysicalWarehousing({
+  adapterId: 'flagship-store',
+  stock: async (referenceDate, configuration, context) => 99999,
+  productionTime: 0,      // ms; made-to-order lead time
+  commissioningTime: 0,   // ms to prepare for shipping
+});
 ```
+
+Each option accepts either a literal value or a `(…args, configuration, context) => Promise<number>` callback.
+
+| Option | Description |
+|---|---|
+| `stock` | available quantity at a reference date |
+| `productionTime` | ms to produce a quantity (made-to-order) |
+| `commissioningTime` | ms to prepare a quantity for shipping |
+| `orderIndex` | execution order (default `0`) |
+
+## Example: tokenized products
+
+```typescript
+import { registerVirtualWarehousing } from '@unchainedshop/core';
+
+registerVirtualWarehousing({
+  adapterId: 'nft-minter',
+  tokenize: async (configuration, context) => {
+    // return the token surrogates to mint for the checked-out position
+    return [{
+      _id: crypto.randomUUID(),
+      quantity: 1,
+      contractAddress: '0x…',
+      tokenSerialNumber: '1',
+      meta: {},
+    }];
+  },
+});
+```
+
+> For full control of every `IWarehousingAdapter` method, build the adapter directly and register it via `pluginRegistry.register()` — see [Plugin System](../../../concepts/director-adapter-pattern.md#adapter-contracts).
+
+## Related
+
+- [Plugin Factories](../../plugin-factories.md#warehousing) — the warehousing factories
+- [Warehousing plugins](../../../plugins/warehousing/warehousing-store) — shipped adapters

--- a/docs/docs/extend/order-fulfilment/fulfilment-plugins/warehousing.md
+++ b/docs/docs/extend/order-fulfilment/fulfilment-plugins/warehousing.md
@@ -82,7 +82,7 @@ const Store: IWarehousingAdapter = {
 ## Register warehousing adapter
 
 ```typescript
-import { WarehousingDirector } from '@unchainedshop/core-warehousing';
+import { pluginRegistry } from '@unchainedshop/core-warehousing';
 
-WarehousingDirector.registerAdapter(Store);
+pluginRegistry.register({ key: Store.key, label: Store.label, version: Store.version, adapters: [Store] });
 ```

--- a/docs/docs/extend/plugin-factories.md
+++ b/docs/docs/extend/plugin-factories.md
@@ -46,7 +46,7 @@ A generic payment provider for any gateway.
 |---|---|---|---|
 | `adapterId` | `string` | ✅ | key `shop.unchained.payment.<adapterId>` |
 | `charge` | `false \| (config, context) => Promise<PaymentChargeActionResult \| false>` | ✅ | `false`/return-`false` = not yet paid; return `{ transactionId }` = paid; throw = abort checkout |
-| `type` | `PaymentProviderType` | | `GENERIC` (default), `CARD`, `INVOICE` |
+| `type` | `PaymentProviderType` | | `GENERIC` (default) or `INVOICE`; card gateways use `GENERIC` |
 | `sign` | `(config, context) => Promise<string \| null>` | | sign a client-side payment intent |
 | `validate` | `(config, context) => Promise<boolean>` | | validate a stored credential |
 | `isActive` | `boolean` | | default `true` |
@@ -61,7 +61,7 @@ registerPaymentProvider({
   adapterId: 'acme-gateway',
   isActive: true,
   charge: async (configuration, context) => {
-    const receipt = await acme.charge(context.order, context.paymentContext);
+    const receipt = await acme.charge(context.order, context.transactionContext);
     return { transactionId: receipt.id };
   },
 });

--- a/docs/docs/extend/plugin-factories.md
+++ b/docs/docs/extend/plugin-factories.md
@@ -1,0 +1,351 @@
+---
+sidebar_position: 3
+sidebar_label: Plugin Factories
+title: Plugin Registration Factories
+description: Author custom adapters with one typed registerX() call
+---
+
+# Plugin Registration Factories
+
+Unchained ships a set of **`registerX(...)` factory functions** — the recommended way to add a custom payment provider, pricing rule, discount, delivery method, worker, filter, file backend, quotation or enrollment adapter. Each factory takes a small typed options object, builds the underlying [`IPlugin`](../concepts/director-adapter-pattern.md) for you, and registers it with the plugin registry in a single call.
+
+All factories are exported from `@unchainedshop/core`:
+
+```ts
+import { registerPaymentProvider, registerProductPricing } from '@unchainedshop/core';
+```
+
+:::tip Three ways to register a plugin
+1. **Presets** — `registerBasePlugins()` / `registerAllPlugins()` for the built-in plugins (see [Plugin Presets](../platform-configuration/plugin-presets.md)).
+2. **`registerX(...)` factories** — *recommended* for your own custom adapters (this page).
+3. **Hand-built `IPlugin` + `pluginRegistry.register()`** — the low-level escape hatch (see [When not to use a factory](#when-not-to-use-a-factory)).
+
+Call factories **before `startPlatform()`**, in your boot code.
+:::
+
+## Two things every factory does for you
+
+- **Keys are auto-namespaced.** You pass an `adapterId` (a short, stable string), and the factory derives the plugin/adapter key as `shop.unchained.<domain>.<adapterId>`. Re-using the same `adapterId` is dedupe-safe (the registry ignores a duplicate key and warns). Pick a stable id; don't generate a random one per boot.
+- **The version is fixed at `1.0.0`.** If you need to control the `key`, `version`, attach HTTP `routes`, a `module`, or `onRegister`/`onShutdown` lifecycle hooks, build an `IPlugin` by hand instead — see [below](#when-not-to-use-a-factory).
+
+:::note Parameter naming varies per factory
+Because each director exposes a different adapter contract, the option names differ between factories (e.g. payment uses `isActive`, delivery uses `active`). The tables below are authoritative per factory.
+:::
+
+Many behavior options accept **either a literal value or a function** — e.g. `charge`, `send`, `stock`. Pass a constant for static behavior, or a `(configuration, context) => Promise<...>` callback for dynamic behavior.
+
+---
+
+## Payment
+
+### `registerPaymentProvider`
+
+A generic payment provider for any gateway.
+
+| Option | Type | Required | Notes |
+|---|---|---|---|
+| `adapterId` | `string` | ✅ | key `shop.unchained.payment.<adapterId>` |
+| `charge` | `false \| (config, context) => Promise<PaymentChargeActionResult \| false>` | ✅ | `false`/return-`false` = not yet paid; return `{ transactionId }` = paid; throw = abort checkout |
+| `type` | `PaymentProviderType` | | `GENERIC` (default), `CARD`, `INVOICE` |
+| `sign` | `(config, context) => Promise<string \| null>` | | sign a client-side payment intent |
+| `validate` | `(config, context) => Promise<boolean>` | | validate a stored credential |
+| `isActive` | `boolean` | | default `true` |
+| `isPayLaterAllowed` | `boolean` | | default `false` |
+| `configurationError` | `PaymentError \| null` | | surface a misconfiguration |
+| `cancel` / `confirm` | `(config, context) => Promise<boolean>` | | refund / capture |
+
+```ts
+import { registerPaymentProvider } from '@unchainedshop/core';
+
+registerPaymentProvider({
+  adapterId: 'acme-gateway',
+  isActive: true,
+  charge: async (configuration, context) => {
+    const receipt = await acme.charge(context.order, context.paymentContext);
+    return { transactionId: receipt.id };
+  },
+});
+```
+
+### `registerInvoicePayment`
+
+A pay-by-invoice provider (`PaymentProviderType.INVOICE`).
+
+| Option | Type | Required | Notes |
+|---|---|---|---|
+| `adapterId` | `string` | ✅ | key `shop.unchained.payment.invoice-<adapterId>` |
+| `charge` | `false \| (config, context) => Promise<…>` | ✅ | usually `false` (collected out of band) |
+| `active` | `boolean` | | default `true` |
+| `payLaterAllowed` | `boolean` | | default `false` |
+
+> See also: [Payment plugins](./order-fulfilment/fulfilment-plugins/payment.md)
+
+---
+
+## Delivery
+
+### `registerDeliveryProvider`
+
+A generic delivery provider; choose the `type`.
+
+| Option | Type | Required | Notes |
+|---|---|---|---|
+| `adapterId` | `string` | ✅ | key `shop.unchained.delivery.<adapterId>` |
+| `send` | `boolean \| (config, context) => Promise<boolean \| Work>` | ✅ | trigger fulfilment; return a `Work` item to defer to the work queue |
+| `type` | `DeliveryProviderType` | | `SHIPPING` (default), `PICKUP` |
+| `active` | `boolean` | | default `true` |
+| `autoReleaseAllowed` | `boolean` | | default `true` |
+| `estimatedDeliveryThroughput` | `(warehousingThroughputTime, context) => Promise<number \| null>` | | ms estimate |
+
+```ts
+import { registerDeliveryProvider } from '@unchainedshop/core';
+
+registerDeliveryProvider({
+  adapterId: 'acme-express',
+  send: async (configuration, context) => {
+    await acme.createShipment(context.order);
+    return true;
+  },
+});
+```
+
+### `registerShippingDelivery` / `registerPickUpDelivery`
+
+Convenience specializations of the above for `SHIPPING` and `PICKUP`. `registerPickUpDelivery` additionally takes:
+
+| Option | Type | Required | Notes |
+|---|---|---|---|
+| `locations` | `DeliveryLocation[] \| (context) => Promise<DeliveryLocation[]>` | ✅ | available pickup points |
+
+> See also: [Delivery plugins](./order-fulfilment/fulfilment-plugins/delivery.md)
+
+---
+
+## Warehousing
+
+### `registerPhysicalWarehousing`
+
+Stock and timing for physical goods.
+
+| Option | Type | Required | Notes |
+|---|---|---|---|
+| `adapterId` | `string` | ✅ | key `shop.unchained.warehousing.physical.<adapterId>` |
+| `stock` | `number \| (referenceDate, config, context) => Promise<number>` | | available quantity |
+| `productionTime` | `number \| (qty, config, context) => Promise<number>` | | ms (made-to-order) |
+| `commissioningTime` | `number \| (qty, config, context) => Promise<number>` | | ms to prepare |
+| `orderIndex` | `number` | | default `0` |
+
+### `registerVirtualWarehousing`
+
+Tokenized / NFT products. `tokenize` is required.
+
+| Option | Type | Required | Notes |
+|---|---|---|---|
+| `adapterId` | `string` | ✅ | key `shop.unchained.warehousing.virtual.<adapterId>` |
+| `tokenize` | `(config, context) => Promise<TokenSurrogate[]>` | ✅ | mint tokens for a checked-out position |
+| `stock` | `number \| fn` | | |
+| `tokenMetadata` | `(serial, date, config, context) => Promise<Metadata>` | | ERC metadata |
+| `isInvalidateable` | `(serial, date, config, context) => Promise<boolean>` | | |
+| `orderIndex` | `number` | | default `0` |
+
+> See also: [Warehousing plugins](./order-fulfilment/fulfilment-plugins/warehousing.md)
+
+---
+
+## Pricing
+
+The four pricing factories share the **same signature**: `{ adapterId, orderIndex?, isActivatedFor?, calculate }`.
+
+| Option | Type | Required | Notes |
+|---|---|---|---|
+| `adapterId` | `string` | ✅ | key `shop.unchained.pricing.<domain>-<adapterId>` |
+| `calculate` | `(sheet, context) => Promise<void>` | ✅ | push rows onto `sheet`; the factory continues the chain for you |
+| `isActivatedFor` | `(context) => boolean` | | default `true` |
+| `orderIndex` | `number` | | chain order, default `0` |
+
+:::warning Do not call the base `calculate()` yourself
+The factory wraps your `calculate` and continues the pricing chain automatically. Just push rows onto the `sheet` — **do not** call `super.calculate()` / `pricingAdapter.calculate()` (that was the old class-based API).
+:::
+
+- **`registerProductPricing`** — per-product price (`sheet.addItem({ amount, isTaxable, isNetPrice, meta })`)
+- **`registerOrderPricing`** — order totals (`sheet.addItems(...)`)
+- **`registerPaymentPricing`** — payment fees (`sheet.addFee(...)`)
+- **`registerDeliveryPricing`** — delivery fees (`sheet.addFee(...)`)
+
+```ts
+import { registerProductPricing } from '@unchainedshop/core';
+
+registerProductPricing({
+  adapterId: 'member-surcharge',
+  isActivatedFor: (context) => Boolean(context.product?.tags?.includes('exclusive')),
+  calculate: async (sheet, context) => {
+    sheet.addItem({ amount: 500, isTaxable: true, isNetPrice: true, meta: { adapter: 'member-surcharge' } });
+  },
+});
+```
+
+> See also: [Product pricing](./pricing/product-pricing.md), [Delivery pricing](./pricing/delivery-pricing.md), [Payment pricing](./pricing/payment-pricing.md)
+
+---
+
+## Discounts
+
+### `registerProductDiscount` / `registerOrderDiscount`
+
+`discountForPricingAdapterKey` is the core hook (return a discount configuration, or `null` to not discount).
+
+| Option | Type | Required | Notes |
+|---|---|---|---|
+| `adapterId` | `string` | ✅ | key `shop.unchained.discount.<product\|order>-<adapterId>` |
+| `discountForPricingAdapterKey` | `(params, context?) => DiscountConfiguration \| null` | ✅ | maps a discount to a pricing row |
+| `isValidForSystemTriggering` | `() => Promise<boolean>` | | auto-apply without a code |
+| `isValidForCodeTriggering` | `(code/context) => Promise<boolean>` | | apply for a coupon code |
+| `reserve` / `release` | `fn` | | reserve/return coupon capacity |
+| `orderIndex` *(product only)* | `number` | | |
+| `isManualAdditionAllowed` / `isManualRemovalAllowed` *(product only)* | `fn` | | manual coupon entry |
+
+```ts
+import { registerOrderDiscount } from '@unchainedshop/core';
+
+registerOrderDiscount({
+  adapterId: 'promo10',
+  isValidForCodeTriggering: async (code) => code === 'PROMO10',
+  discountForPricingAdapterKey: ({ pricingAdapterKey }) =>
+    pricingAdapterKey === 'shop.unchained.pricing.order-items' ? { rate: 0.1 } : null,
+});
+```
+
+> See also: [Order discounts](./pricing/order-discounts.md)
+
+---
+
+## Filters & Search
+
+| Factory | Required callback | Notes |
+|---|---|---|
+| `registerProductSearchFilter` | `search(params) => Promise<string[]>` | external product search (e.g. Algolia); `adapterId` optional |
+| `registerAssortmentSearchFilter` | `search(params) => Promise<string[]>` | external assortment search; `adapterId` optional |
+| `registerProductDiscoverabilityFilter` | — | hides products tagged `hiddenTagValue` (default `'hidden'`) from search |
+
+`search` receives `SearchQuery & { queryString, locale }` and returns matching ids. All three accept an optional `adapterId` (auto-generated if omitted) and `orderIndex`.
+
+```ts
+import { registerProductSearchFilter } from '@unchainedshop/core';
+
+registerProductSearchFilter({
+  adapterId: 'algolia',
+  search: async ({ queryString, locale }) => algolia.search(queryString, locale.baseName),
+});
+```
+
+> See also: [Filters](./catalog/filter.md)
+
+---
+
+## Workers
+
+### `registerWorker`
+
+A background job type. **Keyed by `type`** — there is no `adapterId`.
+
+| Option | Type | Required | Notes |
+|---|---|---|---|
+| `type` | `string` | ✅ | work type; key `shop.unchained.worker.<type>` |
+| `process` | `(input, workId) => Promise<Result>` | | your job logic; a thrown error becomes `{ success: false }` |
+| `external` | `boolean` | | default `false` |
+| `maxParallelAllocations` | `number` | | concurrency cap |
+
+```ts
+import { registerWorker } from '@unchainedshop/core';
+
+registerWorker<{ email: string }, { messageId: string }>({
+  type: 'SEND_WELCOME',
+  process: async (input) => ({ messageId: await mailer.send(input.email) }),
+});
+```
+
+> See also: [Work Queue](./worker.md)
+
+---
+
+## Files
+
+### `registerFileAdapter`
+
+A storage backend (S3, etc.). `createSignedURL` and `uploadFileFromStream` are required.
+
+| Option | Type | Required |
+|---|---|---|
+| `adapterId` | `string` | ✅ |
+| `createSignedURL` | `(directoryName, fileName, api) => Promise<{ putURL, … } \| null>` | ✅ |
+| `uploadFileFromStream` | `(directoryName, rawFile, api, options?) => Promise<UploadFileData>` | ✅ |
+| `createDownloadURL` | `(file, expiry?) => Promise<string \| null>` | |
+| `removeFiles` | `(files, api) => Promise<void>` | |
+| `uploadFileFromURL` | `(directoryName, fileInput, api) => Promise<UploadFileData>` | |
+
+> The active file backend is the **first registered** file adapter — register exactly one (the base preset registers GridFS). See [File plugins](../plugins/files/index.md).
+
+---
+
+## Quotations
+
+### `registerQuotation`
+
+All callbacks are optional (the base adapter provides working defaults); only `adapterId` is required.
+
+| Option | Type | Notes |
+|---|---|---|
+| `adapterId` | `string` | required |
+| `quote` | `(context) => Promise<QuotationProposal>` | produce the offer |
+| `transformItemConfiguration` | `(params, context) => Promise<QuotationItemConfiguration \| null>` | map the requested config to an order item |
+| `isManualProposalRequired` / `isManualRequestVerificationRequired` | `boolean` | |
+| `submitRequest` / `verifyRequest` / `rejectRequest` | `(context) => Promise<boolean>` | lifecycle hooks |
+
+> See also: [Quotation](./quotation.md)
+
+---
+
+## Enrollments
+
+### `registerEnrollment`
+
+Recurring/subscription plans. `configurationForOrder` is required.
+
+| Option | Type | Notes |
+|---|---|---|
+| `adapterId` | `string` | required |
+| `configurationForOrder` | `(params, context) => Promise<{ orderPositionTemplates, orderContext? } \| null>` | builds the recurring order |
+| `isActivatedFor` | `(productPlan?) => boolean` | gate by plan; default `true` |
+| `transformOrderItem` | `(orderPosition, api) => Promise<EnrollmentPlan>` | |
+| `nextPeriod` | `(context) => Promise<EnrollmentPeriod \| null>` | next billing window |
+| `isOverdue` / `isValidForActivation` | `(context) => Promise<boolean>` | |
+
+> See also: [Enrollment](./enrollment.md)
+
+---
+
+## When not to use a factory
+
+Reach for a hand-built [`IPlugin`](../concepts/director-adapter-pattern.md) + `pluginRegistry.register()` when you need:
+
+- a custom `key` or `version` (factories fix the namespace and `1.0.0`);
+- HTTP `routes` (a webhook), a DB-backed `module`, or `onRegister`/`onShutdown` lifecycle hooks;
+- more than one adapter in a single plugin;
+- behavior a factory doesn't expose.
+
+```ts
+import { pluginRegistry, type IPlugin } from '@unchainedshop/core';
+
+const MyPlugin: IPlugin = {
+  key: 'com.acme.payment.gateway',
+  label: 'Acme Gateway',
+  version: '2.1.0',
+  adapters: [AcmeAdapter],
+  routes: [{ path: '/payment/acme/webhook', method: 'POST', handler: acmeWebhook }],
+  onRegister: () => {
+    if (!process.env.ACME_SECRET) throw new Error('ACME_SECRET not set');
+  },
+};
+
+pluginRegistry.register(MyPlugin);
+```

--- a/docs/docs/extend/pricing/delivery-pricing.md
+++ b/docs/docs/extend/pricing/delivery-pricing.md
@@ -9,211 +9,69 @@ description: Custom delivery pricing adapters
 
 Delivery pricing adapters calculate shipping and handling fees based on order contents, delivery method, and destination.
 
-For conceptual overview, see [Pricing System](../../concepts/pricing-system.md).
+For the conceptual overview, see [Pricing System](../../concepts/pricing-system.md).
 
-## Creating an Adapter
+## Creating an adapter
 
-Extend `DeliveryPricingAdapter` and register it with `DeliveryPricingDirector`:
+Use the [`registerDeliveryPricing`](../plugin-factories.md#pricing) factory. Push fees onto the `sheet` with `addFee(...)`; the factory continues the chain for you.
 
 ```typescript
-import {
-  DeliveryPricingAdapter,
-  DeliveryPricingDirector,
-} from '@unchainedshop/core-pricing';
+import { registerDeliveryPricing } from '@unchainedshop/core';
 
-class MyDeliveryPricing extends DeliveryPricingAdapter {
-  static key = 'my-shop.pricing.delivery';
-  static version = '1.0.0';
-  static label = 'Custom Delivery Pricing';
-  static orderIndex = 0;
-
-  static isActivatedFor({ provider }) {
-    return provider.type === 'SHIPPING';
-  }
-
-  async calculate() {
-    this.result.addItem({
-      amount: 800, // 8.00 flat rate
-      isTaxable: true,
-      isNetPrice: true,
-      category: 'DELIVERY',
-      meta: { adapter: this.constructor.key },
-    });
-
-    return super.calculate();
-  }
-}
-
-DeliveryPricingDirector.registerAdapter(MyDeliveryPricing);
+registerDeliveryPricing({
+  adapterId: 'flat-rate',
+  isActivatedFor: (context) => context.provider?.type === 'SHIPPING',
+  calculate: async (sheet, context) => {
+    sheet.addFee({ amount: 800, isTaxable: true, isNetPrice: true, meta: { adapter: 'flat-rate' } });
+  },
+});
 ```
+
+`calculate(sheet, context)` receives the running `sheet` and the delivery pricing `context` (`provider`, `order`, `modules`, `currencyCode`).
 
 ## Examples
 
-### Weight-Based Shipping
+### Zone-based pricing
 
 ```typescript
-class WeightBasedShipping extends DeliveryPricingAdapter {
-  static key = 'my-shop.pricing.weight-shipping';
-  static orderIndex = 0;
-
-  static isActivatedFor({ provider }) {
-    return provider.type === 'SHIPPING';
-  }
-
-  async calculate() {
-    const { order, modules } = this.context;
-
-    const items = await modules.orders.positions.findOrderPositions({
-      orderId: order._id,
+registerDeliveryPricing({
+  adapterId: 'zone-shipping',
+  isActivatedFor: (context) => context.provider?.type === 'SHIPPING',
+  calculate: async (sheet, context) => {
+    const zoneRates = { CH: 800, DE: 1500, AT: 1500, FR: 1500, IT: 1500, default: 2500 };
+    const countryCode = context.order?.delivery?.address?.countryCode;
+    sheet.addFee({
+      amount: zoneRates[countryCode] ?? zoneRates.default,
+      isTaxable: true,
+      isNetPrice: true,
+      meta: { zone: countryCode },
     });
+  },
+});
+```
 
-    // Calculate total weight
-    let totalWeight = 0;
-    for (const item of items) {
-      const product = await modules.products.findProduct({ productId: item.productId });
-      totalWeight += (product?.warehousing?.weight || 0) * item.quantity;
+### Free-shipping threshold
+
+```typescript
+registerDeliveryPricing({
+  adapterId: 'free-shipping',
+  orderIndex: 10, // after base shipping
+  calculate: async (sheet, context) => {
+    const productTotal = sheet.sum({ category: 'ITEMS' }); // order item total
+    const deliveryTotal = sheet.sum({ category: 'DELIVERY' });
+    if (productTotal >= 10000 && deliveryTotal > 0) {
+      sheet.addDiscount({ amount: -deliveryTotal, isTaxable: true, isNetPrice: true, discountId: 'free-shipping', meta: { threshold: 10000 } });
     }
-
-    // Price: base + per kg
-    const basePrice = 500; // 5.00 base
-    const pricePerKg = 200; // 2.00 per kg
-
-    this.result.addItem({
-      amount: basePrice + Math.round(totalWeight * pricePerKg),
-      isTaxable: true,
-      isNetPrice: true,
-      category: 'DELIVERY',
-      meta: { weight: totalWeight, adapter: this.constructor.key },
-    });
-
-    return super.calculate();
-  }
-}
+  },
+});
 ```
 
-### Zone-Based Pricing
+## Low-level adapter (advanced)
 
-```typescript
-class ZoneBasedShipping extends DeliveryPricingAdapter {
-  static key = 'my-shop.pricing.zone-shipping';
-  static orderIndex = 0;
-
-  static isActivatedFor({ provider }) {
-    return provider.type === 'SHIPPING';
-  }
-
-  async calculate() {
-    const { order } = this.context;
-    const countryCode = order.delivery?.address?.countryCode;
-
-    const zoneRates = {
-      CH: 800,    // 8.00 domestic
-      DE: 1500,   // 15.00 EU neighbor
-      AT: 1500,
-      FR: 1500,
-      IT: 1500,
-      default: 2500, // 25.00 international
-    };
-
-    const amount = zoneRates[countryCode] || zoneRates.default;
-
-    this.result.addItem({
-      amount,
-      isTaxable: true,
-      isNetPrice: true,
-      category: 'DELIVERY',
-      meta: { zone: countryCode, adapter: this.constructor.key },
-    });
-
-    return super.calculate();
-  }
-}
-```
-
-### Free Shipping Threshold
-
-```typescript
-class FreeShippingThreshold extends DeliveryPricingAdapter {
-  static key = 'my-shop.pricing.free-shipping';
-  static orderIndex = 10; // After base shipping
-
-  async calculate() {
-    const { order, modules } = this.context;
-    const threshold = 10000; // Free shipping over 100.00
-
-    // Calculate product total
-    const items = await modules.orders.positions.findOrderPositions({
-      orderId: order._id,
-    });
-    const productTotal = items.reduce((sum, item) => {
-      return sum + (item.calculation?.find(c => c.category === 'BASE')?.amount || 0);
-    }, 0);
-
-    if (productTotal >= threshold) {
-      const deliveryTotal = this.calculation.sum({ category: 'DELIVERY' });
-
-      if (deliveryTotal > 0) {
-        this.result.addItem({
-          amount: -deliveryTotal,
-          isTaxable: true,
-          isNetPrice: true,
-          category: 'DISCOUNT',
-          meta: { type: 'free-shipping', threshold, adapter: this.constructor.key },
-        });
-      }
-    }
-
-    return super.calculate();
-  }
-}
-```
-
-### Express Shipping Option
-
-```typescript
-class ExpressShipping extends DeliveryPricingAdapter {
-  static key = 'my-shop.pricing.express';
-  static orderIndex = 0;
-
-  static isActivatedFor({ provider }) {
-    // Only for express delivery provider
-    return provider.adapterKey === 'my-shop.delivery.express';
-  }
-
-  async calculate() {
-    const { order } = this.context;
-
-    // Express: 2x standard rate
-    const standardRate = 800;
-    const expressMultiplier = 2;
-
-    this.result.addItem({
-      amount: standardRate * expressMultiplier,
-      isTaxable: true,
-      isNetPrice: true,
-      category: 'DELIVERY',
-      meta: { type: 'express', adapter: this.constructor.key },
-    });
-
-    return super.calculate();
-  }
-}
-```
-
-## Context Properties
-
-Available in `this.context`:
-
-| Property | Description |
-|----------|-------------|
-| `provider` | The delivery provider |
-| `order` | The current order |
-| `modules` | Access to all modules |
-| `currency` | Currency code |
+For behavior the factory doesn't expose, build the adapter by spreading `DeliveryPricingAdapter` and registering it via `pluginRegistry.register()`. See [Plugin System](../../concepts/director-adapter-pattern.md#adapter-contracts).
 
 ## Related
 
-- [Pricing System](../../concepts/pricing-system.md) - Conceptual overview
-- [Product Pricing](./product-pricing.md) - Product prices
-- [Payment Pricing](./payment-pricing.md) - Payment fees
-- [Delivery Plugins](../order-fulfilment/fulfilment-plugins/delivery.md) - Delivery adapters
+- [Pricing System](../../concepts/pricing-system.md) — conceptual overview
+- [Plugin Factories](../plugin-factories.md#pricing) — all four pricing factories
+- [Product Pricing](./product-pricing.md) · [Payment Pricing](./payment-pricing.md) · [Delivery Plugins](../order-fulfilment/fulfilment-plugins/delivery.md)

--- a/docs/docs/extend/pricing/order-discounts.md
+++ b/docs/docs/extend/pricing/order-discounts.md
@@ -9,317 +9,87 @@ description: Custom discount adapters for orders
 
 Order discount adapters handle coupon codes, promotional discounts, and automatic order-level discounts.
 
-For conceptual overview, see [Pricing System](../../concepts/pricing-system.md).
+For the conceptual overview, see [Pricing System](../../concepts/pricing-system.md).
 
-## Creating an Adapter
+## Creating an adapter
 
-Register a discount adapter with `OrderDiscountDirector`:
+Use the [`registerOrderDiscount`](../plugin-factories.md#discounts) factory. The core hook is `discountForPricingAdapterKey` — return a discount configuration, or `null` to not discount.
 
 ```typescript
-import { OrderDiscountDirector, type IDiscountAdapter } from '@unchainedshop/core';
+import { registerOrderDiscount } from '@unchainedshop/core';
 
-const MyDiscount: IDiscountAdapter = {
-  key: 'my-shop.discount.custom',
-  label: 'Custom Discount',
-  version: '1.0.0',
-  orderIndex: 0,
-
-  isManualAdditionAllowed(code) {
-    return true; // Allow users to enter this discount code
-  },
-
-  isManualRemovalAllowed() {
-    return true; // Allow users to remove this discount
-  },
-
-  actions(context) {
-    return {
-      isValidForSystemTriggering() {
-        return false; // Don't auto-apply
-      },
-
-      isValidForCodeTriggering(code) {
-        return code === 'SAVE10';
-      },
-
-      discountForPricingAdapterKey({ pricingAdapterKey }) {
-        return { rate: 0.1 }; // 10% off
-      },
-
-      async reserve(code) {
-        // Optional: Track usage
-      },
-
-      async release() {
-        // Optional: Release reservation on cancellation
-      },
-    };
-  },
-};
-
-OrderDiscountDirector.registerAdapter(MyDiscount);
+registerOrderDiscount({
+  adapterId: 'save10',
+  // apply when the buyer enters a matching code:
+  isValidForCodeTriggering: async (code) => code === 'SAVE10',
+  discountForPricingAdapterKey: ({ pricingAdapterKey }) =>
+    pricingAdapterKey === 'shop.unchained.pricing.order-items' ? { rate: 0.1 } : null,
+});
 ```
+
+| Option | Purpose |
+|---|---|
+| `isValidForSystemTriggering(context)` | auto-apply without a code (e.g. first-order discount) |
+| `isValidForCodeTriggering(code, context)` | apply for a coupon code |
+| `discountForPricingAdapterKey(params, context)` | return `{ rate }` / `{ fixedRate }` for a pricing row, or `null` |
+| `reserve(code, context)` / `release(context)` | decrement / restore coupon capacity |
 
 ## Examples
 
-### Coupon Code Discount
+### Coupon codes
 
 ```typescript
-const CouponDiscount: IDiscountAdapter = {
-  key: 'my-shop.discount.coupon',
-  label: 'Coupon Code',
-  version: '1.0.0',
-  orderIndex: 0,
+const codes = { SAVE10: { rate: 0.1 }, SAVE20: { rate: 0.2 }, DISCOUNT50: { fixedRate: 5000 } };
 
-  isManualAdditionAllowed(code) {
-    // Accept codes starting with 'SAVE' or 'DISCOUNT'
-    return code?.startsWith('SAVE') || code?.startsWith('DISCOUNT');
-  },
-
-  isManualRemovalAllowed() {
-    return true;
-  },
-
-  actions(context) {
-    const validCodes = {
-      SAVE10: { rate: 0.1 },
-      SAVE20: { rate: 0.2 },
-      DISCOUNT50: { fixedRate: 5000 }, // 50.00 off
-    };
-
-    return {
-      isValidForSystemTriggering() {
-        return false;
-      },
-
-      isValidForCodeTriggering(code) {
-        return code in validCodes;
-      },
-
-      discountForPricingAdapterKey({ code }) {
-        return validCodes[code] || null;
-      },
-
-      async reserve(code) {
-        // Decrement coupon usage count
-        await db.collection('coupons').updateOne(
-          { code },
-          { $inc: { usageCount: 1 } }
-        );
-      },
-
-      async release() {
-        // Increment back on cancellation
-        const { code } = context.orderDiscount;
-        await db.collection('coupons').updateOne(
-          { code },
-          { $inc: { usageCount: -1 } }
-        );
-      },
-    };
-  },
-};
+registerOrderDiscount({
+  adapterId: 'coupon',
+  isValidForCodeTriggering: async (code) => code in codes,
+  discountForPricingAdapterKey: ({ pricingAdapterKey }, context) =>
+    pricingAdapterKey === 'shop.unchained.pricing.order-items' ? codes[context.code] ?? null : null,
+  reserve: async (code) => db.collection('coupons').updateOne({ code }, { $inc: { usageCount: 1 } }),
+  release: async (context) => db.collection('coupons').updateOne({ code: context.code }, { $inc: { usageCount: -1 } }),
+});
 ```
 
-### Automatic First-Order Discount
+### Automatic first-order discount
 
 ```typescript
-const FirstOrderDiscount: IDiscountAdapter = {
-  key: 'my-shop.discount.first-order',
-  label: 'First Order Discount',
-  version: '1.0.0',
-  orderIndex: 1,
-
-  isManualAdditionAllowed() {
-    return false; // Auto-applied only
+registerOrderDiscount({
+  adapterId: 'first-order',
+  isValidForSystemTriggering: async (context) => {
+    const previous = await context.modules.orders.count({ userId: context.order.userId, status: { $ne: null } });
+    return previous === 0;
   },
-
-  isManualRemovalAllowed() {
-    return false;
-  },
-
-  actions(context) {
-    const { order, modules } = context;
-
-    return {
-      async isValidForSystemTriggering() {
-        // Check if this is the user's first order
-        const previousOrders = await modules.orders.count({
-          userId: order.userId,
-          status: { $ne: null }, // Exclude carts
-        });
-        return previousOrders === 0;
-      },
-
-      isValidForCodeTriggering() {
-        return false;
-      },
-
-      discountForPricingAdapterKey() {
-        return { rate: 0.15 }; // 15% off first order
-      },
-
-      async reserve() {},
-      async release() {},
-    };
-  },
-};
+  discountForPricingAdapterKey: ({ pricingAdapterKey }) =>
+    pricingAdapterKey === 'shop.unchained.pricing.order-items' ? { rate: 0.15 } : null,
+});
 ```
 
-### Minimum Order Value Discount
+## Discount configuration
 
-```typescript
-const MinimumOrderDiscount: IDiscountAdapter = {
-  key: 'my-shop.discount.minimum-order',
-  label: 'Spend More Save More',
-  version: '1.0.0',
-  orderIndex: 2,
-
-  isManualAdditionAllowed() {
-    return false;
-  },
-
-  isManualRemovalAllowed() {
-    return false;
-  },
-
-  actions(context) {
-    const { order } = context;
-
-    return {
-      async isValidForSystemTriggering() {
-        const total = order.pricing().total().amount;
-        return total >= 10000; // Minimum 100.00
-      },
-
-      isValidForCodeTriggering() {
-        return false;
-      },
-
-      discountForPricingAdapterKey() {
-        const total = order.pricing().total().amount;
-
-        // Tiered discounts
-        if (total >= 50000) {
-          return { rate: 0.15 }; // 15% off for 500+
-        } else if (total >= 25000) {
-          return { rate: 0.1 }; // 10% off for 250+
-        } else if (total >= 10000) {
-          return { rate: 0.05 }; // 5% off for 100+
-        }
-
-        return null;
-      },
-
-      async reserve() {},
-      async release() {},
-    };
-  },
-};
-```
-
-### Limited-Use Coupon
-
-```typescript
-const LimitedCoupon: IDiscountAdapter = {
-  key: 'my-shop.discount.limited',
-  label: 'Limited Coupon',
-  version: '1.0.0',
-  orderIndex: 0,
-
-  isManualAdditionAllowed(code) {
-    return code?.startsWith('LIMITED');
-  },
-
-  isManualRemovalAllowed() {
-    return true;
-  },
-
-  actions(context) {
-    return {
-      isValidForSystemTriggering() {
-        return false;
-      },
-
-      async isValidForCodeTriggering(code) {
-        // Check if coupon exists and has remaining uses
-        const coupon = await db.collection('coupons').findOne({ code });
-        if (!coupon) return false;
-        return coupon.usageCount < coupon.maxUsage;
-      },
-
-      discountForPricingAdapterKey({ code }) {
-        return { rate: 0.25 }; // 25% off
-      },
-
-      async reserve(code) {
-        await db.collection('coupons').updateOne(
-          { code },
-          { $inc: { usageCount: 1 } }
-        );
-      },
-
-      async release() {
-        const { code } = context.orderDiscount;
-        await db.collection('coupons').updateOne(
-          { code },
-          { $inc: { usageCount: -1 } }
-        );
-      },
-    };
-  },
-};
-```
-
-## Adapter Methods
-
-| Method | Description |
-|--------|-------------|
-| `isManualAdditionAllowed(code)` | Can users add this discount with a code? |
-| `isManualRemovalAllowed()` | Can users remove this discount? |
-| `isValidForSystemTriggering()` | Should this discount auto-apply? |
-| `isValidForCodeTriggering(code)` | Is this code valid? |
-| `discountForPricingAdapterKey()` | Return discount configuration |
-| `reserve(code)` | Called when discount is applied |
-| `release()` | Called when order is cancelled |
-
-## Discount Configuration
-
-Return from `discountForPricingAdapterKey`:
+Returned from `discountForPricingAdapterKey`:
 
 | Property | Description |
-|----------|-------------|
-| `rate` | Percentage discount (0.1 = 10%) |
-| `fixedRate` | Fixed amount in cents (5000 = 50.00) |
+|---|---|
+| `rate` | Percentage discount (`0.1` = 10%) |
+| `fixedRate` | Fixed amount in cents (`5000` = 50.00) |
+
+> For fine-grained control of manual code entry/removal (`isManualAdditionAllowed` / `isManualRemovalAllowed`), build the adapter directly by spreading `OrderDiscountAdapter` and registering it via `pluginRegistry.register()`. See [Plugin System](../../concepts/director-adapter-pattern.md#adapter-contracts).
 
 ## GraphQL
 
-Apply discount:
-
 ```graphql
 mutation ApplyDiscount($code: String!) {
-  addCartDiscount(code: $code) {
-    _id
-    code
-    total {
-      amount
-      currencyCode
-    }
-  }
+  addCartDiscount(code: $code) { _id code total { amount currencyCode } }
 }
-```
 
-Remove discount:
-
-```graphql
 mutation RemoveDiscount($discountId: ID!) {
-  removeCartDiscount(discountId: $discountId) {
-    _id
-  }
+  removeCartDiscount(discountId: $discountId) { _id }
 }
 ```
 
 ## Related
 
-- [Pricing System](../../concepts/pricing-system.md) - Conceptual overview
-- [Product Pricing](./product-pricing.md) - Product-level discounts
+- [Pricing System](../../concepts/pricing-system.md) — conceptual overview
+- [Plugin Factories](../plugin-factories.md#discounts) — `registerOrderDiscount` / `registerProductDiscount`
+- [Product Pricing](./product-pricing.md)

--- a/docs/docs/extend/pricing/order-discounts.md
+++ b/docs/docs/extend/pricing/order-discounts.md
@@ -57,7 +57,7 @@ registerOrderDiscount({
 registerOrderDiscount({
   adapterId: 'first-order',
   isValidForSystemTriggering: async (context) => {
-    const previous = await context.modules.orders.count({ userId: context.order.userId, status: { $ne: null } });
+    const previous = await ordersRepository.countConfirmedForUser(context.order.userId);
     return previous === 0;
   },
   discountForPricingAdapterKey: ({ pricingAdapterKey }) =>

--- a/docs/docs/extend/pricing/payment-pricing.md
+++ b/docs/docs/extend/pricing/payment-pricing.md
@@ -7,190 +7,64 @@ description: Custom payment pricing adapters
 
 # Payment Pricing
 
-Payment pricing adapters calculate fees for different payment methods, such as credit card processing fees or invoice handling charges.
+Payment pricing adapters calculate fees for different payment methods — e.g. credit-card processing fees or invoice handling charges.
 
-For conceptual overview, see [Pricing System](../../concepts/pricing-system.md).
+For the conceptual overview, see [Pricing System](../../concepts/pricing-system.md).
 
-## Creating an Adapter
+## Creating an adapter
 
-Extend `PaymentPricingAdapter` and register it with `PaymentPricingDirector`:
+Use the [`registerPaymentPricing`](../plugin-factories.md#pricing) factory. Push fees onto the `sheet` with `addFee(...)`; the factory continues the chain for you.
 
 ```typescript
-import {
-  PaymentPricingAdapter,
-  PaymentPricingDirector,
-} from '@unchainedshop/core-pricing';
+import { registerPaymentPricing } from '@unchainedshop/core';
 
-class MyPaymentPricing extends PaymentPricingAdapter {
-  static key = 'my-shop.pricing.payment';
-  static version = '1.0.0';
-  static label = 'Custom Payment Pricing';
-  static orderIndex = 0;
-
-  static isActivatedFor({ provider }) {
-    return true; // Activate for all payment providers
-  }
-
-  async calculate() {
-    this.result.addItem({
-      amount: 0, // No fee
-      isTaxable: false,
-      isNetPrice: true,
-      category: 'PAYMENT',
-      meta: { adapter: this.constructor.key },
-    });
-
-    return super.calculate();
-  }
-}
-
-PaymentPricingDirector.registerAdapter(MyPaymentPricing);
+registerPaymentPricing({
+  adapterId: 'invoice-fee',
+  isActivatedFor: (context) => context.provider?.type === 'INVOICE',
+  calculate: async (sheet) => {
+    sheet.addFee({ amount: 500, isTaxable: true, isNetPrice: true, meta: { type: 'invoice' } });
+  },
+});
 ```
+
+`calculate(sheet, context)` receives the running `sheet` and the payment pricing `context` (`provider`, `order`, `modules`, `currencyCode`).
 
 ## Examples
 
-### Credit Card Fee
+### Credit-card fee
 
 ```typescript
-class CardFeeAdapter extends PaymentPricingAdapter {
-  static key = 'my-shop.pricing.card-fee';
-  static orderIndex = 0;
-
-  static isActivatedFor({ provider }) {
-    return provider.type === 'CARD' || provider.type === 'GENERIC';
-  }
-
-  async calculate() {
-    const { order } = this.context;
-    const orderTotal = order.pricing().total().amount;
-
-    // 2.9% + 30 cents (typical card processing fee)
-    const fee = Math.round(orderTotal * 0.029 + 30);
-
-    this.result.addItem({
-      amount: fee,
-      isTaxable: false,
-      isNetPrice: true,
-      category: 'PAYMENT',
-      meta: { rate: 0.029, fixed: 30, adapter: this.constructor.key },
-    });
-
-    return super.calculate();
-  }
-}
+registerPaymentPricing({
+  adapterId: 'card-fee',
+  isActivatedFor: (context) => ['CARD', 'GENERIC'].includes(context.provider?.type),
+  calculate: async (sheet, context) => {
+    const orderTotal = context.order.pricing().total().amount;
+    const fee = Math.round(orderTotal * 0.029 + 30); // 2.9% + 0.30
+    sheet.addFee({ amount: fee, isTaxable: false, isNetPrice: true, meta: { rate: 0.029, fixed: 30 } });
+  },
+});
 ```
 
-### Invoice Fee
+### Tiered processing fee
 
 ```typescript
-class InvoiceFeeAdapter extends PaymentPricingAdapter {
-  static key = 'my-shop.pricing.invoice-fee';
-  static orderIndex = 0;
-
-  static isActivatedFor({ provider }) {
-    return provider.type === 'INVOICE';
-  }
-
-  async calculate() {
-    // Flat fee for invoice handling
-    this.result.addItem({
-      amount: 500, // 5.00 invoice fee
-      isTaxable: true,
-      isNetPrice: true,
-      category: 'PAYMENT',
-      meta: { type: 'invoice', adapter: this.constructor.key },
-    });
-
-    return super.calculate();
-  }
-}
+registerPaymentPricing({
+  adapterId: 'tiered-fee',
+  isActivatedFor: (context) => context.provider?.type === 'CARD',
+  calculate: async (sheet, context) => {
+    const orderTotal = context.order.pricing().total().amount;
+    const rate = orderTotal >= 50000 ? 0.019 : orderTotal >= 10000 ? 0.025 : 0.029;
+    sheet.addFee({ amount: Math.round(orderTotal * rate + 30), isTaxable: false, isNetPrice: true, meta: { rate } });
+  },
+});
 ```
 
-### Discount for Bank Transfer
+## Low-level adapter (advanced)
 
-```typescript
-class BankTransferDiscountAdapter extends PaymentPricingAdapter {
-  static key = 'my-shop.pricing.bank-discount';
-  static orderIndex = 0;
-
-  static isActivatedFor({ provider }) {
-    return provider.adapterKey === 'my-shop.payment.bank-transfer';
-  }
-
-  async calculate() {
-    const { order } = this.context;
-    const orderTotal = order.pricing().total().amount;
-
-    // 2% discount for bank transfer (no card fees)
-    const discount = Math.round(orderTotal * 0.02);
-
-    this.result.addItem({
-      amount: -discount,
-      isTaxable: true,
-      isNetPrice: true,
-      category: 'DISCOUNT',
-      meta: { type: 'bank-transfer-discount', rate: 0.02 },
-    });
-
-    return super.calculate();
-  }
-}
-```
-
-### Tiered Processing Fees
-
-```typescript
-class TieredFeeAdapter extends PaymentPricingAdapter {
-  static key = 'my-shop.pricing.tiered-fee';
-  static orderIndex = 0;
-
-  static isActivatedFor({ provider }) {
-    return provider.type === 'CARD';
-  }
-
-  async calculate() {
-    const { order } = this.context;
-    const orderTotal = order.pricing().total().amount;
-
-    // Tiered rates based on order value
-    let rate: number;
-    if (orderTotal >= 50000) {
-      rate = 0.019; // 1.9% for orders >= 500
-    } else if (orderTotal >= 10000) {
-      rate = 0.025; // 2.5% for orders >= 100
-    } else {
-      rate = 0.029; // 2.9% for smaller orders
-    }
-
-    const fee = Math.round(orderTotal * rate + 30);
-
-    this.result.addItem({
-      amount: fee,
-      isTaxable: false,
-      isNetPrice: true,
-      category: 'PAYMENT',
-      meta: { rate, orderTotal, adapter: this.constructor.key },
-    });
-
-    return super.calculate();
-  }
-}
-```
-
-## Context Properties
-
-Available in `this.context`:
-
-| Property | Description |
-|----------|-------------|
-| `provider` | The payment provider |
-| `order` | The current order |
-| `modules` | Access to all modules |
-| `currency` | Currency code |
+For behavior the factory doesn't expose, build the adapter by spreading `PaymentPricingAdapter` and registering it via `pluginRegistry.register()`. See [Plugin System](../../concepts/director-adapter-pattern.md#adapter-contracts).
 
 ## Related
 
-- [Pricing System](../../concepts/pricing-system.md) - Conceptual overview
-- [Product Pricing](./product-pricing.md) - Product prices
-- [Delivery Pricing](./delivery-pricing.md) - Shipping fees
-- [Payment Plugins](../order-fulfilment/fulfilment-plugins/payment.md) - Payment adapters
+- [Pricing System](../../concepts/pricing-system.md) — conceptual overview
+- [Plugin Factories](../plugin-factories.md#pricing) — all four pricing factories
+- [Product Pricing](./product-pricing.md) · [Delivery Pricing](./delivery-pricing.md) · [Payment Plugins](../order-fulfilment/fulfilment-plugins/payment.md)

--- a/docs/docs/extend/pricing/payment-pricing.md
+++ b/docs/docs/extend/pricing/payment-pricing.md
@@ -27,18 +27,25 @@ registerPaymentPricing({
 });
 ```
 
-`calculate(sheet, context)` receives the running `sheet` and the payment pricing `context` (`provider`, `order`, `modules`, `currencyCode`).
+`calculate(sheet, context)` receives the running `sheet` and the payment pricing `context` (`provider`, `order`, `currencyCode`).
 
 ## Examples
 
 ### Credit-card fee
 
 ```typescript
+import { OrderPricingSheet, registerPaymentPricing } from '@unchainedshop/core';
+
 registerPaymentPricing({
   adapterId: 'card-fee',
-  isActivatedFor: (context) => ['CARD', 'GENERIC'].includes(context.provider?.type),
+  isActivatedFor: (context) =>
+    context.provider.adapterKey === 'shop.unchained.payment.stripe',
   calculate: async (sheet, context) => {
-    const orderTotal = context.order.pricing().total().amount;
+    const orderPricing = OrderPricingSheet({
+      calculation: context.order?.calculation,
+      currencyCode: context.order?.currencyCode,
+    });
+    const orderTotal = orderPricing.total().amount;
     const fee = Math.round(orderTotal * 0.029 + 30); // 2.9% + 0.30
     sheet.addFee({ amount: fee, isTaxable: false, isNetPrice: true, meta: { rate: 0.029, fixed: 30 } });
   },
@@ -50,9 +57,14 @@ registerPaymentPricing({
 ```typescript
 registerPaymentPricing({
   adapterId: 'tiered-fee',
-  isActivatedFor: (context) => context.provider?.type === 'CARD',
+  isActivatedFor: (context) =>
+    context.provider.adapterKey === 'shop.unchained.payment.stripe',
   calculate: async (sheet, context) => {
-    const orderTotal = context.order.pricing().total().amount;
+    const orderPricing = OrderPricingSheet({
+      calculation: context.order?.calculation,
+      currencyCode: context.order?.currencyCode,
+    });
+    const orderTotal = orderPricing.total().amount;
     const rate = orderTotal >= 50000 ? 0.019 : orderTotal >= 10000 ? 0.025 : 0.029;
     sheet.addFee({ amount: Math.round(orderTotal * rate + 30), isTaxable: false, isNetPrice: true, meta: { rate } });
   },

--- a/docs/docs/extend/pricing/product-pricing.md
+++ b/docs/docs/extend/pricing/product-pricing.md
@@ -7,192 +7,90 @@ description: Custom product pricing adapters
 
 # Product Pricing
 
-Product pricing adapters calculate prices when products are queried or added to cart. Use them to implement taxes, discounts, rounding, and currency conversion.
+Product pricing adapters calculate prices when products are queried or added to cart. Use them to implement taxes, surcharges, discounts, rounding, and currency conversion.
 
-For conceptual overview, see [Pricing System](../../concepts/pricing-system.md).
+For the conceptual overview (the pricing chain, categories, and leveled tiers), see [Pricing System](../../concepts/pricing-system.md).
 
-## Creating an Adapter
+## Creating an adapter
 
-Extend `ProductPricingAdapter` and register it with `ProductPricingDirector`:
+The recommended way is the [`registerProductPricing`](../plugin-factories.md#pricing) factory. You push rows onto the `sheet`; the factory continues the pricing chain for you — **don't** call the chain yourself.
 
 ```typescript
-import {
-  ProductPricingAdapter,
-  ProductPricingDirector,
-} from '@unchainedshop/core-pricing';
+import { registerProductPricing } from '@unchainedshop/core';
 
-class MyProductPricing extends ProductPricingAdapter {
-  static key = 'my-shop.pricing.custom';
-  static version = '1.0.0';
-  static label = 'Custom Product Pricing';
-  static orderIndex = 0;
-
-  static isActivatedFor({ product, currencyCode }) {
-    return true; // Activate for all products
-  }
-
-  async calculate() {
-    const { product, quantity, currencyCode } = this.context;
-
-    this.result.addItem({
+registerProductPricing({
+  adapterId: 'custom-base',
+  orderIndex: 0,
+  isActivatedFor: (context) => true, // activate for all products
+  calculate: async (sheet, context) => {
+    sheet.addItem({
       amount: 1000, // 10.00 in cents
       isTaxable: true,
       isNetPrice: true,
-      category: 'BASE',
-      meta: { adapter: this.constructor.key },
+      meta: { adapter: 'custom-base' },
     });
-
-    return super.calculate();
-  }
-}
-
-ProductPricingDirector.registerAdapter(MyProductPricing);
+  },
+});
 ```
+
+`calculate(sheet, context)` receives the running pricing `sheet` and the pricing `context` (`product`, `quantity`, `currencyCode`, `countryCode`, …). Run order is controlled by `orderIndex` (lower runs first).
 
 ## Examples
 
-### Tax Calculation
+### Tax
 
 ```typescript
-class SwissTaxAdapter extends ProductPricingAdapter {
-  static key = 'my-shop.pricing.swiss-tax';
-  static orderIndex = 20; // After base price and discounts
-
-  static isActivatedFor({ country }) {
-    return country === 'CH';
-  }
-
-  async calculate() {
+registerProductPricing({
+  adapterId: 'swiss-tax',
+  orderIndex: 20, // after base price and discounts
+  isActivatedFor: (context) => context.countryCode === 'CH',
+  calculate: async (sheet) => {
     const taxRate = 0.081; // 8.1% Swiss VAT
-    const taxableAmount = this.calculation.sum({ isTaxable: true });
-
-    if (taxableAmount > 0) {
-      this.result.addItem({
-        amount: Math.round(taxableAmount * taxRate),
+    const taxable = sheet.sum({ isTaxable: true });
+    if (taxable > 0) {
+      sheet.addItem({
+        amount: Math.round(taxable * taxRate),
         isTaxable: false,
         isNetPrice: false,
         category: 'TAX',
-        meta: { rate: taxRate, adapter: this.constructor.key },
+        meta: { rate: taxRate },
       });
     }
-
-    return super.calculate();
-  }
-}
+  },
+});
 ```
 
-### Bulk Discount
+### Bulk discount
 
 ```typescript
-class BulkDiscountAdapter extends ProductPricingAdapter {
-  static key = 'my-shop.pricing.bulk-discount';
-  static orderIndex = 10; // After base price, before tax
-
-  async calculate() {
-    const { quantity } = this.context;
-
-    if (quantity >= 10) {
-      const baseTotal = this.calculation.sum({ category: 'BASE' });
-      const discountRate = 0.1; // 10% off
-
-      this.result.addItem({
-        amount: -Math.round(baseTotal * discountRate),
+registerProductPricing({
+  adapterId: 'bulk-discount',
+  orderIndex: 10, // after base price, before tax
+  calculate: async (sheet, context) => {
+    if ((context.quantity ?? 1) >= 10) {
+      const base = sheet.sum({ category: 'BASE' });
+      sheet.addItem({
+        amount: -Math.round(base * 0.1), // 10% off (negative)
         isTaxable: true,
         isNetPrice: true,
         category: 'DISCOUNT',
-        meta: { type: 'bulk', rate: discountRate },
+        meta: { type: 'bulk' },
       });
     }
-
-    return super.calculate();
-  }
-}
+  },
+});
 ```
 
-### Price Rounding
+:::tip Quantity-tier catalog prices
+If you just want different unit prices at different quantities (e.g. cheaper at 10+), you usually don't need a custom adapter — set [leveled catalog prices](../../concepts/pricing-system.md#leveled-quantity-tier-catalog-pricing) (`minQuantity` tiers) on the product instead.
+:::
 
-```typescript
-class PriceRoundingAdapter extends ProductPricingAdapter {
-  static key = 'my-shop.pricing.rounding';
-  static orderIndex = 30; // Run last
+## Low-level adapter (advanced)
 
-  async calculate() {
-    const { calculation = [] } = this;
-
-    if (calculation.length) {
-      const [basePrice] = calculation;
-      const rounded = this.roundToNext(basePrice.amount, 50);
-
-      this.resetCalculation();
-      this.result.addItem({
-        amount: rounded,
-        isTaxable: basePrice.isTaxable,
-        isNetPrice: basePrice.isNetPrice,
-        meta: { adapter: this.constructor.key },
-      });
-    }
-
-    return super.calculate();
-  }
-
-  roundToNext(value: number, precision: number) {
-    const remainder = value % precision;
-    return remainder === 0 ? value : value + (precision - remainder);
-  }
-}
-```
-
-### Currency Conversion
-
-```typescript
-class CurrencyConversionAdapter extends ProductPricingAdapter {
-  static key = 'my-shop.pricing.currency';
-  static orderIndex = 1;
-
-  async calculate() {
-    const { currencyCode, baseCurrencyCode } = this.context;
-
-    if (currencyCode !== baseCurrencyCode) {
-      const rate = await this.getExchangeRate(baseCurrencyCode, currencyCode);
-
-      for (const item of this.calculation) {
-        item.amount = Math.round(item.amount * rate);
-      }
-    }
-
-    return super.calculate();
-  }
-
-  async getExchangeRate(from: string, to: string) {
-    // Fetch from your exchange rate service
-    return 1.1;
-  }
-}
-```
-
-## Adapter Properties
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `key` | string | Unique identifier |
-| `version` | string | Version for tracking |
-| `label` | string | Human-readable name |
-| `orderIndex` | number | Execution order (lower = earlier) |
-
-## Context Properties
-
-Available in `this.context`:
-
-| Property | Description |
-|----------|-------------|
-| `product` | The product being priced |
-| `quantity` | Quantity requested |
-| `currencyCode` | Target currency |
-| `country` | Country code |
+For behavior the factory doesn't expose — e.g. **mutating or resetting** existing rows (price rounding, currency conversion across all items) — build the adapter object directly by spreading `ProductPricingAdapter` and registering it with `pluginRegistry.register()`. Inside `actions(params)` you have the full `resultSheet()` and may call the base `calculate()` yourself. See [Plugin System](../../concepts/director-adapter-pattern.md#adapter-contracts).
 
 ## Related
 
-- [Pricing System](../../concepts/pricing-system.md) - Conceptual overview
-- [Delivery Pricing](./delivery-pricing.md) - Shipping fees
-- [Payment Pricing](./payment-pricing.md) - Payment fees
-- [Order Discounts](./order-discounts.md) - Order-level discounts
+- [Pricing System](../../concepts/pricing-system.md) — conceptual overview and leveled tiers
+- [Plugin Factories](../plugin-factories.md#pricing) — all four pricing factories
+- [Delivery Pricing](./delivery-pricing.md) · [Payment Pricing](./payment-pricing.md) · [Order Discounts](./order-discounts.md)

--- a/docs/docs/extend/quotation.md
+++ b/docs/docs/extend/quotation.md
@@ -7,88 +7,42 @@ description: Customizing quotation
 
 # Quotation Adapters
 
-## QuotationAdapter
+Accept and process quotation (request-for-quote) requests for shop items, manually or automatically. Several adapters can be active; they run in ascending `orderIndex`.
 
-You can accept quotation requests for a shop items. For every quotation received you can setup a quotation adapter to process this request manually or automatically. In order to process quotation request you need to create a quotation adapter that implements the `IQuotationAdapter` and register the adapter on the global quotation director that implements the `IQuotationDirector`.
+## Creating an adapter
 
-There can be multiple quotation adapters configured and active for a store and all of them will be executed for every quotation requests based on there `orderIndex` value. Quotation adapters that have smaller `orderIndex` value will be executed first.
-
-Below is a sample manual quotation adapter implementation that will mark every quotation request as expired after an hour of request if no quote is given in between by a user that is managing quotation requests. 
+Use the [`registerQuotation`](./plugin-factories.md#quotations) factory. Only `adapterId` is required — every callback has a sensible default. The example below requires manual verification and proposal, and expires a request after an hour if no quote is given.
 
 ```typescript
-import { log, LogLevel } from '@unchainedshop/logger';
+import { registerQuotation } from '@unchainedshop/core';
 
-import { IQuotationAdapter } from '@unchainedshop/core-quotations';
-import { QuotationError } from '@unchainedshop/core-quotations';
-
-export const ManualOffering: IQuotationAdapter = {
-  key: 'shop.unchained.quotations.manual',
-  label: 'Manual quotation'
-  version: '1.0.0',
-  orderIndex: 1,
-
-  isActivatedFor: (quotationContext: QuotationContext, unchainedAPI: UnchainedCore): boolean => {
-    return false;
-  },
-
-  actions: (params: QuotationContext & Context): QuotationAdapterActions => {
-    return {
-      configurationError: () => {
-        return QuotationError.NOT_IMPLEMENTED;
-      },
-
-      isManualRequestVerificationRequired: async (): Promise<boolean> => {
-        return true;
-      },
-
-      isManualProposalRequired: async (): Promise<boolean> => {
-        return true;
-      },
-
-      quote: async (): Promise<QuotationProposal> => {
-      return {
-          expires: new Date(new Date().getTime() + 3600 * 1000),
-        };
-      },
-
-      rejectRequest: async (unchainedAPI?: any): Promise<boolean> => {
-        return true;
-      },
-
-      submitRequest: async (unchainedAPI?: any): Promise<boolean> => {
-        return true;
-      },
-
-      verifyRequest: async (unchainedAPI?: any): Promise<boolean> => {
-        return true;
-      },
-
-      transformItemConfiguration: async (params: QuotationItemConfiguration) => {
-        return { quantity: params.quantity, configuration: params.configuration };
-      },
-    };
-  },
-};
-
+registerQuotation({
+  adapterId: 'manual',
+  isManualRequestVerificationRequired: true,
+  isManualProposalRequired: true,
+  quote: async (context) => ({
+    expires: new Date(Date.now() + 3600 * 1000),
+  }),
+  transformItemConfiguration: async (params, context) => ({
+    quantity: params.quantity,
+    configuration: params.configuration,
+  }),
+});
 ```
 
+## Callback reference
 
-- **isActivatedFor: (quotationContext: QuotationContext, unchainedAPI: UnchainedCore)**: Determines for which type of quotation request an adapter is active for. it can be based on the actual quotation in question or any condition you can think of.
-- **configurationError: QuotationError**: Returns any error that occurred while initializing the adapter. it can be missing environment variable or and other missing required values.
-- **isManualRequestVerificationRequired**: defines if a quotation should be considered valid and ready for quote automatically or should be verified by someone manually.
-- **isManualProposalRequired** Define if a user can respond to quotation request manually or not.
-- **quote**: Responds with the actual quotation request.
-- **rejectRequest** Will mark a quotation as rejected if returned to based on any condition check performed.
-- **submitRequest**: Will approve a quotation request for processing if you return true from this function.
-- **verifyRequest** It will mark the quotation as verified for a certain quotation if this function returns true.
-- **transformItemConfiguration(params: QuotationItemConfiguration)**: A quotation request is submitted as a `JSON` value and there is no predefined format of quotation request. use this function to transform the submitted `JSON` from the front end into a structure that will be best to work with in an adapter.
+| Option | Description |
+|---|---|
+| `quote(context)` | produce the offer (a `QuotationProposal`) |
+| `transformItemConfiguration(params, context)` | normalize the submitted request JSON into a structured item configuration |
+| `isManualRequestVerificationRequired` | a request must be verified by a human before it is valid (boolean) |
+| `isManualProposalRequired` | the quote is created manually rather than automatically (boolean) |
+| `submitRequest` / `verifyRequest` / `rejectRequest` | lifecycle hooks returning a boolean for the corresponding transition |
 
+> For full control of every `IQuotationAdapter` method, build the adapter directly and register it via `pluginRegistry.register()` — see [Plugin System](../concepts/director-adapter-pattern.md#adapter-contracts).
 
+## Related
 
-## Registering Quotation Adapter
-
-```typescript
-import { pluginRegistry } from '@unchainedshop/core-quotations';
-
-pluginRegistry.register({ key: ManualOffering.key, label: ManualOffering.label, version: ManualOffering.version, adapters: [ManualOffering] });
-```
+- [Plugin Factories](./plugin-factories.md#quotations) — `registerQuotation`
+- [Manual quotation plugin](../plugins/quotations/quotation-manual) — the shipped adapter

--- a/docs/docs/extend/quotation.md
+++ b/docs/docs/extend/quotation.md
@@ -88,7 +88,7 @@ export const ManualOffering: IQuotationAdapter = {
 ## Registering Quotation Adapter
 
 ```typescript
-import { QuotationDirector } from '@unchainedshop/core-quotations';
+import { pluginRegistry } from '@unchainedshop/core-quotations';
 
-QuotationDirector.registerAdapter(ManualOffering);
+pluginRegistry.register({ key: ManualOffering.key, label: ManualOffering.label, version: ManualOffering.version, adapters: [ManualOffering] });
 ```

--- a/docs/docs/extend/worker.md
+++ b/docs/docs/extend/worker.md
@@ -7,85 +7,61 @@ description: Add custom background workers
 
 # Work Queue
 
-## WorkAdapter
+Workers perform background tasks based on input and triggers — a cron job that runs on an interval, sending an email after an operation, syncing with an external system, and so on.
 
-You can add different types of works to perform various task based on different input and triggers. Work can be a cron operation that run on a given interval to do a system backup or send an email to a user after a certain operation.
+## Creating a worker
 
-In order to make use of work to perform any task you need to implement the `IWorkerAdapter` interface and register it to the global WorkDirector which implements the `IWorkerDirector`.
-
-Below is an example of work adapter that checks if all works are healthy and working correctly, runs on the  `wait` interval value passed as input
-
+The recommended way is the [`registerWorker`](./plugin-factories.md#workers) factory. You pass the work `type` and a `process` callback; the factory builds and registers the worker plugin.
 
 ```typescript
-import { IWorkerAdapter } from '@unchainedshop/core-worker';
+import { registerWorker } from '@unchainedshop/core';
 
-const wait = async (time: number) => {
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve(true);
-    }, time);
-  });
-};
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-type Arg = {
-  wait?: number;
-  fails?: boolean;
-};
-
-type Result = Arg;
-
-const Heartbeat: IWorkerAdapter<Arg, Result> = {
-
-  key: 'shop.unchained.worker-plugin.heartbeat',
-  label: 'Heartbeat plugin to check if workers are working',
-  version: '1.0.0',
-
+registerWorker<{ wait?: number; fails?: boolean }, { wait?: number }>({
   type: 'HEARTBEAT',
-
-  doWork: async (input: Arg): Promise<{ success: boolean; result: Result }> => {
-    if (input?.wait) {
-      await wait(input.wait);
-    }
-    if (input?.fails) {
-      return {
-        success: false,
-        result: input,
-      };
-    }
-    return {
-      success: true,
-      result: input,
-    };
+  process: async (input) => {
+    if (input?.wait) await wait(input.wait);
+    if (input?.fails) throw new Error('heartbeat failed'); // a thrown error => { success: false }
+    return input; // the resolved value => { success: true, result: input }
   },
-};
-
+});
 ```
-- **type**: type of the worker, this value is used to specify the worker you are targeting when adding a work to a work queue using `WorkerModule.addWork(data: WorkData, userId: string)` function
-- **doWork**: function that defines the actual work that is going to be performed by the work adapter
 
-## Registering Work Adapter
-Before you can add a worker in the work queue you need to register it to the global Worker director
+| Option | Description |
+|---|---|
+| `type` | Work type — passed to `modules.worker.addWork({ type })` to enqueue this work. Keyed `shop.unchained.worker.<type>`. |
+| `process(input, workId)` | The work logic. Return a result (→ `{ success: true, result }`); a thrown error becomes `{ success: false }`. |
+| `external` | `true` if the work is processed outside the engine (default `false`). |
+| `maxParallelAllocations` | Concurrency cap for this work type. |
+
+> For full control (a custom `key`/`version`, or the raw `doWork(input, api, workId)` shape), build an `IWorkerAdapter` and register it via `pluginRegistry.register()` — see [Plugin System](../concepts/director-adapter-pattern.md#adapter-contracts).
+
+## Scheduling recurring work
 
 ```typescript
-import { pluginRegistry } from '@unchainedshop/core-worker';
+import { WorkerDirector } from '@unchainedshop/core';
 
-pluginRegistry.register({ key: Heartbeat.key, label: Heartbeat.label, version: Heartbeat.version, adapters: [Heartbeat] });
+WorkerDirector.configureAutoscheduling({
+  type: 'HEARTBEAT',
+  schedule: '0 * * * *', // every hour (cron syntax)
+  input: () => ({ wait: 1000 }),
+});
 ```
 
-## Adding work to the work queue
+## Adding work to the queue
 
-Triggering a worker is done by adding a work to the work queue using the worker module found on unchained context. below is an example that demonstrate adding the work adapter we have created above
+Enqueue work via the worker module on the Unchained context:
 
-```typescript  
-unchainedAPI.modules.worker.addWork(
-    {
-      type: 'HEARTBEAT',
-      retries: 0,
-      input: {
-        wait: 1000,
-      },
-    },
-  );
-}
-
+```typescript
+await unchainedAPI.modules.worker.addWork({
+  type: 'HEARTBEAT',
+  retries: 0,
+  input: { wait: 1000 },
+});
 ```
+
+## Related
+
+- [Plugin Factories](./plugin-factories.md#workers) — `registerWorker`
+- [Plugin System](../concepts/director-adapter-pattern.md) — the plugin architecture

--- a/docs/docs/extend/worker.md
+++ b/docs/docs/extend/worker.md
@@ -67,9 +67,9 @@ const Heartbeat: IWorkerAdapter<Arg, Result> = {
 Before you can add a worker in the work queue you need to register it to the global Worker director
 
 ```typescript
-import { WorkerDirector } from '@unchainedshop/core-worker';
+import { pluginRegistry } from '@unchainedshop/core-worker';
 
-WorkerDirector.registerAdapter(Heartbeat);
+pluginRegistry.register({ key: Heartbeat.key, label: Heartbeat.label, version: Heartbeat.version, adapters: [Heartbeat] });
 ```
 
 ## Adding work to the work queue

--- a/docs/docs/guides/bulk-import.md
+++ b/docs/docs/guides/bulk-import.md
@@ -419,7 +419,7 @@ query ImportJobs {
 For systems requiring pull-based sync:
 
 ```typescript
-import { WorkerDirector } from '@unchainedshop/core';
+import { pluginRegistry, WorkerDirector } from '@unchainedshop/core';
 
 const PIMSyncWorker = {
   key: 'shop.example.worker.pim-sync',
@@ -455,7 +455,7 @@ const PIMSyncWorker = {
   },
 };
 
-WorkerDirector.registerAdapter(PIMSyncWorker);
+pluginRegistry.register({ key: PIMSyncWorker.key, label: PIMSyncWorker.label, version: PIMSyncWorker.version, adapters: [PIMSyncWorker] });
 
 // Schedule hourly sync
 WorkerDirector.configureAutoscheduling({

--- a/docs/docs/guides/bulk-import.md
+++ b/docs/docs/guides/bulk-import.md
@@ -419,43 +419,26 @@ query ImportJobs {
 For systems requiring pull-based sync:
 
 ```typescript
-import { pluginRegistry, WorkerDirector } from '@unchainedshop/core';
+import { registerWorker, WorkerDirector } from '@unchainedshop/core';
 
-const PIMSyncWorker = {
-  key: 'shop.example.worker.pim-sync',
-  label: 'PIM Synchronization',
-  version: '1.0.0',
+registerWorker<{ lastSyncDate?: string }, { synced: number }>({
   type: 'PIM_SYNC',
   external: true,
   maxParallelAllocations: 1,
-
-  async doWork(input, unchainedAPI) {
+  process: async (input) => {
     const { lastSyncDate } = input;
 
-    // Fetch changed products from PIM
     const products = await fetchPIMProducts({ since: lastSyncDate });
-
-    // Transform to bulk import format
-    const events = products.map(product => ({
+    const events = products.map((product) => ({
       entity: 'PRODUCT',
       operation: 'UPDATE',
       payload: transformProduct(product),
     }));
 
-    // Queue bulk import
-    await unchainedAPI.modules.worker.addWork({
-      type: 'BULK_IMPORT',
-      input: {
-        events,
-        createShouldUpsertIfIDExists: true,
-      },
-    });
-
-    return { success: true, result: { synced: events.length } };
+    await submitBulkImport(events);
+    return { synced: events.length };
   },
-};
-
-pluginRegistry.register({ key: PIMSyncWorker.key, label: PIMSyncWorker.label, version: PIMSyncWorker.version, adapters: [PIMSyncWorker] });
+});
 
 // Schedule hourly sync
 WorkerDirector.configureAutoscheduling({

--- a/docs/docs/guides/custom-pricing.md
+++ b/docs/docs/guides/custom-pricing.md
@@ -7,588 +7,190 @@ description: Implement custom pricing logic with pricing adapters
 
 # Custom Pricing
 
-This guide covers implementing custom pricing logic in Unchained Engine using pricing adapters.
+This guide covers implementing custom pricing logic using pricing adapters. For the conceptual model (the chain, categories, and leveled tiers), see [Pricing System](../concepts/pricing-system.md). For the full factory reference, see [Plugin Factories](../extend/plugin-factories.md#pricing).
 
 ## Overview
 
-Unchained uses a pricing pipeline where multiple adapters can contribute to the final price:
+Unchained uses a pricing pipeline where multiple adapters contribute to the final price:
 
 ```mermaid
 flowchart LR
-    BP[Base Price<br/>Adapter] --> TA[Tax<br/>Adapter] --> DA[Discount<br/>Adapter] --> FP[Final Price]
-```
-### Key Principles
-
-**Determinism:**
-All pricing must produce the same result for the same input. Avoid using real-time external data after checkout begins. If you fetch external data, store it in meta for reproducibility.
-
-**Immutability after checkout:**
-Once checkoutCart is executed, prices are frozen. Adapters cannot change finalized orders.
-
-**Net vs gross:**
-| Flag               | Meaning                     |
-| ------------------ | --------------------------- |
-| `isNetPrice=true`  | Tax will be added later     |
-| `isNetPrice=false` | Amount already includes tax |
-
-**Currency awareness:**
-Adapters must respect `currencyCode` in context. Do not assume base currency. Use `modules.currencies.round(amount, currencyCode)` for correct rounding.
-
-## Prerequisites
-
-- Node.js 22+
-- Running Unchained Engine instance
-- Basic TypeScript knowledge
-
-## Creating a Product Pricing Adapter
-
-### Basic Structure
-
-```typescript
-import {
-  ProductPricingAdapter,
-  ProductPricingDirector,
-} from '@unchainedshop/core-pricing';
-
-class CustomPricingAdapter extends ProductPricingAdapter {
-  // Unique identifier
-  static key = 'shop.example.pricing.custom';
-
-  // Display name in admin
-  static label = 'Custom Pricing Adapter';
-
-  // Version for tracking
-  static version = '1.0.0';
-
-  // Execution order (lower = earlier)
-  static orderIndex = 10;
-
-  // When to activate this adapter
-  static isActivatedFor({ product, country, currency }) {
-    return true; // Activate for all products
-  }
-
-  // Calculate pricing adjustments
-  async calculate() {
-    // Add pricing items
-    this.result.addItem({
-      amount: 100, // Amount in cents
-      isTaxable: true,
-      isNetPrice: true,
-      meta: { adapter: this.constructor.key },
-    });
-
-    // Always call super.calculate() at the end
-    return super.calculate();
-  }
-}
-
-// Register the adapter
-ProductPricingDirector.registerAdapter(CustomPricingAdapter);
+    BP[Base Price] --> TA[Tax] --> DA[Discount] --> FP[Final Price]
 ```
 
-### Context Available
+### Key principles
 
-The adapter has access to context information:
+- **Determinism** — the same input must produce the same price. If you fetch external data, store it in `meta` for reproducibility.
+- **Immutability after checkout** — once `checkoutCart` runs, prices are frozen.
+- **Net vs gross** — `isNetPrice: true` means tax is added later; `false` means the amount already includes tax.
+- **Currency awareness** — respect `context.currencyCode`; work in the smallest currency unit (cents).
+
+## Creating a product pricing adapter
+
+Use the [`registerProductPricing`](../extend/plugin-factories.md#pricing) factory. Push rows onto the `sheet`; **the factory continues the chain for you** — don't call it yourself.
 
 ```typescript
-async calculate() {
-  const {
-    product,        // The product being priced
-    quantity,       // Quantity requested
-    currencyCode,   // Target currency
-    countryCode,    // Target country
-    user,           // Current user (if logged in)
-    discounts,      // Applied discount codes
-    modules,        // All Unchained modules
-  } = this.context;
+import { registerProductPricing } from '@unchainedshop/core';
 
-  // Your pricing logic here
-}
+registerProductPricing({
+  adapterId: 'custom',
+  orderIndex: 10,
+  isActivatedFor: (context) => true, // all products
+  calculate: async (sheet, context) => {
+    sheet.addItem({ amount: 100, isTaxable: true, isNetPrice: true, meta: { adapter: 'custom' } });
+  },
+});
 ```
 
-## Example: Weather-Based Pricing
+`calculate(sheet, context)` receives the running `sheet` and the pricing `context` (`product`, `quantity`, `currencyCode`, `countryCode`, `user`, `modules`, …).
 
-A fun example that adjusts sausage prices based on outdoor temperature:
+## Example: weather-based pricing
+
+Adjust prices based on outdoor temperature (store the reading in `meta` for determinism):
 
 ```typescript
-import {
-  ProductPricingAdapter,
-  ProductPricingDirector,
-} from '@unchainedshop/core-pricing';
-
-const SAUSAGE_TAG = 'sausage';
-const TEMPERATURE_THRESHOLD = 20; // Celsius
-
-class WeatherBasedPricingAdapter extends ProductPricingAdapter {
-  static key = 'shop.example.pricing.weather-based';
-  static label = 'Weather-Based Sausage Pricing';
-  static version = '1.0.0';
-  static orderIndex = 5;
-
-  // Only activate for products tagged with "sausage"
-  static isActivatedFor({ product }) {
-    return product.tags?.includes(SAUSAGE_TAG);
-  }
-
-  async calculate() {
-    const { quantity, currencyCode } = this.context;
-
+registerProductPricing({
+  adapterId: 'weather-based',
+  orderIndex: 5,
+  isActivatedFor: (context) => context.product?.tags?.includes('sausage'),
+  calculate: async (sheet, context) => {
     try {
-      // Fetch current weather
-      const weather = await this.fetchWeather('Zurich');
-
-      if (weather.temperature > TEMPERATURE_THRESHOLD) {
-        // BBQ season! Increase price
-        this.result.addItem({
-          amount: 100 * quantity, // +1 CHF per item
+      const weather = await fetchWeather('Zurich');
+      if (weather.temperature > 20) {
+        sheet.addItem({
+          amount: 100 * (context.quantity ?? 1), // +1.00 per item in BBQ season
           isTaxable: true,
           isNetPrice: true,
-          meta: {
-            adapter: this.constructor.key,
-            reason: 'bbq-season-surcharge',
-            temperature: weather.temperature,
-          },
+          meta: { reason: 'bbq-season-surcharge', temperature: weather.temperature },
         });
       }
     } catch (error) {
-      console.error('Weather pricing failed:', error);
-      // Gracefully continue without adjustment
+      // Gracefully continue without an adjustment
     }
-
-    return super.calculate();
-  }
-
-  private async fetchWeather(city: string): Promise<{ temperature: number }> {
-    const response = await fetch(
-      `https://api.weatherapi.com/v1/current.json?key=${process.env.WEATHER_API_KEY}&q=${city}`
-    );
-    const data = await response.json();
-    return { temperature: data.current.temp_c };
-  }
-}
-
-ProductPricingDirector.registerAdapter(WeatherBasedPricingAdapter);
+  },
+});
 ```
 
-## Example: Volume Discounts
-
-Implement quantity-based discounts:
+## Example: volume discounts
 
 ```typescript
-import {
-  ProductPricingAdapter,
-  ProductPricingDirector,
-} from '@unchainedshop/core-pricing';
-
 const VOLUME_TIERS = [
-  { minQuantity: 100, discount: 0.20 }, // 20% off for 100+
-  { minQuantity: 50, discount: 0.15 },  // 15% off for 50+
-  { minQuantity: 20, discount: 0.10 },  // 10% off for 20+
-  { minQuantity: 10, discount: 0.05 },  // 5% off for 10+
+  { minQuantity: 100, discount: 0.2 },
+  { minQuantity: 50, discount: 0.15 },
+  { minQuantity: 20, discount: 0.1 },
+  { minQuantity: 10, discount: 0.05 },
 ];
 
-class VolumeDiscountAdapter extends ProductPricingAdapter {
-  static key = 'shop.example.pricing.volume-discount';
-  static label = 'Volume Discount';
-  static version = '1.0.0';
-  static orderIndex = 20; // Run after base price
-
-  static isActivatedFor({ product }) {
-    // Only for products marked for volume discounts
-    return product.meta?.allowVolumeDiscount === true;
-  }
-
-  async calculate() {
-    const { quantity } = this.context;
-
-    // Find applicable tier
-    const tier = VOLUME_TIERS.find(t => quantity >= t.minQuantity);
-
+registerProductPricing({
+  adapterId: 'volume-discount',
+  orderIndex: 20, // after base price
+  isActivatedFor: (context) => context.product?.meta?.allowVolumeDiscount === true,
+  calculate: async (sheet, context) => {
+    const tier = VOLUME_TIERS.find((t) => (context.quantity ?? 1) >= t.minQuantity);
     if (tier) {
-      // Get current subtotal
-      const subtotal = this.calculation.sum();
-
-      // Apply percentage discount
-      const discountAmount = Math.round(subtotal * tier.discount);
-
-      this.result.addItem({
-        amount: -discountAmount, // Negative for discount
+      const subtotal = sheet.sum();
+      sheet.addItem({
+        amount: -Math.round(subtotal * tier.discount), // negative = discount
         isTaxable: true,
         isNetPrice: true,
-        meta: {
-          adapter: this.constructor.key,
-          tier: tier.minQuantity,
-          discountPercent: tier.discount * 100,
-        },
+        category: 'DISCOUNT',
+        meta: { tier: tier.minQuantity, discountPercent: tier.discount * 100 },
       });
     }
-
-    return super.calculate();
-  }
-}
-
-ProductPricingDirector.registerAdapter(VolumeDiscountAdapter);
+  },
+});
 ```
 
-## Example: Customer-Specific Pricing
+:::tip Simple quantity tiers don't need an adapter
+For plain "cheaper at 10+" unit prices, set [leveled catalog prices](../concepts/pricing-system.md#leveled-quantity-tier-catalog-pricing) (`minQuantity` tiers) on the product instead of writing an adapter.
+:::
 
-Different prices for B2B customers:
+## Example: customer-specific (B2B) pricing
 
 ```typescript
-import {
-  ProductPricingAdapter,
-  ProductPricingDirector,
-} from '@unchainedshop/core-pricing';
-
-class B2BPricingAdapter extends ProductPricingAdapter {
-  static key = 'shop.example.pricing.b2b';
-  static label = 'B2B Customer Pricing';
-  static version = '1.0.0';
-  static orderIndex = 3; // Run early
-
-  static isActivatedFor({ product, context }) {
-    // Only for logged-in B2B customers
-    return context.user?.tags?.includes('b2b');
-  }
-
-  async calculate() {
-    const { product, user, modules } = this.context;
-
-    // Check for customer-specific price
-    const customerPrice = await this.getCustomerPrice(product, user);
-
+registerProductPricing({
+  adapterId: 'b2b',
+  orderIndex: 5,
+  isActivatedFor: (context) => context.user?.tags?.includes('b2b'),
+  calculate: async (sheet, context) => {
+    const customerPrice = await getCustomerPrice(context.product, context.user);
     if (customerPrice) {
-      // Replace base price with customer price
-      this.result.resetCalculation();
-      this.result.addItem({
-        amount: customerPrice.amount,
-        isTaxable: customerPrice.isTaxable,
-        isNetPrice: true,
-        meta: {
-          adapter: this.constructor.key,
-          priceListId: customerPrice.priceListId,
-        },
-      });
-    }
-
-    return super.calculate();
-  }
-
-  private async getCustomerPrice(product, user) {
-    // Look up price from customer-specific price list
-    const priceList = user.meta?.priceListId;
-    if (!priceList) return null;
-
-    // Your price list lookup logic here
-    return null;
-  }
-}
-
-ProductPricingDirector.registerAdapter(B2BPricingAdapter);
-```
-
-## Example: Time-Based Pricing
-
-Happy hour or flash sale pricing:
-
-```typescript
-import {
-  ProductPricingAdapter,
-  ProductPricingDirector,
-} from '@unchainedshop/core-pricing';
-
-class HappyHourPricingAdapter extends ProductPricingAdapter {
-  static key = 'shop.example.pricing.happy-hour';
-  static label = 'Happy Hour Pricing';
-  static version = '1.0.0';
-  static orderIndex = 15;
-
-  static isActivatedFor({ product }) {
-    return product.tags?.includes('happy-hour-eligible');
-  }
-
-  async calculate() {
-    const now = new Date();
-    const hour = now.getHours();
-
-    // Happy hour: 16:00 - 18:00
-    if (hour >= 16 && hour < 18) {
-      const subtotal = this.calculation.sum();
-      const discount = Math.round(subtotal * 0.25); // 25% off
-
-      this.result.addItem({
-        amount: -discount,
+      // Adjust toward the negotiated price (delta vs the current subtotal)
+      sheet.addItem({
+        amount: customerPrice.amount - sheet.sum(),
         isTaxable: true,
         isNetPrice: true,
-        meta: {
-          adapter: this.constructor.key,
-          reason: 'happy-hour',
-          validUntil: new Date(now.setHours(18, 0, 0, 0)).toISOString(),
-        },
+        meta: { priceListId: customerPrice.priceListId },
       });
     }
-
-    return super.calculate();
-  }
-}
-
-ProductPricingDirector.registerAdapter(HappyHourPricingAdapter);
+  },
+});
 ```
 
-## Other Pricing Adapter Types
+> To **replace** rather than adjust the base price (reset the sheet), build a low-level adapter — see [Plugin System](../concepts/director-adapter-pattern.md#adapter-contracts).
 
-### Order Pricing
+## Order, delivery & payment pricing
 
-Adjust order-level pricing (shipping discounts, order minimums):
+The same pattern applies with the matching factory and sheet method:
 
 ```typescript
-import {
-  OrderPricingAdapter,
-  OrderPricingDirector,
-} from '@unchainedshop/core-pricing';
+import { registerOrderPricing, registerDeliveryPricing, registerPaymentPricing } from '@unchainedshop/core';
 
-class FreeShippingAdapter extends OrderPricingAdapter {
-  static key = 'shop.example.pricing.free-shipping';
-  static label = 'Free Shipping Over 100';
-  static version = '1.0.0';
-  static orderIndex = 10;
-
-  static isActivatedFor() {
-    return true;
-  }
-
-  async calculate() {
-    const { order } = this.context;
-    const itemsTotal = order.calculation?.items || 0;
-
-    // Free shipping for orders over 100
-    if (itemsTotal >= 10000) { // 100.00 in cents
-      const shippingCost = this.calculation.sum({ category: 'DELIVERY' });
-
-      if (shippingCost > 0) {
-        this.result.addItem({
-          amount: -shippingCost,
-          category: 'DELIVERY',
-          isTaxable: false,
-          isNetPrice: true,
-          meta: {
-            adapter: this.constructor.key,
-            reason: 'free-shipping-threshold',
-          },
-        });
-      }
+// Free shipping over 100.00
+registerDeliveryPricing({
+  adapterId: 'free-shipping',
+  orderIndex: 10,
+  calculate: async (sheet) => {
+    const delivery = sheet.sum({ category: 'DELIVERY' });
+    if (sheet.sum({ category: 'ITEMS' }) >= 10000 && delivery > 0) {
+      sheet.addDiscount({ amount: -delivery, isTaxable: false, isNetPrice: true, discountId: 'free-shipping' });
     }
+  },
+});
 
-    return super.calculate();
-  }
-}
-
-OrderPricingDirector.registerAdapter(FreeShippingAdapter);
+// 2% discount for invoice payment
+registerPaymentPricing({
+  adapterId: 'cash-discount',
+  isActivatedFor: (context) => context.provider?.adapterKey === 'shop.unchained.payment.invoice',
+  calculate: async (sheet, context) => {
+    sheet.addFee({ amount: -Math.round(context.order.pricing().total().amount * 0.02), isTaxable: false, isNetPrice: true });
+  },
+});
 ```
 
-### Delivery Pricing
-
-Custom delivery cost calculations:
-
-```typescript
-import {
-  DeliveryPricingAdapter,
-  DeliveryPricingDirector,
-} from '@unchainedshop/core-pricing';
-
-class WeightBasedDeliveryAdapter extends DeliveryPricingAdapter {
-  static key = 'shop.example.pricing.weight-delivery';
-  static label = 'Weight-Based Delivery';
-  static version = '1.0.0';
-  static orderIndex = 5;
-
-  static isActivatedFor({ provider }) {
-    return provider.type === 'SHIPPING';
-  }
-
-  async calculate() {
-    const { order, modules } = this.context;
-
-    // Calculate total weight
-    let totalWeight = 0;
-    for (const item of order.items) {
-      const product = await modules.products.findProduct({ productId: item.productId });
-      totalWeight += (product.warehousing?.dimensions?.weightInGram || 0) * item.quantity;
-    }
-
-    // Price tiers by weight
-    let deliveryCost = 500; // Base 5.00
-    if (totalWeight > 5000) deliveryCost = 1500; // 15.00 for 5kg+
-    else if (totalWeight > 2000) deliveryCost = 1000; // 10.00 for 2kg+
-    else if (totalWeight > 1000) deliveryCost = 750; // 7.50 for 1kg+
-
-    this.result.addItem({
-      amount: deliveryCost,
-      isTaxable: true,
-      isNetPrice: true,
-      meta: {
-        adapter: this.constructor.key,
-        totalWeightGrams: totalWeight,
-      },
-    });
-
-    return super.calculate();
-  }
-}
-
-DeliveryPricingDirector.registerAdapter(WeightBasedDeliveryAdapter);
-```
-
-### Payment Pricing
-
-Payment method surcharges or discounts:
-
-```typescript
-import {
-  PaymentPricingAdapter,
-  PaymentPricingDirector,
-} from '@unchainedshop/core-pricing';
-
-class CashDiscountAdapter extends PaymentPricingAdapter {
-  static key = 'shop.example.pricing.cash-discount';
-  static label = 'Cash Payment Discount';
-  static version = '1.0.0';
-  static orderIndex = 5;
-
-  static isActivatedFor({ provider }) {
-    return provider.adapterKey === 'shop.unchained.payment.invoice';
-  }
-
-  async calculate() {
-    const { order } = this.context;
-    const orderTotal = order.calculation?.total || 0;
-
-    // 2% discount for bank transfer
-    const discount = Math.round(orderTotal * 0.02);
-
-    this.result.addItem({
-      amount: -discount,
-      isTaxable: false,
-      isNetPrice: true,
-      meta: {
-        adapter: this.constructor.key,
-        reason: 'cash-discount',
-      },
-    });
-
-    return super.calculate();
-  }
-}
-
-PaymentPricingDirector.registerAdapter(CashDiscountAdapter);
-```
+See [Order Pricing / Delivery Pricing / Payment Pricing](../extend/pricing/product-pricing.md) for details.
 
 ## Registration
 
-Register your adapter by importing it in your boot file:
+Factories register the plugin when called — just import the module that calls them in your boot file, before `startPlatform()`:
 
 ```typescript
 // boot.ts
 import './pricing/weather-based';
 import './pricing/volume-discount';
-import './pricing/b2b-pricing';
 ```
 
-## Testing Your Adapter
-
-Use the GraphQL playground to test:
+## Testing
 
 ```graphql
 query TestPricing {
   product(productId: "your-product-id") {
     ... on SimpleProduct {
-      simulatedPrice(quantity: 10) {
-        amount
-        currencyCode
-        isTaxable
-        isNetPrice
-      }
+      simulatedPrice(quantity: 10) { amount currencyCode isTaxable isNetPrice }
     }
   }
 }
 ```
 
-## Best Practices
+## Best practices
 
-### 1. Order Index Strategy
-
-```typescript
-// Suggested order indices:
-// 0-5:   Base price, currency conversion
-// 5-10:  Customer-specific pricing
-// 10-20: Product-level discounts
-// 20-30: Tax calculations
-// 30+:   Final adjustments
-```
-
-### 2. Always Call Super
-
-```typescript
-async calculate() {
-  // Your logic here
-
-  return super.calculate(); // Don't forget this!
-}
-```
-
-### 3. Use Meta for Transparency
-
-```typescript
-this.result.addItem({
-  amount: discountAmount,
-  meta: {
-    adapter: this.constructor.key,
-    reason: 'volume-discount',
-    appliedTier: '20+',
-    originalAmount: baseAmount,
-  },
-});
-```
-
-### 4. Handle Errors Gracefully
-
-```typescript
-async calculate() {
-  try {
-    const externalData = await fetchExternalPricing();
-    // Apply pricing
-  } catch (error) {
-    console.error('External pricing failed:', error);
-    // Continue without failing the entire pricing
-  }
-
-  return super.calculate();
-}
-```
-
-### 5. Cache External Calls
-
-```typescript
-const priceCache = new Map();
-
-async calculate() {
-  const cacheKey = `${this.context.product._id}-${this.context.currencyCode}`;
-
-  if (!priceCache.has(cacheKey)) {
-    const price = await this.fetchExternalPrice();
-    priceCache.set(cacheKey, { price, expires: Date.now() + 60000 });
-  }
-
-  const cached = priceCache.get(cacheKey);
-  if (cached.expires > Date.now()) {
-    // Use cached price
-  }
-}
-```
+1. **Order index** — base price (0–9) → customer/volume pricing (10–19) → tax (20–29) → adjustments (30+).
+2. **Meta for transparency** — record the reason/rate/source in `meta` for debugging and reporting.
+3. **Fail gracefully** — wrap external calls in `try/catch`; never let a pricing adapter throw and break checkout. (For missing configuration, surface it rather than throwing.)
+4. **Cache external lookups** — memoize slow rate/price-list lookups per `(product, currencyCode)`.
 
 ## Related
 
-- [Pricing System](../concepts/pricing-system) - Pricing architecture overview
-- [Order Discounts](../extend/pricing/order-discounts) - Discount system
-- [Product Pricing](../extend/pricing/product-pricing) - Product pricing details
+- [Pricing System](../concepts/pricing-system.md) — architecture and leveled tiers
+- [Plugin Factories](../extend/plugin-factories.md#pricing) — all four pricing factories
+- [Order Discounts](../extend/pricing/order-discounts.md) · [Product Pricing](../extend/pricing/product-pricing.md)

--- a/docs/docs/guides/custom-pricing.md
+++ b/docs/docs/guides/custom-pricing.md
@@ -134,7 +134,11 @@ registerProductPricing({
 The same pattern applies with the matching factory and sheet method:
 
 ```typescript
-import { registerOrderPricing, registerDeliveryPricing, registerPaymentPricing } from '@unchainedshop/core';
+import {
+  OrderPricingSheet,
+  registerDeliveryPricing,
+  registerPaymentPricing,
+} from '@unchainedshop/core';
 
 // Free shipping over 100.00
 registerDeliveryPricing({
@@ -153,7 +157,15 @@ registerPaymentPricing({
   adapterId: 'cash-discount',
   isActivatedFor: (context) => context.provider?.adapterKey === 'shop.unchained.payment.invoice',
   calculate: async (sheet, context) => {
-    sheet.addFee({ amount: -Math.round(context.order.pricing().total().amount * 0.02), isTaxable: false, isNetPrice: true });
+    const orderPricing = OrderPricingSheet({
+      calculation: context.order?.calculation,
+      currencyCode: context.order?.currencyCode,
+    });
+    sheet.addFee({
+      amount: -Math.round(orderPricing.total().amount * 0.02),
+      isTaxable: false,
+      isNetPrice: true,
+    });
   },
 });
 ```

--- a/docs/docs/guides/multi-currency-setup.md
+++ b/docs/docs/guides/multi-currency-setup.md
@@ -205,20 +205,14 @@ WorkerDirector.configureAutoscheduling({
 Create a worker to fetch rates from your preferred provider:
 
 ```typescript
-import { pluginRegistry, WorkerDirector, type IWorkerAdapter } from '@unchainedshop/core';
+import { registerWorker, WorkerDirector } from '@unchainedshop/core';
 
-const ExchangeRateWorker: IWorkerAdapter = {
-  key: 'shop.example.worker.exchange-rates',
-  label: 'Custom Exchange Rate Worker',
-  version: '1.0.0',
+registerWorker<{ baseCurrency: string }, { updated: number }>({
   type: 'UPDATE_EXCHANGE_RATES',
-  external: false,
   maxParallelAllocations: 1,
-
-  async doWork(input, unchainedAPI) {
+  process: async (input) => {
     const { baseCurrency } = input;
 
-    // Fetch rates from your provider (e.g., Open Exchange Rates, Fixer.io)
     const response = await fetch(
       `https://api.exchangerate-api.com/v4/latest/${baseCurrency}`
     );
@@ -232,14 +226,10 @@ const ExchangeRateWorker: IWorkerAdapter = {
       timestamp: Date.now(),
     }));
 
-    // Update rates in database
-    await unchainedAPI.modules.products.prices.rates.updateRates(rates);
-
-    return { success: true, result: { updated: rates.length } };
+    await updateExchangeRates(rates);
+    return { updated: rates.length };
   },
-};
-
-pluginRegistry.register({ key: ExchangeRateWorker.key, label: ExchangeRateWorker.label, version: ExchangeRateWorker.version, adapters: [ExchangeRateWorker] });
+});
 
 // Schedule hourly updates
 WorkerDirector.configureAutoscheduling({
@@ -254,55 +244,34 @@ WorkerDirector.configureAutoscheduling({
 Create a pricing adapter for automatic conversion:
 
 ```typescript
-import {
-  ProductPricingAdapter,
-  ProductPricingDirector,
-} from '@unchainedshop/core-pricing';
+import { registerProductPricing } from '@unchainedshop/core';
 
-class CurrencyConversionAdapter extends ProductPricingAdapter {
-  static key = 'shop.unchained.pricing.currency-conversion';
-  static orderIndex = 1; // Run early
-
-  static isActivatedFor({ currencyCode, product }) {
-    // Only if product has no price in requested currency
-    const hasDirectPrice = product.commerce?.pricing?.some(
-      (p) => p.currencyCode === currencyCode
-    );
-    return !hasDirectPrice;
-  }
-
-  async calculate() {
-    const { product, currencyCode, modules } = this.context;
-
-    // Get base price
-    const basePrice = product.commerce?.pricing?.[0];
-    if (!basePrice) return super.calculate();
-
-    // Get exchange rate
-    const rate = await modules.currencies.getExchangeRate(
+registerProductPricing({
+  adapterId: 'currency-conversion',
+  orderIndex: 1, // run early
+  // only when the product has no direct price in the requested currency
+  isActivatedFor: (context) =>
+    !context.product?.commerce?.pricing?.some((p) => p.currencyCode === context.currencyCode),
+  calculate: async (sheet, context) => {
+    const basePrice = context.product?.commerce?.pricing?.[0];
+    if (!basePrice) return;
+    const rate = await exchangeRateProvider.getRate(
       basePrice.currencyCode,
-      currencyCode
+      context.currencyCode,
     );
-
     if (rate) {
-      this.result.addItem({
+      sheet.addItem({
         amount: Math.round(basePrice.amount * rate),
         isTaxable: basePrice.isTaxable,
         isNetPrice: basePrice.isNetPrice,
-        meta: {
-          adapter: this.constructor.key,
-          convertedFrom: basePrice.currencyCode,
-          rate,
-        },
+        meta: { convertedFrom: basePrice.currencyCode, rate },
       });
     }
-
-    return super.calculate();
-  }
-}
-
-pluginRegistry.register({ key: CurrencyConversionAdapter.key, label: CurrencyConversionAdapter.label, version: CurrencyConversionAdapter.version, adapters: [CurrencyConversionAdapter] });
+  },
+});
 ```
+
+> Most stores use the built-in `ProductPriceRateConversion` plugin (in the `crypto` preset) for this — write a custom adapter only for bespoke conversion logic.
 
 ## Querying Prices
 
@@ -506,33 +475,23 @@ mutation CreateCryptoCurrency {
 ### Crypto Pricing
 
 ```typescript
-class CryptoPricingAdapter extends ProductPricingAdapter {
-  static key = 'shop.unchained.pricing.crypto';
-  static orderIndex: 2;
+import { registerProductPricing } from '@unchainedshop/core';
 
-  static isActivatedFor({ currencyCode }) {
-    return ['ETH', 'BTC', 'USDC'].includes(currencyCode);
-  }
-
-  async calculate() {
-    const { currencyCode, modules } = this.context;
-
-    // Get crypto exchange rate
-    const rate = await fetchCryptoRate(currencyCode);
-
-    // Convert from base currency
-    const baseTotal = this.calculation.sum({ category: 'BASE' });
-
-    this.result.addItem({
-      amount: convertToCrypto(baseTotal, rate, currencyCode),
+registerProductPricing({
+  adapterId: 'crypto',
+  orderIndex: 2,
+  isActivatedFor: (context) => ['ETH', 'BTC', 'USDC'].includes(context.currencyCode),
+  calculate: async (sheet, context) => {
+    const rate = await fetchCryptoRate(context.currencyCode);
+    const baseTotal = sheet.sum({ category: 'BASE' });
+    sheet.addItem({
+      amount: convertToCrypto(baseTotal, rate, context.currencyCode),
       isTaxable: false,
       isNetPrice: true,
       meta: { cryptoRate: rate },
     });
-
-    return super.calculate();
-  }
-}
+  },
+});
 ```
 
 ## Best Practices

--- a/docs/docs/guides/multi-currency-setup.md
+++ b/docs/docs/guides/multi-currency-setup.md
@@ -205,7 +205,7 @@ WorkerDirector.configureAutoscheduling({
 Create a worker to fetch rates from your preferred provider:
 
 ```typescript
-import { WorkerDirector, type IWorkerAdapter } from '@unchainedshop/core';
+import { pluginRegistry, WorkerDirector, type IWorkerAdapter } from '@unchainedshop/core';
 
 const ExchangeRateWorker: IWorkerAdapter = {
   key: 'shop.example.worker.exchange-rates',
@@ -239,7 +239,7 @@ const ExchangeRateWorker: IWorkerAdapter = {
   },
 };
 
-WorkerDirector.registerAdapter(ExchangeRateWorker);
+pluginRegistry.register({ key: ExchangeRateWorker.key, label: ExchangeRateWorker.label, version: ExchangeRateWorker.version, adapters: [ExchangeRateWorker] });
 
 // Schedule hourly updates
 WorkerDirector.configureAutoscheduling({
@@ -301,7 +301,7 @@ class CurrencyConversionAdapter extends ProductPricingAdapter {
   }
 }
 
-ProductPricingDirector.registerAdapter(CurrencyConversionAdapter);
+pluginRegistry.register({ key: CurrencyConversionAdapter.key, label: CurrencyConversionAdapter.label, version: CurrencyConversionAdapter.version, adapters: [CurrencyConversionAdapter] });
 ```
 
 ## Querying Prices

--- a/docs/docs/guides/payment-integration.md
+++ b/docs/docs/guides/payment-integration.md
@@ -275,7 +275,7 @@ DATATRANS_SIGN_KEY=xxx
 Create a custom adapter for payment gateways not covered by built-in plugins:
 
 ```typescript
-import { PaymentDirector, type IPaymentAdapter } from '@unchainedshop/core';
+import { pluginRegistry, type IPaymentAdapter } from '@unchainedshop/core';
 
 const MyPaymentAdapter: IPaymentAdapter = {
   key: 'com.mycompany.payment.custom',
@@ -351,7 +351,7 @@ const MyPaymentAdapter: IPaymentAdapter = {
   },
 };
 
-PaymentDirector.registerAdapter(MyPaymentAdapter);
+pluginRegistry.register({ key: MyPaymentAdapter.key, label: MyPaymentAdapter.label, version: MyPaymentAdapter.version, adapters: [MyPaymentAdapter] });
 ```
 
 ## Testing Payments
@@ -430,7 +430,7 @@ try {
 Add payment processing fees to orders:
 
 ```typescript
-import { PaymentPricingDirector, PaymentPricingAdapter } from '@unchainedshop/core';
+import { pluginRegistry, PaymentPricingAdapter } from '@unchainedshop/core';
 
 class CardFeeAdapter extends PaymentPricingAdapter {
   static key = 'shop.unchained.pricing.card-fee';
@@ -458,7 +458,7 @@ class CardFeeAdapter extends PaymentPricingAdapter {
   }
 }
 
-PaymentPricingDirector.registerAdapter(CardFeeAdapter);
+pluginRegistry.register({ key: CardFeeAdapter.key, label: CardFeeAdapter.label, version: CardFeeAdapter.version, adapters: [CardFeeAdapter] });
 ```
 
 ## Multi-Currency Support

--- a/docs/docs/guides/payment-integration.md
+++ b/docs/docs/guides/payment-integration.md
@@ -22,10 +22,9 @@ flowchart LR
 
 | Provider | Type | Use Case |
 |----------|------|----------|
-| [Stripe](../plugins/payment/stripe.md) | CARD | Credit/debit cards |
-| [Braintree](../plugins/payment/braintree.md) | CARD | Cards, PayPal |
-| [Datatrans](../plugins/payment/datatrans.md) | CARD | Swiss payment gateway |
-| [Saferpay](../plugins/payment/saferpay.md) | CARD | Swiss payment gateway |
+| [Stripe](../plugins/payment/stripe.md) | GENERIC | Credit/debit cards |
+| [Datatrans](../plugins/payment/datatrans.md) | GENERIC | Swiss payment gateway |
+| [Saferpay](../plugins/payment/saferpay.md) | GENERIC | Swiss payment gateway |
 | [Cryptopay](../plugins/payment/cryptopay.md) | GENERIC | Cryptocurrency |
 | [Invoice](../plugins/payment/invoice.md) | INVOICE | Manual invoicing |
 
@@ -275,83 +274,51 @@ DATATRANS_SIGN_KEY=xxx
 Create a custom adapter for payment gateways not covered by built-in plugins:
 
 ```typescript
-import { pluginRegistry, type IPaymentAdapter } from '@unchainedshop/core';
+import {
+  OrderPricingSheet,
+  PaymentError,
+  registerPaymentProvider,
+} from '@unchainedshop/core';
 
-const MyPaymentAdapter: IPaymentAdapter = {
-  key: 'com.mycompany.payment.custom',
-  label: 'My Payment Gateway',
-  version: '1.0.0',
+registerPaymentProvider({
+  adapterId: 'custom-gateway',
+  type: 'GENERIC',
+  configurationError: process.env.MY_GATEWAY_API_KEY
+    ? null
+    : PaymentError.INCOMPLETE_CONFIGURATION,
 
-  typeSupported(type) {
-    return type === 'CARD';
+  // Create a payment session for the front-end SDK
+  sign: async (configuration, context) => {
+    if (!context.order) return null;
+    const pricing = OrderPricingSheet({
+      calculation: context.order.calculation,
+      currencyCode: context.order.currencyCode,
+    });
+    const session = await myGateway.createSession({
+      amount: pricing.total().amount,
+      currency: context.order.currencyCode,
+      orderId: context.order._id,
+    });
+    return session.clientToken;
   },
 
-  actions(params) {
-    const { paymentContext, context } = params;
-    const { order, orderPayment } = paymentContext;
-
-    return {
-      configurationError() {
-        if (!process.env.MY_GATEWAY_API_KEY) {
-          return { code: 'MISSING_API_KEY' };
-        }
-        return null;
-      },
-
-      isActive() {
-        return true;
-      },
-
-      isPayLaterAllowed() {
-        return false; // Require payment before order confirmation
-      },
-
-      async sign() {
-        // Create payment session with gateway
-        const session = await myGateway.createSession({
-          amount: order.pricing().total().amount,
-          currency: order.currency,
-          orderId: order._id,
-        });
-        return session.clientToken;
-      },
-
-      async charge() {
-        // Check if payment is complete
-        const { transactionId } = orderPayment.context || {};
-        if (transactionId) {
-          const payment = await myGateway.getPayment(transactionId);
-          if (payment.status === 'completed') {
-            return { transactionId };
-          }
-        }
-        return false;
-      },
-
-      async cancel() {
-        const { transactionId } = orderPayment;
-        if (transactionId) {
-          await myGateway.refund(transactionId);
-        }
-        return true;
-      },
-
-      async confirm() {
-        return { transactionId: orderPayment.transactionId };
-      },
-
-      async register() {
-        return { token: '' };
-      },
-
-      async validate() {
-        return true;
-      },
-    };
+  // Confirm the charge (here, completed out of band and recorded on orderPayment.context)
+  charge: async (configuration, context) => {
+    const { transactionId } = context.orderPayment?.context || {};
+    if (transactionId) {
+      const payment = await myGateway.getPayment(transactionId);
+      if (payment.status === 'completed') return { transactionId };
+    }
+    return false; // not complete yet → order stays PENDING
   },
-};
 
-pluginRegistry.register({ key: MyPaymentAdapter.key, label: MyPaymentAdapter.label, version: MyPaymentAdapter.version, adapters: [MyPaymentAdapter] });
+  cancel: async (configuration, context) => {
+    if (context.orderPayment?.transactionId) {
+      await myGateway.refund(context.orderPayment.transactionId);
+    }
+    return true;
+  },
+});
 ```
 
 ## Testing Payments
@@ -430,35 +397,21 @@ try {
 Add payment processing fees to orders:
 
 ```typescript
-import { pluginRegistry, PaymentPricingAdapter } from '@unchainedshop/core';
+import { OrderPricingSheet, registerPaymentPricing } from '@unchainedshop/core';
 
-class CardFeeAdapter extends PaymentPricingAdapter {
-  static key = 'shop.unchained.pricing.card-fee';
-  static orderIndex = 0;
-
-  static isActivatedFor({ provider }) {
-    return provider.type === 'CARD';
-  }
-
-  async calculate() {
-    const { order } = this.context;
-    const total = order.pricing().total().amount;
-
-    // 2.9% + 30 cents
-    const fee = Math.round(total * 0.029 + 30);
-
-    this.result.addItem({
-      amount: fee,
-      isTaxable: false,
-      isNetPrice: true,
-      category: 'PAYMENT',
+registerPaymentPricing({
+  adapterId: 'card-fee',
+  isActivatedFor: (context) =>
+    context.provider.adapterKey === 'shop.unchained.payment.stripe',
+  calculate: async (sheet, context) => {
+    const pricing = OrderPricingSheet({
+      calculation: context.order?.calculation,
+      currencyCode: context.order?.currencyCode,
     });
-
-    return super.calculate();
-  }
-}
-
-pluginRegistry.register({ key: CardFeeAdapter.key, label: CardFeeAdapter.label, version: CardFeeAdapter.version, adapters: [CardFeeAdapter] });
+    const total = pricing.total().amount;
+    sheet.addFee({ amount: Math.round(total * 0.029 + 30), isTaxable: false, isNetPrice: true }); // 2.9% + 0.30
+  },
+});
 ```
 
 ## Multi-Currency Support
@@ -466,16 +419,20 @@ pluginRegistry.register({ key: CardFeeAdapter.key, label: CardFeeAdapter.label, 
 Handle multiple currencies:
 
 ```typescript
-async sign() {
-  const { order } = this.paymentContext;
+import { OrderPricingSheet } from '@unchainedshop/core';
 
+async function createCheckoutSession(order) {
+  const pricing = OrderPricingSheet({
+    calculation: order.calculation,
+    currencyCode: order.currencyCode,
+  });
   const session = await stripe.checkout.sessions.create({
     payment_method_types: ['card'],
     line_items: [{
       price_data: {
-        currency: order.currency.toLowerCase(),
+        currency: order.currencyCode.toLowerCase(),
         product_data: { name: `Order ${order.orderNumber}` },
-        unit_amount: order.pricing().total().amount,
+        unit_amount: pricing.total().amount,
       },
       quantity: 1,
     }],

--- a/docs/docs/guides/search-and-filtering.md
+++ b/docs/docs/guides/search-and-filtering.md
@@ -508,66 +508,26 @@ function useUrlFilters() {
 }
 ```
 
-## Custom Filter Adapter
+## External search (Elasticsearch, Algolia, …)
 
-Create a custom filter adapter for advanced search:
+To delegate product search to an external engine, use the [`registerProductSearchFilter`](../extend/plugin-factories.md#filters--search) factory — its `search` callback receives the query and returns the matching product ids:
 
 ```typescript
-import { pluginRegistry, type IFilterAdapter } from '@unchainedshop/core';
+import { registerProductSearchFilter } from '@unchainedshop/core';
 
-const ElasticsearchFilter: IFilterAdapter = {
-  key: 'shop.example.filter.elasticsearch',
-  label: 'Elasticsearch Filter',
-  version: '1.0.0',
-  orderIndex: 0,
-
-  actions(context) {
-    return {
-      async searchProducts(params, options) {
-        const { queryString, filterQuery } = params;
-
-        // Build Elasticsearch query
-        const esQuery = buildESQuery(queryString, filterQuery);
-
-        // Search Elasticsearch
-        const results = await elasticsearch.search({
-          index: 'products',
-          body: esQuery,
-        });
-
-        return {
-          productIds: results.hits.hits.map((hit) => hit._id),
-          totalCount: results.hits.total.value,
-        };
-      },
-
-      async searchAssortments(params, options) {
-        // Similar implementation for assortments
-        return { assortmentIds: [], totalCount: 0 };
-      },
-
-      async aggregateProductIds(params) {
-        // Return product IDs matching filter
-        return [];
-      },
-
-      transformProductSelector(selector, options) {
-        return selector;
-      },
-
-      transformFilterSelector(selector, options) {
-        return selector;
-      },
-
-      transformSortStage(sort, options) {
-        return sort;
-      },
-    };
+registerProductSearchFilter({
+  adapterId: 'elasticsearch',
+  search: async ({ queryString, locale }) => {
+    const results = await elasticsearch.search({
+      index: 'products',
+      body: buildESQuery(queryString, locale),
+    });
+    return results.hits.hits.map((hit) => hit._id);
   },
-};
-
-pluginRegistry.register({ key: ElasticsearchFilter.key, label: ElasticsearchFilter.label, version: ElasticsearchFilter.version, adapters: [ElasticsearchFilter] });
+});
 ```
+
+For custom MongoDB selector / sort logic (rather than an external engine), build a `FilterAdapter` directly — see [Filters](../extend/catalog/filter.md).
 
 ## Performance Tips
 

--- a/docs/docs/guides/search-and-filtering.md
+++ b/docs/docs/guides/search-and-filtering.md
@@ -513,7 +513,7 @@ function useUrlFilters() {
 Create a custom filter adapter for advanced search:
 
 ```typescript
-import { FilterDirector, type IFilterAdapter } from '@unchainedshop/core';
+import { pluginRegistry, type IFilterAdapter } from '@unchainedshop/core';
 
 const ElasticsearchFilter: IFilterAdapter = {
   key: 'shop.example.filter.elasticsearch',
@@ -566,7 +566,7 @@ const ElasticsearchFilter: IFilterAdapter = {
   },
 };
 
-FilterDirector.registerAdapter(ElasticsearchFilter);
+pluginRegistry.register({ key: ElasticsearchFilter.key, label: ElasticsearchFilter.label, version: ElasticsearchFilter.version, adapters: [ElasticsearchFilter] });
 ```
 
 ## Performance Tips

--- a/docs/docs/guides/testing.md
+++ b/docs/docs/guides/testing.md
@@ -49,34 +49,27 @@ node --no-warnings \
 
 ## Unit Testing
 
-Unit tests validate individual functions and adapters in isolation.
+Unit tests validate the behavior callbacks passed to the registration factories. Keep domain logic in named functions, register those functions in boot code, and test them without initializing the global plugin registry.
 
 ### Testing a Custom Plugin
 
 ```typescript
-import { describe, it, assert } from 'node:test';
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
 
-describe('My Custom Payment Adapter', () => {
-  const adapter = MyPaymentAdapter;
+export const charge = async (configuration, context) => {
+  const result = await gateway.charge(context.order);
+  return { transactionId: result.id };
+};
 
-  it('should have correct key', () => {
-    assert.equal(adapter.key, 'shop.example.payment.custom');
-  });
+// Boot code:
+// registerPaymentProvider({ adapterId: 'custom', type: 'GENERIC', charge });
 
-  it('should have correct type', () => {
-    assert.equal(adapter.type, 'GENERIC');
-  });
-
-  it('should support the adapter interface', () => {
-    assert.ok(adapter.initialConfiguration);
-    assert.ok(adapter.actions);
-  });
-
-  it('should validate configuration', () => {
-    const actions = adapter.actions({
-      config: [{ key: 'apiKey', value: 'test-key' }],
-    });
-    assert.ok(actions.isActive());
+describe('custom payment charge', () => {
+  it('returns the gateway transaction id', async () => {
+    gateway.charge = async () => ({ id: 'tx-1' });
+    const result = await charge([], { order: { _id: 'order-1' } });
+    assert.deepEqual(result, { transactionId: 'tx-1' });
   });
 });
 ```
@@ -84,22 +77,24 @@ describe('My Custom Payment Adapter', () => {
 ### Testing a Pricing Plugin
 
 ```typescript
-import { describe, it, assert } from 'node:test';
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
 
-describe('Custom Discount Adapter', () => {
-  it('should calculate 10% discount', () => {
-    const adapter = new MyDiscountAdapter({
-      context: {
-        order: { _id: 'test-order' },
-        orderDiscount: { code: 'SAVE10' },
-      },
-    });
+export const calculateMemberPrice = async (sheet, context) => {
+  if (context.product.tags?.includes('member-price')) {
+    sheet.addItem({ amount: -100, isTaxable: true, isNetPrice: true });
+  }
+};
 
-    const discount = adapter.discountForPricingAdapterKey({
-      pricingAdapterKey: 'shop.unchained.pricing.product-catalog-price',
-    });
+// Boot code:
+// registerProductPricing({ adapterId: 'member-price', calculate: calculateMemberPrice });
 
-    assert.deepEqual(discount, { rate: 0.1 });
+describe('member pricing', () => {
+  it('adds the member discount row', async () => {
+    const rows = [];
+    const sheet = { addItem: (row) => rows.push(row) };
+    await calculateMemberPrice(sheet, { product: { tags: ['member-price'] } });
+    assert.equal(rows[0].amount, -100);
   });
 });
 ```

--- a/docs/docs/migrations.md
+++ b/docs/docs/migrations.md
@@ -11,7 +11,16 @@ All migration instructions are consolidated in a single file:
 
 **[MIGRATION.md](https://github.com/unchainedshop/unchained/blob/master/MIGRATION.md)**
 
-Covers: v2 → v3 and v3 → v4
+Covers: v2 → v3, v3 → v4, and v4 → v5.
+
+## v4 → v5 highlights
+
+The full details (with before/after snippets) are in [MIGRATION.md](https://github.com/unchainedshop/unchained/blob/master/MIGRATION.md#v4--v5-breaking-changes). The breaking changes most likely to affect your code:
+
+- **Plugin registration.** `Director.registerAdapter()` is removed. Register built-ins via the [presets](./platform-configuration/plugin-presets.md) (`registerAllPlugins()`), author custom adapters with the [`registerX()` factories](./extend/plugin-factories.md), or use `pluginRegistry.register()` with a hand-built `IPlugin`.
+- **Leveled pricing.** Catalog price tiers are keyed by `minQuantity` (lower bound; base `= 0`) instead of `maxQuantity`. An automatic, idempotent startup migration converts existing data — but update any code that *writes* prices to use `minQuantity`. See [Leveled Pricing](./concepts/pricing-system.md#leveled-quantity-tier-catalog-pricing).
+- **Events.** Redis / EventBridge transports must be registered explicitly with `setEmitAdapter(RedisEventEmitter())` (no more auto-registration on import).
+- **Auth, admin-ui, dependencies.** Stateless JWT auth (set `UNCHAINED_TOKEN_SECRET`), runtime admin-ui permissions, and several dependency bumps — see the full guide.
 
 ## General Upgrade Process
 

--- a/docs/docs/plugins/delivery/delivery-post.md
+++ b/docs/docs/plugins/delivery/delivery-post.md
@@ -69,7 +69,7 @@ Returns a default delivery estimate. Override in configuration or extend the ada
 For production use, extend or replace this adapter with carrier-specific integrations:
 
 ```typescript
-import { DeliveryDirector } from '@unchainedshop/core';
+import { pluginRegistry } from '@unchainedshop/core';
 
 const SwissPostAdapter = {
   key: 'ch.post.delivery',
@@ -110,7 +110,7 @@ const SwissPostAdapter = {
   },
 };
 
-DeliveryDirector.registerAdapter(SwissPostAdapter);
+pluginRegistry.register({ key: SwissPostAdapter.key, label: SwissPostAdapter.label, version: SwissPostAdapter.version, adapters: [SwissPostAdapter] });
 ```
 
 ## Delivery Pricing

--- a/docs/docs/plugins/delivery/delivery-post.md
+++ b/docs/docs/plugins/delivery/delivery-post.md
@@ -66,51 +66,23 @@ Returns a default delivery estimate. Override in configuration or extend the ada
 
 ## Extending for Real Carriers
 
-For production use, extend or replace this adapter with carrier-specific integrations:
+For production use, register a carrier-specific shipping provider:
 
 ```typescript
-import { pluginRegistry } from '@unchainedshop/core';
+import { registerShippingDelivery } from '@unchainedshop/core';
 
-const SwissPostAdapter = {
-  key: 'ch.post.delivery',
-  label: 'Swiss Post',
-  version: '1.0.0',
-
-  typeSupported: (type) => type === 'SHIPPING',
-
-  actions(config, context) {
-    return {
-      configurationError() { return null; },
-      isActive() { return true; },
-      isAutoReleaseAllowed() { return true; },
-
-      async send() {
-        const { order } = context;
-
-        // Call Swiss Post API
-        const response = await swissPostApi.createShipment({
-          recipient: order.delivery.address,
-          weight: calculateWeight(order.items),
-        });
-
-        return {
-          trackingNumber: response.trackingNumber,
-          trackingUrl: `https://www.post.ch/track?id=${response.trackingNumber}`,
-        };
-      },
-
-      estimatedDeliveryThroughput(warehousingTime) {
-        // Swiss Post typically delivers in 1-2 days
-        return warehousingTime + (2 * 24 * 60 * 60 * 1000);
-      },
-
-      async pickUpLocations() { return []; },
-      async pickUpLocationById() { return null; },
-    };
+registerShippingDelivery({
+  adapterId: 'swiss-post',
+  estimatedDeliveryThroughput: async (warehousingTime) =>
+    warehousingTime + 2 * 24 * 60 * 60 * 1000,
+  send: async (configuration, { order }) => {
+    await swissPostApi.createShipment({
+      recipient: order.delivery.address,
+      weight: calculateWeight(order.items),
+    });
+    return true;
   },
-};
-
-pluginRegistry.register({ key: SwissPostAdapter.key, label: SwissPostAdapter.label, version: SwissPostAdapter.version, adapters: [SwissPostAdapter] });
+});
 ```
 
 ## Delivery Pricing

--- a/docs/docs/plugins/delivery/delivery-send-message.md
+++ b/docs/docs/plugins/delivery/delivery-send-message.md
@@ -107,7 +107,7 @@ Send order details to:
 Configure the `DELIVERY` template in your messaging setup:
 
 ```typescript
-import { MessagingDirector } from '@unchainedshop/core';
+import { pluginRegistry } from '@unchainedshop/core';
 
 const DeliveryTemplate = {
   key: 'DELIVERY',
@@ -136,7 +136,7 @@ const DeliveryTemplate = {
   }),
 };
 
-MessagingDirector.registerAdapter(DeliveryTemplate);
+pluginRegistry.register({ key: DeliveryTemplate.key, label: DeliveryTemplate.label, version: DeliveryTemplate.version, adapters: [DeliveryTemplate] });
 ```
 
 ## Custom Digital Delivery Adapter
@@ -144,7 +144,7 @@ MessagingDirector.registerAdapter(DeliveryTemplate);
 For more complex digital delivery scenarios:
 
 ```typescript
-import { DeliveryDirector, type IDeliveryAdapter } from '@unchainedshop/core';
+import { pluginRegistry, type IDeliveryAdapter } from '@unchainedshop/core';
 
 const DigitalDeliveryAdapter: IDeliveryAdapter = {
   key: 'my-shop.digital-delivery',
@@ -221,7 +221,7 @@ const DigitalDeliveryAdapter: IDeliveryAdapter = {
   },
 };
 
-DeliveryDirector.registerAdapter(DigitalDeliveryAdapter);
+pluginRegistry.register({ key: DigitalDeliveryAdapter.key, label: DigitalDeliveryAdapter.label, version: DigitalDeliveryAdapter.version, adapters: [DigitalDeliveryAdapter] });
 ```
 
 ## Combining with Physical Delivery

--- a/docs/docs/plugins/delivery/delivery-send-message.md
+++ b/docs/docs/plugins/delivery/delivery-send-message.md
@@ -141,87 +141,31 @@ pluginRegistry.register({ key: DeliveryTemplate.key, label: DeliveryTemplate.lab
 
 ## Custom Digital Delivery Adapter
 
-For more complex digital delivery scenarios:
+For more complex digital delivery scenarios, register a shipping provider whose `send` callback prepares the digital assets and queues the message:
 
 ```typescript
-import { pluginRegistry, type IDeliveryAdapter } from '@unchainedshop/core';
+import { registerShippingDelivery } from '@unchainedshop/core';
 
-const DigitalDeliveryAdapter: IDeliveryAdapter = {
-  key: 'my-shop.digital-delivery',
-  label: 'Digital Product Delivery',
-  version: '1.0.0',
+registerShippingDelivery({
+  adapterId: 'digital-delivery',
+  estimatedDeliveryThroughput: async () => 0,
+  send: async (configuration, { order }) => {
+    if (!order) return false;
+    const positions = await orderRepository.findPositions(order._id);
+    const deliveryItems = await createDigitalDeliveryItems(positions, order);
 
-  typeSupported: (type) => type === 'SHIPPING',
-
-  actions(config, context) {
-    return {
-      configurationError() { return null; },
-      isActive() { return true; },
-      isAutoReleaseAllowed() { return true; },
-
-      async send() {
-        const { order, modules } = context;
-        const positions = await modules.orders.positions.findOrderPositions({
-          orderId: order._id,
-        });
-
-        const deliveryItems = [];
-
-        for (const position of positions) {
-          const product = await modules.products.findProduct({
-            productId: position.productId,
-          });
-
-          if (product.type === 'SIMPLE') {
-            // Generate license key
-            const licenseKey = await generateLicenseKey(product, order);
-            deliveryItems.push({
-              product: product.texts?.title,
-              licenseKey,
-            });
-          }
-
-          if (product.meta?.downloadUrl) {
-            // Generate signed download URL
-            const downloadUrl = await generateSignedUrl(
-              product.meta.downloadUrl,
-              { expiresIn: '7d' }
-            );
-            deliveryItems.push({
-              product: product.texts?.title,
-              downloadUrl,
-            });
-          }
-        }
-
-        // Queue delivery email
-        await modules.worker.addWork({
-          type: 'MESSAGE',
-          input: {
-            template: 'DIGITAL_DELIVERY',
-            orderId: order._id,
-            deliveryItems,
-          },
-        });
-
-        return {
-          status: 'DELIVERED',
-          deliveryItems,
-        };
+    await enqueueMessage({
+      type: 'MESSAGE',
+      input: {
+        template: 'DIGITAL_DELIVERY',
+        orderId: order._id,
+        deliveryItems,
       },
+    });
 
-      estimatedDeliveryThroughput() {
-        // Instant delivery
-        return 0;
-      },
-
-      async pickUpLocations() { return []; },
-      async pickUpLocationById() { return null; },
-    };
+    return true;
   },
-};
-
-pluginRegistry.register({ key: DigitalDeliveryAdapter.key, label: DigitalDeliveryAdapter.label, version: DigitalDeliveryAdapter.version, adapters: [DigitalDeliveryAdapter] });
+});
 ```
 
 ## Combining with Physical Delivery

--- a/docs/docs/plugins/delivery/delivery-stores.md
+++ b/docs/docs/plugins/delivery/delivery-stores.md
@@ -144,7 +144,7 @@ mutation SetPickupLocation($deliveryProviderId: ID!, $locationId: ID!) {
 For stores managed in a database or external system:
 
 ```typescript
-import { DeliveryDirector, type IDeliveryAdapter } from '@unchainedshop/core';
+import { pluginRegistry, type IDeliveryAdapter } from '@unchainedshop/core';
 
 const DynamicStoresAdapter: IDeliveryAdapter = {
   key: 'my-shop.dynamic-stores',
@@ -205,7 +205,7 @@ const DynamicStoresAdapter: IDeliveryAdapter = {
   },
 };
 
-DeliveryDirector.registerAdapter(DynamicStoresAdapter);
+pluginRegistry.register({ key: DynamicStoresAdapter.key, label: DynamicStoresAdapter.label, version: DynamicStoresAdapter.version, adapters: [DynamicStoresAdapter] });
 ```
 
 ## Store Locator Integration

--- a/docs/docs/plugins/delivery/delivery-stores.md
+++ b/docs/docs/plugins/delivery/delivery-stores.md
@@ -141,71 +141,32 @@ mutation SetPickupLocation($deliveryProviderId: ID!, $locationId: ID!) {
 
 ## Extending for Dynamic Stores
 
-For stores managed in a database or external system:
+For stores managed in a database or external system, supply a dynamic `locations` callback:
 
 ```typescript
-import { pluginRegistry, type IDeliveryAdapter } from '@unchainedshop/core';
+import { registerPickUpDelivery } from '@unchainedshop/core';
 
-const DynamicStoresAdapter: IDeliveryAdapter = {
-  key: 'my-shop.dynamic-stores',
-  label: 'Dynamic Store Locations',
-  version: '1.0.0',
+registerPickUpDelivery({
+  adapterId: 'dynamic-stores',
+  autoReleaseAllowed: false,
+  locations: async () => {
+    const stores = await storeRepository.findActive();
 
-  typeSupported: (type) => type === 'PICKUP',
-
-  actions(config, context) {
-    const { modules } = context;
-
-    return {
-      configurationError() { return null; },
-      isActive() { return true; },
-      isAutoReleaseAllowed() { return false; },
-
-      async pickUpLocations() {
-        // Fetch from database or external API
-        const stores = await modules.warehousing.findWarehouses({
-          type: 'STORE',
-          isActive: true,
-        });
-
-        return stores.map(store => ({
-          _id: store._id,
-          name: store.name,
-          address: store.address,
-          geoPoint: store.coordinates ? {
-            latitude: store.coordinates.lat,
-            longitude: store.coordinates.lng,
-          } : null,
-        }));
-      },
-
-      async pickUpLocationById(locationId) {
-        const store = await modules.warehousing.findWarehouse({ _id: locationId });
-        if (!store) return null;
-
-        return {
-          _id: store._id,
-          name: store.name,
-          address: store.address,
-        };
-      },
-
-      async send() {
-        // Notify store about pickup order
-        const { order } = context;
-        await notifyStore(order);
-        return { status: 'READY_FOR_PICKUP' };
-      },
-
-      estimatedDeliveryThroughput(warehousingTime) {
-        // Pickup ready same day
-        return warehousingTime;
-      },
-    };
+    return stores.map((store) => ({
+      _id: store._id,
+      name: store.name,
+      address: store.address,
+      geoPoint: store.coordinates
+        ? { latitude: store.coordinates.lat, longitude: store.coordinates.lng }
+        : null,
+    }));
   },
-};
-
-pluginRegistry.register({ key: DynamicStoresAdapter.key, label: DynamicStoresAdapter.label, version: DynamicStoresAdapter.version, adapters: [DynamicStoresAdapter] });
+  estimatedDeliveryThroughput: async (warehousingTime) => warehousingTime,
+  send: async (configuration, { order }) => {
+    await notifyStore(order);
+    return false;
+  },
+});
 ```
 
 ## Store Locator Integration

--- a/docs/docs/plugins/enrollments/enrollment-licensed.md
+++ b/docs/docs/plugins/enrollments/enrollment-licensed.md
@@ -204,7 +204,7 @@ configureGenerateOrderAutoscheduling();
 For custom subscription logic:
 
 ```typescript
-import { EnrollmentDirector, EnrollmentAdapter, type IEnrollmentAdapter } from '@unchainedshop/core';
+import { pluginRegistry, EnrollmentAdapter, type IEnrollmentAdapter } from '@unchainedshop/core';
 
 const CustomEnrollmentAdapter: IEnrollmentAdapter = {
   ...EnrollmentAdapter,
@@ -285,7 +285,7 @@ const CustomEnrollmentAdapter: IEnrollmentAdapter = {
   },
 };
 
-EnrollmentDirector.registerAdapter(CustomEnrollmentAdapter);
+pluginRegistry.register({ key: CustomEnrollmentAdapter.key, label: CustomEnrollmentAdapter.label, version: CustomEnrollmentAdapter.version, adapters: [CustomEnrollmentAdapter] });
 ```
 
 ## Adapter Details

--- a/docs/docs/plugins/enrollments/enrollment-licensed.md
+++ b/docs/docs/plugins/enrollments/enrollment-licensed.md
@@ -201,91 +201,39 @@ configureGenerateOrderAutoscheduling();
 
 ## Extending the Adapter
 
-For custom subscription logic:
+For custom subscription logic, use `registerEnrollment`:
 
 ```typescript
-import { pluginRegistry, EnrollmentAdapter, type IEnrollmentAdapter } from '@unchainedshop/core';
+import { registerEnrollment } from '@unchainedshop/core';
 
-const CustomEnrollmentAdapter: IEnrollmentAdapter = {
-  ...EnrollmentAdapter,
+registerEnrollment({
+  adapterId: 'metered',
+  isActivatedFor: (plan) => plan?.usageCalculationType === 'METERED',
 
-  key: 'my-shop.enrollments.custom',
-  version: '1.0.0',
-  label: 'Custom Subscription',
-
-  isActivatedFor: (productPlan) => {
-    return productPlan?.usageCalculationType === 'METERED';
+  isValidForActivation: async ({ enrollment }) => {
+    const now = Date.now();
+    return (enrollment?.periods || []).some(
+      (period) =>
+        new Date(period.start).getTime() <= now &&
+        new Date(period.end).getTime() >= now,
+    );
   },
 
-  actions: (params) => {
-    const { enrollment, modules } = params;
+  configurationForOrder: async ({ period }, { enrollment }) => {
+    if (!enrollment) return null;
+    const usage = await calculateUsage(enrollment._id, period);
 
     return {
-      ...EnrollmentAdapter.actions(params),
-
-      isValidForActivation: async () => {
-        // Custom validation logic
-        const periods = enrollment?.periods || [];
-        const hasActivePeriod = periods.some(p => {
-          const now = Date.now();
-          return new Date(p.start).getTime() <= now &&
-                 new Date(p.end).getTime() >= now;
-        });
-
-        // Also check payment status
-        const latestOrder = await modules.orders.findOrder({
-          enrollmentId: enrollment._id,
-          sort: { created: -1 },
-        });
-
-        return hasActivePeriod && latestOrder?.status === 'CONFIRMED';
-      },
-
-      isOverdue: async () => {
-        // Check if payment is overdue
-        const gracePeriodDays = 7;
-        const periods = enrollment?.periods || [];
-        const currentPeriod = periods.find(p => {
-          const now = Date.now();
-          return new Date(p.start).getTime() <= now;
-        });
-
-        if (!currentPeriod?.orderId) return false;
-
-        const order = await modules.orders.findOrder({
-          orderId: currentPeriod.orderId,
-        });
-
-        if (order?.status !== 'PENDING') return false;
-
-        const dueDate = new Date(currentPeriod.start);
-        dueDate.setDate(dueDate.getDate() + gracePeriodDays);
-
-        return Date.now() > dueDate.getTime();
-      },
-
-      configurationForOrder: async ({ period }) => {
-        // Custom order generation with usage-based pricing
-        const usage = await calculateUsage(enrollment._id, period);
-
-        return {
-          period,
-          orderContext: { usage },
-          orderPositionTemplates: [{
-            quantity: usage.units,
-            productId: enrollment.productId,
-            originalProductId: enrollment.productId,
-            configuration: [
-              { key: 'usageUnits', value: String(usage.units) },
-            ],
-          }],
-        };
-      },
+      orderContext: { usage },
+      orderPositionTemplates: [{
+        quantity: usage.units,
+        productId: enrollment.productId,
+        originalProductId: enrollment.productId,
+        configuration: [{ key: 'usageUnits', value: String(usage.units) }],
+      }],
     };
   },
-};
-
-pluginRegistry.register({ key: CustomEnrollmentAdapter.key, label: CustomEnrollmentAdapter.label, version: CustomEnrollmentAdapter.version, adapters: [CustomEnrollmentAdapter] });
+});
 ```
 
 ## Adapter Details

--- a/docs/docs/plugins/files/file-minio.md
+++ b/docs/docs/plugins/files/file-minio.md
@@ -9,25 +9,22 @@ description: S3-compatible file storage with MinIO or Amazon S3
 
 S3-compatible object storage using the MinIO client, supporting both MinIO and Amazon S3.
 
-:::warning GridFS Conflict
-If you're using a preset that includes GridFS (like `base` or `all`), you must unregister the GridFS adapter before using MinIO:
-
-```typescript
-import { FileDirector } from '@unchainedshop/file-upload';
-import '@unchainedshop/plugins/files/minio';
-
-// Unregister GridFS adapter loaded by presets
-FileDirector.unregisterAdapter('shop.unchained.file-upload-plugin.gridfs');
-```
+:::warning One file backend at a time
+The active file backend is the **first registered** file adapter. The `base` / `all` presets register GridFS, so to use Minio/S3 you must register `MinioPlugin` **instead of** GridFS — don't register both. If you rely on `registerBasePlugins()` (which registers GridFS), register your plugins individually instead, omitting `GridFSPlugin`.
 :::
 
 ## Installation
 
+Register the plugin in your boot code, before `startPlatform()`:
+
 ```typescript
-import '@unchainedshop/plugins/files/minio';
+import { pluginRegistry } from '@unchainedshop/core';
+import { MinioPlugin } from '@unchainedshop/plugins/files/minio';
+
+pluginRegistry.register(MinioPlugin);
 ```
 
-The plugin automatically registers when environment variables are configured.
+Configure the backend with the environment variables below.
 
 ## Environment Variables
 

--- a/docs/docs/plugins/filters/filter-local-search.md
+++ b/docs/docs/plugins/filters/filter-local-search.md
@@ -168,63 +168,34 @@ MongoDB applies stemming based on language:
 
 ## Custom Search Adapter
 
-For external search services:
+For external search services, register a search callback instead of building a filter adapter by hand:
 
 ```typescript
-import { pluginRegistry, FilterAdapter, type IFilterAdapter } from '@unchainedshop/core';
+import {
+  registerAssortmentSearchFilter,
+  registerProductSearchFilter,
+} from '@unchainedshop/core';
 
-const AlgoliaSearchAdapter: IFilterAdapter = {
-  ...FilterAdapter,
+const productIndex = algoliaClient.initIndex('products');
+const assortmentIndex = algoliaClient.initIndex('assortments');
 
-  key: 'my-shop.algolia-search',
-  label: 'Algolia Search',
-  version: '1.0.0',
+registerProductSearchFilter({
+  adapterId: 'algolia',
   orderIndex: 10,
-
-  actions: (params) => {
-    const { searchQuery, modules } = params;
-
-    return {
-      ...FilterAdapter.actions(params),
-
-      async searchProducts({ productIds }) {
-        const { queryString } = searchQuery;
-        if (!queryString) return productIds;
-
-        const algoliaClient = algoliasearch(
-          process.env.ALGOLIA_APP_ID,
-          process.env.ALGOLIA_API_KEY
-        );
-        const index = algoliaClient.initIndex('products');
-
-        const { hits } = await index.search(queryString, {
-          filters: productIds
-            ? `productId:${productIds.join(' OR productId:')}`
-            : undefined,
-          hitsPerPage: 1000,
-        });
-
-        return hits.map(hit => hit.productId);
-      },
-
-      async searchAssortments({ assortmentIds }) {
-        const { queryString } = searchQuery;
-        if (!queryString) return assortmentIds;
-
-        const algoliaClient = algoliasearch(
-          process.env.ALGOLIA_APP_ID,
-          process.env.ALGOLIA_API_KEY
-        );
-        const index = algoliaClient.initIndex('assortments');
-
-        const { hits } = await index.search(queryString);
-        return hits.map(hit => hit.assortmentId);
-      },
-    };
+  search: async ({ queryString }) => {
+    const { hits } = await productIndex.search(queryString, { hitsPerPage: 1000 });
+    return hits.map((hit) => hit.productId);
   },
-};
+});
 
-pluginRegistry.register({ key: AlgoliaSearchAdapter.key, label: AlgoliaSearchAdapter.label, version: AlgoliaSearchAdapter.version, adapters: [AlgoliaSearchAdapter] });
+registerAssortmentSearchFilter({
+  adapterId: 'algolia',
+  orderIndex: 10,
+  search: async ({ queryString }) => {
+    const { hits } = await assortmentIndex.search(queryString);
+    return hits.map((hit) => hit.assortmentId);
+  },
+});
 ```
 
 ## Performance Considerations

--- a/docs/docs/plugins/filters/filter-local-search.md
+++ b/docs/docs/plugins/filters/filter-local-search.md
@@ -171,7 +171,7 @@ MongoDB applies stemming based on language:
 For external search services:
 
 ```typescript
-import { FilterDirector, FilterAdapter, type IFilterAdapter } from '@unchainedshop/core';
+import { pluginRegistry, FilterAdapter, type IFilterAdapter } from '@unchainedshop/core';
 
 const AlgoliaSearchAdapter: IFilterAdapter = {
   ...FilterAdapter,
@@ -224,7 +224,7 @@ const AlgoliaSearchAdapter: IFilterAdapter = {
   },
 };
 
-FilterDirector.registerAdapter(AlgoliaSearchAdapter);
+pluginRegistry.register({ key: AlgoliaSearchAdapter.key, label: AlgoliaSearchAdapter.label, version: AlgoliaSearchAdapter.version, adapters: [AlgoliaSearchAdapter] });
 ```
 
 ## Performance Considerations

--- a/docs/docs/plugins/quotations/quotation-manual.md
+++ b/docs/docs/plugins/quotations/quotation-manual.md
@@ -114,7 +114,7 @@ mutation AcceptQuotation {
 For custom quotation logic:
 
 ```typescript
-import { QuotationDirector, QuotationAdapter, type IQuotationAdapter } from '@unchainedshop/core';
+import { pluginRegistry, QuotationAdapter, type IQuotationAdapter } from '@unchainedshop/core';
 
 const CustomQuotationAdapter: IQuotationAdapter = {
   ...QuotationAdapter,
@@ -155,7 +155,7 @@ const CustomQuotationAdapter: IQuotationAdapter = {
   },
 };
 
-QuotationDirector.registerAdapter(CustomQuotationAdapter);
+pluginRegistry.register({ key: CustomQuotationAdapter.key, label: CustomQuotationAdapter.label, version: CustomQuotationAdapter.version, adapters: [CustomQuotationAdapter] });
 ```
 
 ## Adapter Details

--- a/docs/docs/plugins/quotations/quotation-manual.md
+++ b/docs/docs/plugins/quotations/quotation-manual.md
@@ -111,51 +111,26 @@ mutation AcceptQuotation {
 
 ## Extending the Adapter
 
-For custom quotation logic:
+For custom quotation logic, use `registerQuotation`:
 
 ```typescript
-import { pluginRegistry, QuotationAdapter, type IQuotationAdapter } from '@unchainedshop/core';
+import { registerQuotation } from '@unchainedshop/core';
 
-const CustomQuotationAdapter: IQuotationAdapter = {
-  ...QuotationAdapter,
-
-  key: 'my-shop.quotations.custom',
-  version: '1.0.0',
-  label: 'Custom Quotations',
-  orderIndex: 0,
-
-  isActivatedFor: (product) => {
-    // Only activate for specific products
-    return product?.meta?.quotationEnabled === true;
-  },
-
-  actions: (params) => {
-    const { quotation, modules } = params;
+registerQuotation({
+  adapterId: 'bulk-pricing',
+  quote: async ({ quotation }) => {
+    if (!quotation) return {};
+    const quantity =
+      Number(quotation.configuration?.find((entry) => entry.key === 'quantity')?.value) || 1;
+    const basePrice = await catalogPriceFor(quotation.productId, quotation.currencyCode);
+    const discount = quantity > 100 ? 0.15 : quantity > 50 ? 0.1 : 0.05;
 
     return {
-      ...QuotationAdapter.actions(params),
-
-      quote: async () => {
-        // Custom logic to calculate quote
-        const product = await modules.products.findProduct({
-          productId: quotation.productId,
-        });
-
-        // Auto-calculate bulk discount
-        const quantity = quotation.configuration?.find(c => c.key === 'quantity')?.value || 1;
-        const basePrice = product?.commerce?.pricing?.[0]?.amount || 0;
-        const discount = quantity > 100 ? 0.15 : quantity > 50 ? 0.10 : 0.05;
-
-        return {
-          expires: new Date(Date.now() + 24 * 60 * 60 * 1000), // 24 hours
-          price: Math.round(basePrice * quantity * (1 - discount)),
-        };
-      },
+      expires: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      price: Math.round(basePrice * quantity * (1 - discount)),
     };
   },
-};
-
-pluginRegistry.register({ key: CustomQuotationAdapter.key, label: CustomQuotationAdapter.label, version: CustomQuotationAdapter.version, adapters: [CustomQuotationAdapter] });
+});
 ```
 
 ## Adapter Details

--- a/docs/docs/plugins/warehousing/warehousing-eth-minter.md
+++ b/docs/docs/plugins/warehousing/warehousing-eth-minter.md
@@ -281,7 +281,7 @@ const CustomMinterAdapter: IWarehousingAdapter = {
   },
 };
 
-WarehousingDirector.registerAdapter(CustomMinterAdapter);
+pluginRegistry.register({ key: CustomMinterAdapter.key, label: CustomMinterAdapter.label, version: CustomMinterAdapter.version, adapters: [CustomMinterAdapter] });
 ```
 
 ## Querying Tokens

--- a/docs/docs/plugins/warehousing/warehousing-eth-minter.md
+++ b/docs/docs/plugins/warehousing/warehousing-eth-minter.md
@@ -211,77 +211,33 @@ for (const token of tokens) {
 
 ## Custom Minting Adapter
 
-For custom blockchain integrations:
+For custom blockchain integrations, use `registerVirtualWarehousing`:
 
 ```typescript
-import {
-  WarehousingDirector,
-  WarehousingAdapter,
-  type IWarehousingAdapter
-} from '@unchainedshop/core';
+import { registerVirtualWarehousing } from '@unchainedshop/core';
 
-const CustomMinterAdapter: IWarehousingAdapter = {
-  ...WarehousingAdapter,
-
-  key: 'my-shop.custom-minter',
-  label: 'Custom NFT Minter',
-  version: '1.0.0',
-
-  typeSupported: (type) => type === 'VIRTUAL',
-
-  actions(configuration, context) {
-    const { product, orderPosition } = context;
-
-    return {
-      ...WarehousingAdapter.actions(configuration, context),
-
-      isActive() {
-        return product?.type === 'TOKENIZED_PRODUCT';
-      },
-
-      configurationError() {
-        if (!process.env.MINTER_PRIVATE_KEY) {
-          return { code: 'MISSING_MINTER_KEY' };
-        }
-        return null;
-      },
-
-      async stock() {
-        // Check on-chain supply
-        const totalSupply = await contract.totalSupply();
-        const maxSupply = await contract.maxSupply();
-        return maxSupply - totalSupply;
-      },
-
-      async tokenize() {
-        const { contractAddress, tokenId } = product.tokenization;
-
-        // Mint on-chain
-        const tx = await contract.mint(
-          orderPosition.quantity,
-          { gasLimit: 500000 }
-        );
-        const receipt = await tx.wait();
-
-        // Extract token IDs from events
-        const mintEvents = receipt.events.filter(e => e.event === 'Transfer');
-
-        return mintEvents.map(event => ({
-          _id: generateDbObjectId(),
-          tokenSerialNumber: event.args.tokenId.toString(),
-          contractAddress,
-          quantity: 1,
-          meta: {
-            txHash: tx.hash,
-            blockNumber: receipt.blockNumber,
-          },
-        }));
-      },
-    };
+registerVirtualWarehousing({
+  adapterId: 'custom-minter',
+  stock: async () => {
+    const totalSupply = await contract.totalSupply();
+    const maxSupply = await contract.maxSupply();
+    return maxSupply - totalSupply;
   },
-};
+  tokenize: async (configuration, { product, orderPosition }) => {
+    const tx = await contract.mint(orderPosition.quantity, { gasLimit: 500000 });
+    const receipt = await tx.wait();
 
-pluginRegistry.register({ key: CustomMinterAdapter.key, label: CustomMinterAdapter.label, version: CustomMinterAdapter.version, adapters: [CustomMinterAdapter] });
+    return receipt.events
+      .filter((event) => event.event === 'Transfer')
+      .map((event) => ({
+        _id: crypto.randomUUID(),
+        tokenSerialNumber: event.args.tokenId.toString(),
+        contractAddress: product.tokenization.contractAddress,
+        quantity: 1,
+        meta: { txHash: tx.hash, blockNumber: receipt.blockNumber },
+      }));
+  },
+});
 ```
 
 ## Querying Tokens

--- a/docs/docs/plugins/warehousing/warehousing-store.md
+++ b/docs/docs/plugins/warehousing/warehousing-store.md
@@ -92,93 +92,38 @@ For small shops where inventory is managed manually outside the system.
 Where stock is always available from suppliers:
 
 ```typescript
-const DropShipAdapter = {
-  ...StoreAdapter,
-  key: 'my-shop.dropship',
-  label: 'Drop Ship',
+import { registerPhysicalWarehousing } from '@unchainedshop/core';
 
-  actions(config, context) {
-    return {
-      ...StoreAdapter.actions(config, context),
-
-      async stock() {
-        // Always available from supplier
-        return 99999;
-      },
-
-      async commissioningTime() {
-        // Supplier needs 2-3 days to ship
-        return 3 * 24 * 60 * 60 * 1000;
-      },
-    };
-  },
-};
+registerPhysicalWarehousing({
+  adapterId: 'dropship',
+  stock: 99999,
+  commissioningTime: 3 * 24 * 60 * 60 * 1000,
+});
 ```
 
 ## Extending for Real Inventory
 
-For production use, extend with actual inventory tracking:
+For production use, pass inventory callbacks to `registerPhysicalWarehousing`:
 
 ```typescript
-import {
-  WarehousingDirector,
-  WarehousingAdapter,
-  type IWarehousingAdapter
-} from '@unchainedshop/core';
+import { registerPhysicalWarehousing } from '@unchainedshop/core';
 
-const RealStoreAdapter: IWarehousingAdapter = {
-  ...WarehousingAdapter,
-
-  key: 'my-shop.real-store',
-  label: 'Real Store Inventory',
-  version: '1.0.0',
+registerPhysicalWarehousing({
+  adapterId: 'real-store',
   orderIndex: 0,
-
-  typeSupported: (type) => type === 'PHYSICAL',
-
-  actions(configuration, context) {
-    const { product, modules } = context;
-
-    return {
-      ...WarehousingAdapter.actions(configuration, context),
-
-      isActive() {
-        return true;
-      },
-
-      configurationError() {
-        return null;
-      },
-
-      async stock() {
-        // Get stock from product warehousing data
-        const sku = product?.warehousing?.sku;
-        if (!sku) return 0;
-
-        // Query your inventory system
-        const inventory = await db.collection('inventory').findOne({ sku });
-        return inventory?.quantity || 0;
-      },
-
-      async productionTime() {
-        const currentStock = await this.stock();
-        if (currentStock > 0) return 0;
-
-        // Out of stock - check backorder time
-        const sku = product?.warehousing?.sku;
-        const supplier = await getSupplierLeadTime(sku);
-        return supplier.leadTimeDays * 24 * 60 * 60 * 1000;
-      },
-
-      async commissioningTime() {
-        // Standard picking and packing time: 4 hours
-        return 4 * 60 * 60 * 1000;
-      },
-    };
+  stock: async (referenceDate, configuration, { product }) => {
+    const sku = product?.warehousing?.sku;
+    if (!sku) return 0;
+    const inventory = await db.collection('inventory').findOne({ sku });
+    return inventory?.quantity || 0;
   },
-};
-
-pluginRegistry.register({ key: RealStoreAdapter.key, label: RealStoreAdapter.label, version: RealStoreAdapter.version, adapters: [RealStoreAdapter] });
+  productionTime: async (quantity, configuration, { product }) => {
+    const sku = product?.warehousing?.sku;
+    const supplier = await getSupplierLeadTime(sku);
+    return supplier.leadTimeDays * 24 * 60 * 60 * 1000;
+  },
+  commissioningTime: 4 * 60 * 60 * 1000,
+});
 ```
 
 ## Integration with Delivery

--- a/docs/docs/plugins/warehousing/warehousing-store.md
+++ b/docs/docs/plugins/warehousing/warehousing-store.md
@@ -178,7 +178,7 @@ const RealStoreAdapter: IWarehousingAdapter = {
   },
 };
 
-WarehousingDirector.registerAdapter(RealStoreAdapter);
+pluginRegistry.register({ key: RealStoreAdapter.key, label: RealStoreAdapter.label, version: RealStoreAdapter.version, adapters: [RealStoreAdapter] });
 ```
 
 ## Integration with Delivery

--- a/docs/docs/troubleshooting/faq.md
+++ b/docs/docs/troubleshooting/faq.md
@@ -101,7 +101,7 @@ See [Extending GraphQL](../extend/graphql) for details.
 Create a payment adapter and register it:
 
 ```typescript
-import { PaymentDirector } from '@unchainedshop/core';
+import { pluginRegistry } from '@unchainedshop/core';
 
 const MyPaymentAdapter = {
   key: 'my-payment',
@@ -113,7 +113,7 @@ const MyPaymentAdapter = {
   }),
 };
 
-PaymentDirector.registerAdapter(MyPaymentAdapter);
+pluginRegistry.register({ key: MyPaymentAdapter.key, label: MyPaymentAdapter.label, version: MyPaymentAdapter.version, adapters: [MyPaymentAdapter] });
 ```
 
 See [Payment Plugins](../extend/order-fulfilment/fulfilment-plugins/payment).
@@ -141,7 +141,7 @@ await startPlatform({ expressApp: app });
 Use the Worker system:
 
 ```typescript
-import { WorkerDirector } from '@unchainedshop/core';
+import { pluginRegistry } from '@unchainedshop/core';
 
 // Schedule a job
 await modules.worker.addWork({
@@ -290,7 +290,7 @@ class MyPricingAdapter extends ProductPricingAdapter {
   }
 }
 
-ProductPricingDirector.registerAdapter(MyPricingAdapter);
+pluginRegistry.register({ key: MyPricingAdapter.key, label: MyPricingAdapter.label, version: MyPricingAdapter.version, adapters: [MyPricingAdapter] });
 ```
 
 ### How do I handle multiple currencies?

--- a/docs/docs/troubleshooting/faq.md
+++ b/docs/docs/troubleshooting/faq.md
@@ -98,22 +98,19 @@ See [Extending GraphQL](../extend/graphql) for details.
 
 ### How do I add a custom payment provider?
 
-Create a payment adapter and register it:
+Use the payment provider factory:
 
 ```typescript
-import { pluginRegistry } from '@unchainedshop/core';
+import { registerPaymentProvider } from '@unchainedshop/core';
 
-const MyPaymentAdapter = {
-  key: 'my-payment',
-  label: 'My Payment',
-  version: '1.0.0',
-  typeSupported: (type) => type === 'CARD',
-  actions: (params) => ({
-    // ... implement methods
-  }),
-};
-
-pluginRegistry.register({ key: MyPaymentAdapter.key, label: MyPaymentAdapter.label, version: MyPaymentAdapter.version, adapters: [MyPaymentAdapter] });
+registerPaymentProvider({
+  adapterId: 'my-payment',
+  type: 'GENERIC',
+  charge: async (configuration, context) => {
+    const result = await gateway.charge(context.order);
+    return { transactionId: result.id };
+  },
+});
 ```
 
 See [Payment Plugins](../extend/order-fulfilment/fulfilment-plugins/payment).
@@ -274,24 +271,21 @@ See [Pricing System](../concepts/pricing-system).
 
 ### How do I implement custom pricing logic?
 
-Create a pricing adapter:
+Use the `registerProductPricing` factory:
 
 ```typescript
-class MyPricingAdapter extends ProductPricingAdapter {
-  static key = 'my-pricing';
-  static orderIndex = 10;
+import { registerProductPricing } from '@unchainedshop/core';
 
-  async calculate() {
-    this.result.addItem({
-      amount: 100,
-      category: 'DISCOUNT',
-    });
-    return super.calculate();
-  }
-}
-
-pluginRegistry.register({ key: MyPricingAdapter.key, label: MyPricingAdapter.label, version: MyPricingAdapter.version, adapters: [MyPricingAdapter] });
+registerProductPricing({
+  adapterId: 'my-pricing',
+  orderIndex: 10,
+  calculate: async (sheet, context) => {
+    sheet.addItem({ amount: -100, isTaxable: true, isNetPrice: true, category: 'DISCOUNT' });
+  },
+});
 ```
+
+See [Custom Pricing](../guides/custom-pricing.md) and [Plugin Factories](../extend/plugin-factories.md#pricing).
 
 ### How do I handle multiple currencies?
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -101,6 +101,7 @@ const sidebars = {
           items: [
             'extend/graphql',
             'extend/custom-modules',
+            'extend/plugin-factories',
             {
               type: 'category',
               label: 'Order Fulfilment',

--- a/packages/api/src/mcp/tools/product/schemas.ts
+++ b/packages/api/src/mcp/tools/product/schemas.ts
@@ -95,11 +95,14 @@ export const ProductSchema = z.object({
         .array(
           z.object({
             amount: z.number().int().describe('Price amount in smallest currency unit.'),
-            maxQuantity: z
+            minQuantity: z
               .number()
               .int()
+              .min(0)
               .optional()
-              .describe('Optional maximum quantity for this price tier'),
+              .describe(
+                'Optional inclusive minimum quantity (tier floor) this price applies to; defaults to the base tier (0).',
+              ),
             isTaxable: z.boolean().optional().describe('Whether tax applies to this price'),
             isNetPrice: z.boolean().optional().describe('Whether this is a net price (without tax)'),
             currencyCode: z

--- a/packages/api/src/resolvers/mutations/products/updateProductCommerce.ts
+++ b/packages/api/src/resolvers/mutations/products/updateProductCommerce.ts
@@ -23,7 +23,19 @@ export default async function updateProductCommerce(
     });
   }
 
-  await modules.products.update(productId, { commerce });
+  // Normalize quantity tiers: an omitted minQuantity is the base tier (0);
+  // an explicit floor must be >= 0.
+  const normalizedCommerce: ProductCommerce = {
+    ...commerce,
+    pricing: commerce?.pricing?.map((priceLevel) => {
+      if (priceLevel.minQuantity != null && priceLevel.minQuantity < 0) {
+        throw new Error('minQuantity must be greater than or equal to 0');
+      }
+      return { ...priceLevel, minQuantity: priceLevel.minQuantity ?? 0 };
+    }),
+  };
+
+  await modules.products.update(productId, { commerce: normalizedCommerce });
 
   return modules.products.findProduct({ productId });
 }

--- a/packages/api/src/resolvers/type/product/product-plan-types.ts
+++ b/packages/api/src/resolvers/type/product/product-plan-types.ts
@@ -71,7 +71,7 @@ export const PlanProduct = {
   ): Promise<
     {
       minQuantity: number;
-      maxQuantity: number;
+      maxQuantity: number | null;
       price: ProductPrice;
     }[]
   > {

--- a/packages/api/src/schema/inputTypes.ts
+++ b/packages/api/src/schema/inputTypes.ts
@@ -105,7 +105,7 @@ export default [
 
     input UpdateProductCommercePricingInput {
       amount: Int!
-      maxQuantity: Int
+      minQuantity: Int
       isTaxable: Boolean
       isNetPrice: Boolean
       currencyCode: String!

--- a/packages/api/src/schema/types/product/product.ts
+++ b/packages/api/src/schema/types/product/product.ts
@@ -139,7 +139,7 @@ export default [
       country: Country!
       currency: Currency!
       amount: Int!
-      maxQuantity: Int
+      minQuantity: Int
     }
 
     union ConfigurableOrBundleProduct = BundleProduct | ConfigurableProduct

--- a/packages/core-products/src/db/ProductsCollection.ts
+++ b/packages/core-products/src/db/ProductsCollection.ts
@@ -63,7 +63,10 @@ export interface ProductPrice extends Price {
   isTaxable?: boolean;
   isNetPrice?: boolean;
   countryCode: string;
-  maxQuantity?: number;
+  // Lower bound (inclusive) of the quantity tier this price applies to. `0` (or
+  // absent on legacy data) is the base tier. The tier runs until the next
+  // tier's minQuantity; the highest minQuantity tier is open-ended.
+  minQuantity?: number;
 }
 
 export interface ProductPriceRange {

--- a/packages/core-products/src/migrations/20260611120000-pricing-maxquantity-to-minquantity.ts
+++ b/packages/core-products/src/migrations/20260611120000-pricing-maxquantity-to-minquantity.ts
@@ -1,0 +1,87 @@
+import { createLogger } from '@unchainedshop/logger';
+import type { MigrationRepository } from '@unchainedshop/mongodb';
+import { ProductsCollection, type ProductPrice } from '../db/ProductsCollection.ts';
+
+const logger = createLogger('unchained:core-products:migrations');
+
+type LegacyProductPrice = ProductPrice & { maxQuantity?: number };
+
+/**
+ * Selector matching products that still carry at least one quantity tier without
+ * a `minQuantity` floor (legacy `maxQuantity`-keyed or bare base tiers). The
+ * migration is a no-op once every tier has a `minQuantity`, so it is safe to re-run.
+ */
+const UNMIGRATED_PRICING_SELECTOR = {
+  'commerce.pricing': { $elemMatch: { minQuantity: { $exists: false } } },
+};
+
+/**
+ * Convert a product's quantity-tier pricing from the inclusive-upper-bound
+ * `maxQuantity` model to the lower-bound `minQuantity` model.
+ *
+ * Tiers are grouped per (countryCode, currencyCode) and sorted ascending by
+ * `maxQuantity` with a falsy/absent `maxQuantity` treated as the open-ended top
+ * tier (sorts last). The lowest tier becomes `minQuantity: 0` (base) and every
+ * subsequent tier's floor is the previous tier's `maxQuantity + 1`.
+ */
+const convertPricingToMinQuantity = (pricing: LegacyProductPrice[] = []): ProductPrice[] => {
+  const groups = new Map<string, LegacyProductPrice[]>();
+  for (const level of pricing) {
+    const key = `${level.countryCode}:${level.currencyCode}`;
+    const group = groups.get(key);
+    if (group) group.push(level);
+    else groups.set(key, [level]);
+  }
+
+  const nextPricing: ProductPrice[] = [];
+  for (const levels of groups.values()) {
+    const sorted = [...levels].sort(
+      (a, b) =>
+        (a.maxQuantity || Number.POSITIVE_INFINITY) - (b.maxQuantity || Number.POSITIVE_INFINITY),
+    );
+
+    const seenMax = new Set<number>();
+    let previousMax = 0;
+    sorted.forEach((level, index) => {
+      if (level.maxQuantity) {
+        if (seenMax.has(level.maxQuantity)) {
+          logger.warn(
+            `Duplicate maxQuantity ${level.maxQuantity} for ${level.countryCode}/${level.currencyCode} — order resolved by stable sort`,
+          );
+        }
+        seenMax.add(level.maxQuantity);
+      }
+      const { maxQuantity, ...rest } = level;
+      nextPricing.push({ ...rest, minQuantity: index === 0 ? 0 : previousMax + 1 });
+      previousMax = maxQuantity || previousMax;
+    });
+  }
+  return nextPricing;
+};
+
+export default function migrateCommercePricingToMinQuantity(repository: MigrationRepository) {
+  repository?.register({
+    id: 20260611120000,
+    name: 'Convert product commerce pricing tiers from maxQuantity to minQuantity',
+    up: async () => {
+      const { Products } = await ProductsCollection(repository.db);
+
+      let migrated = 0;
+      const cursor = Products.find(UNMIGRATED_PRICING_SELECTOR);
+      for await (const product of cursor) {
+        const nextPricing = convertPricingToMinQuantity(
+          (product.commerce?.pricing ?? []) as LegacyProductPrice[],
+        );
+        await Products.updateOne(
+          { _id: product._id },
+          { $set: { 'commerce.pricing': nextPricing } },
+        );
+        migrated += 1;
+      }
+
+      if (migrated > 0) {
+        logger.info(`Converted commerce pricing tiers to minQuantity on ${migrated} product(s)`);
+      }
+    },
+  });
+}

--- a/packages/core-products/src/migrations/20260611120000-pricing-maxquantity-to-minquantity.ts
+++ b/packages/core-products/src/migrations/20260611120000-pricing-maxquantity-to-minquantity.ts
@@ -72,10 +72,7 @@ export default function migrateCommercePricingToMinQuantity(repository: Migratio
         const nextPricing = convertPricingToMinQuantity(
           (product.commerce?.pricing ?? []) as LegacyProductPrice[],
         );
-        await Products.updateOne(
-          { _id: product._id },
-          { $set: { 'commerce.pricing': nextPricing } },
-        );
+        await Products.updateOne({ _id: product._id }, { $set: { 'commerce.pricing': nextPricing } });
         migrated += 1;
       }
 

--- a/packages/core-products/src/mock/product.ts
+++ b/packages/core-products/src/mock/product.ts
@@ -11,7 +11,7 @@ export default {
     pricing: [
       {
         amount: 1000,
-        maxQuantity: null,
+        minQuantity: 3,
         isTaxable: false,
         isNetPrice: false,
         currencyCode: 'CHF',
@@ -19,7 +19,7 @@ export default {
       },
       {
         amount: 20000,
-        maxQuantity: 2,
+        minQuantity: 0,
         isTaxable: true,
         isNetPrice: true,
         currencyCode: 'ETB',
@@ -27,7 +27,7 @@ export default {
       },
       {
         amount: 1,
-        maxQuantity: 1,
+        minQuantity: 0,
         isTaxable: false,
         isNetPrice: false,
         currencyCode: 'ETH',
@@ -35,7 +35,7 @@ export default {
       },
       {
         amount: 750,
-        maxQuantity: 2,
+        minQuantity: 0,
         isTaxable: false,
         isNetPrice: false,
         currencyCode: 'CHF',

--- a/packages/core-products/src/module/configureProductPrices.ts
+++ b/packages/core-products/src/module/configureProductPrices.ts
@@ -63,7 +63,13 @@ export const configureProductPricesModule = ({
       countryCode,
     });
 
-    const foundPrice = pricing.find((level) => !level.maxQuantity || level.maxQuantity >= quantity);
+    // Tiers are sorted ascending by minQuantity; the applicable tier is the
+    // highest floor that is <= quantity. The base tier has minQuantity 0, so the
+    // default quantity 0 used by price-range queries resolves to it. Tiers
+    // without a floor (legacy, un-migrated data) are ignored rather than mispriced.
+    const foundPrice = pricing
+      .filter((level) => level.minQuantity != null && level.minQuantity <= quantity)
+      .pop();
     if (!foundPrice) return null;
 
     const normalizedPrice = {
@@ -138,29 +144,23 @@ export const configureProductPricesModule = ({
     ): Promise<
       {
         minQuantity: number;
-        maxQuantity: number;
+        maxQuantity: number | null;
         price: ProductPrice;
       }[]
     > => {
-      let previousMax: number | undefined;
-
-      const filteredAndSortedPriceLevels = getPriceLevels({
+      const sortedPriceLevels = getPriceLevels({
         product,
         currencyCode,
         countryCode,
       });
 
-      return filteredAndSortedPriceLevels.map((priceLevel, i) => {
-        const max = priceLevel.maxQuantity || 0;
-        const min = previousMax ? previousMax + 1 : 0;
-        previousMax = priceLevel.maxQuantity;
-
+      return sortedPriceLevels.map((priceLevel, i) => {
+        const nextLevel = sortedPriceLevels[i + 1];
+        // Present each tier as [minQuantity .. maxQuantity]. The upper bound is
+        // derived from the next tier's floor; the highest tier is open-ended (null).
         return {
-          minQuantity: min,
-          maxQuantity:
-            i === 0 && priceLevel.maxQuantity && priceLevel.maxQuantity > 0
-              ? priceLevel.maxQuantity
-              : max,
+          minQuantity: priceLevel.minQuantity ?? 0,
+          maxQuantity: nextLevel?.minQuantity != null ? nextLevel.minQuantity - 1 : null,
           price: {
             isTaxable: !!priceLevel.isTaxable,
             isNetPrice: !!priceLevel.isNetPrice,

--- a/packages/core-products/src/module/configureProductPrices.ts
+++ b/packages/core-products/src/module/configureProductPrices.ts
@@ -38,6 +38,19 @@ export const normalizeRate = (
   return rate;
 };
 
+const normalizeProductPrice = (priceLevel: ProductPrice): ProductPrice | null => {
+  if (priceLevel.amount === null) return null;
+
+  return {
+    amount: priceLevel.amount,
+    currencyCode: priceLevel.currencyCode,
+    countryCode: priceLevel.countryCode,
+    minQuantity: priceLevel.minQuantity ?? 0,
+    isTaxable: !!priceLevel.isTaxable,
+    isNetPrice: !!priceLevel.isNetPrice,
+  };
+};
+
 export const configureProductPricesModule = ({
   proxyProducts,
   db,
@@ -65,23 +78,12 @@ export const configureProductPricesModule = ({
 
     // Tiers are sorted ascending by minQuantity; the applicable tier is the
     // highest floor that is <= quantity. The base tier has minQuantity 0, so the
-    // default quantity 0 used by price-range queries resolves to it. Tiers
-    // without a floor (legacy, un-migrated data) are ignored rather than mispriced.
-    const foundPrice = pricing
-      .filter((level) => level.minQuantity != null && level.minQuantity <= quantity)
-      .pop();
+    // default quantity 0 used by price-range queries resolves to it. Legacy
+    // data without a floor is treated as the base tier until it is migrated.
+    const foundPrice = pricing.filter((level) => (level.minQuantity ?? 0) <= quantity).pop();
     if (!foundPrice) return null;
 
-    const normalizedPrice = {
-      isTaxable: false,
-      isNetPrice: false,
-      ...foundPrice,
-    };
-
-    if (normalizedPrice.amount !== null) {
-      return normalizedPrice;
-    }
-    return null;
+    return normalizeProductPrice(foundPrice);
   };
 
   return {
@@ -90,7 +92,9 @@ export const configureProductPricesModule = ({
     priceRange: getPriceRange,
 
     async catalogPrices(product: Product): Promise<ProductPrice[]> {
-      return (product.commerce && product.commerce.pricing) || [];
+      return ((product.commerce && product.commerce.pricing) || [])
+        .map(normalizeProductPrice)
+        .filter((priceLevel): priceLevel is ProductPrice => Boolean(priceLevel));
     },
 
     catalogPriceRange: async (
@@ -154,20 +158,21 @@ export const configureProductPricesModule = ({
         countryCode,
       });
 
-      return sortedPriceLevels.map((priceLevel, i) => {
+      return sortedPriceLevels.flatMap((priceLevel, i) => {
         const nextLevel = sortedPriceLevels[i + 1];
+        const price = normalizeProductPrice({
+          ...priceLevel,
+          currencyCode,
+          countryCode,
+        });
+        if (!price) return [];
+
         // Present each tier as [minQuantity .. maxQuantity]. The upper bound is
         // derived from the next tier's floor; the highest tier is open-ended (null).
         return {
           minQuantity: priceLevel.minQuantity ?? 0,
           maxQuantity: nextLevel?.minQuantity != null ? nextLevel.minQuantity - 1 : null,
-          price: {
-            isTaxable: !!priceLevel.isTaxable,
-            isNetPrice: !!priceLevel.isNetPrice,
-            amount: priceLevel.amount,
-            currencyCode,
-            countryCode,
-          },
+          price,
         };
       });
     },

--- a/packages/core-products/src/module/configureProductsModule.ts
+++ b/packages/core-products/src/module/configureProductsModule.ts
@@ -23,6 +23,7 @@ import { configureProductReviewsModule } from './configureProductReviewsModule.t
 import { configureProductTextsModule } from './configureProductTextsModule.ts';
 import { configureProductVariationsModule } from './configureProductVariationsModule.ts';
 import { productsSettings, type ProductsSettingsOptions } from '../products-settings.ts';
+import migrateCommercePricingToMinQuantity from '../migrations/20260611120000-pricing-maxquantity-to-minquantity.ts';
 
 export interface ProductQuery {
   queryString?: string;
@@ -126,12 +127,14 @@ export const buildFindSelector = ({
 };
 
 export const configureProductsModule = async (moduleInput: ModuleInput<ProductsSettingsOptions>) => {
-  const { db, options: productsOptions = {} } = moduleInput;
+  const { db, migrationRepository, options: productsOptions = {} } = moduleInput;
 
   registerEvents(PRODUCT_EVENTS);
   await productsSettings.configureSettings(productsOptions);
 
   const { Products, ProductTexts } = await ProductsCollection(db);
+
+  migrateCommercePricingToMinQuantity(migrationRepository);
 
   /*
    * Product sub entities

--- a/packages/core-products/src/module/utils/configureProductPrices.test.ts
+++ b/packages/core-products/src/module/utils/configureProductPrices.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { getDecimals, normalizeRate } from '../configureProductPrices.ts';
+import { configureProductPricesModule, getDecimals, normalizeRate } from '../configureProductPrices.ts';
 
 describe('Rate conversion', () => {
   it('getDecimals', () => {
@@ -152,5 +152,94 @@ describe('Rate conversion', () => {
 
     // 1 ETH = 1,000,000,000 GWEI (10^9)
     // 1,000,000,000 GWEI = 1’259’445 CLP
+  });
+});
+
+describe('Catalog price', () => {
+  const createPricesModule = () =>
+    configureProductPricesModule({
+      db: null,
+      proxyProducts: async (product) => [product],
+    } as any);
+
+  const legacyProduct = {
+    _id: 'legacy-product',
+    commerce: {
+      pricing: [
+        {
+          amount: 1000,
+          currencyCode: 'CHF',
+          countryCode: 'CH',
+          isTaxable: true,
+          isNetPrice: false,
+          minQuantity: null,
+          maxQuantity: 4,
+          legacyOnly: true,
+        },
+        {
+          amount: 800,
+          currencyCode: 'CHF',
+          countryCode: 'CH',
+          isTaxable: false,
+          isNetPrice: true,
+          minQuantity: 5,
+          maxQuantity: null,
+          legacyOnly: true,
+        },
+      ],
+    },
+  } as any;
+
+  it('treats null minQuantity as the base tier', async () => {
+    const { price } = createPricesModule();
+
+    assert.deepStrictEqual(
+      await price(legacyProduct, { countryCode: 'CH', currencyCode: 'CHF', quantity: 1 }),
+      {
+        amount: 1000,
+        currencyCode: 'CHF',
+        countryCode: 'CH',
+        minQuantity: 0,
+        isTaxable: true,
+        isNetPrice: false,
+      },
+    );
+
+    assert.deepStrictEqual(
+      await price(legacyProduct, { countryCode: 'CH', currencyCode: 'CHF', quantity: 5 }),
+      {
+        amount: 800,
+        currencyCode: 'CHF',
+        countryCode: 'CH',
+        minQuantity: 5,
+        isTaxable: false,
+        isNetPrice: true,
+      },
+    );
+  });
+
+  it('normalizes ProductPrice return shapes', async () => {
+    const { catalogPrices, price } = createPricesModule();
+
+    const expectedKeys = [
+      'amount',
+      'countryCode',
+      'currencyCode',
+      'isNetPrice',
+      'isTaxable',
+      'minQuantity',
+    ];
+    const singlePrice = await price(legacyProduct, {
+      countryCode: 'CH',
+      currencyCode: 'CHF',
+      quantity: 1,
+    });
+    const priceList = await catalogPrices(legacyProduct);
+
+    assert.deepStrictEqual(Object.keys(singlePrice!).sort(), expectedKeys);
+    assert.deepStrictEqual(
+      priceList.map((productPrice) => Object.keys(productPrice).sort()),
+      [expectedKeys, expectedKeys],
+    );
   });
 });

--- a/packages/core-products/src/module/utils/getPriceLevels.test.ts
+++ b/packages/core-products/src/module/utils/getPriceLevels.test.ts
@@ -13,7 +13,7 @@ describe('Price level', () => {
     assert.deepStrictEqual(getPriceLevels({ product, countryCode: 'ET' } as any), [
       {
         amount: 20000,
-        maxQuantity: 2,
+        minQuantity: 0,
         isTaxable: true,
         isNetPrice: true,
         currencyCode: 'ETB',
@@ -24,7 +24,7 @@ describe('Price level', () => {
     assert.deepStrictEqual(getPriceLevels({ product, countryCode: 'CH' } as any), [
       {
         amount: 1,
-        maxQuantity: 1,
+        minQuantity: 0,
         isTaxable: false,
         isNetPrice: false,
         currencyCode: 'ETH',
@@ -32,7 +32,7 @@ describe('Price level', () => {
       },
       {
         amount: 750,
-        maxQuantity: 2,
+        minQuantity: 0,
         isTaxable: false,
         isNetPrice: false,
         currencyCode: 'CHF',
@@ -40,7 +40,7 @@ describe('Price level', () => {
       },
       {
         amount: 1000,
-        maxQuantity: null,
+        minQuantity: 3,
         isTaxable: false,
         isNetPrice: false,
         currencyCode: 'CHF',
@@ -49,11 +49,11 @@ describe('Price level', () => {
     ]);
   });
 
-  it('Should return all prices for a given country sorted by max quantity ASC', () => {
+  it('Should return all prices for a given country sorted by min quantity ASC', () => {
     assert.deepStrictEqual(getPriceLevels({ product, countryCode: 'CH' } as any), [
       {
         amount: 1,
-        maxQuantity: 1,
+        minQuantity: 0,
         isTaxable: false,
         isNetPrice: false,
         currencyCode: 'ETH',
@@ -61,7 +61,7 @@ describe('Price level', () => {
       },
       {
         amount: 750,
-        maxQuantity: 2,
+        minQuantity: 0,
         isTaxable: false,
         isNetPrice: false,
         currencyCode: 'CHF',
@@ -69,7 +69,7 @@ describe('Price level', () => {
       },
       {
         amount: 1000,
-        maxQuantity: null,
+        minQuantity: 3,
         isTaxable: false,
         isNetPrice: false,
         currencyCode: 'CHF',

--- a/packages/core-products/src/module/utils/getPriceLevels.ts
+++ b/packages/core-products/src/module/utils/getPriceLevels.ts
@@ -6,12 +6,8 @@ export const getPriceLevels = (params: {
   countryCode: string;
 }) => {
   return (params.product?.commerce?.pricing || [])
-    .toSorted(({ maxQuantity: leftMaxQuantity = 0 }, { maxQuantity: rightMaxQuantity = 0 }) => {
-      if (leftMaxQuantity === rightMaxQuantity || (!leftMaxQuantity && !rightMaxQuantity)) return 0;
-      if (!leftMaxQuantity) return 1;
-      if (!rightMaxQuantity) return -1;
-      return leftMaxQuantity - rightMaxQuantity;
-    })
+    // Ascending by tier floor; the highest minQuantity is the open-ended top tier.
+    .toSorted((left, right) => (left.minQuantity ?? 0) - (right.minQuantity ?? 0))
     .filter((priceLevel) => {
       if (!params.currencyCode) return priceLevel.countryCode === params.countryCode;
       return (

--- a/packages/core-products/src/module/utils/getPriceLevels.ts
+++ b/packages/core-products/src/module/utils/getPriceLevels.ts
@@ -5,13 +5,16 @@ export const getPriceLevels = (params: {
   currencyCode?: string;
   countryCode: string;
 }) => {
-  return (params.product?.commerce?.pricing || [])
-    // Ascending by tier floor; the highest minQuantity is the open-ended top tier.
-    .toSorted((left, right) => (left.minQuantity ?? 0) - (right.minQuantity ?? 0))
-    .filter((priceLevel) => {
-      if (!params.currencyCode) return priceLevel.countryCode === params.countryCode;
-      return (
-        priceLevel.currencyCode === params.currencyCode && priceLevel.countryCode === params.countryCode
-      );
-    });
+  return (
+    (params.product?.commerce?.pricing || [])
+      // Ascending by tier floor; the highest minQuantity is the open-ended top tier.
+      .toSorted((left, right) => (left.minQuantity ?? 0) - (right.minQuantity ?? 0))
+      .filter((priceLevel) => {
+        if (!params.currencyCode) return priceLevel.countryCode === params.countryCode;
+        return (
+          priceLevel.currencyCode === params.currencyCode &&
+          priceLevel.countryCode === params.countryCode
+        );
+      })
+  );
 };

--- a/packages/core/src/bulk-exporter/handlers/exportProductsHandler.ts
+++ b/packages/core/src/bulk-exporter/handlers/exportProductsHandler.ts
@@ -33,7 +33,7 @@ const PRODUCT_CSV_SCHEMA = {
     'countryCode',
     'isTaxable',
     'isNetPrice',
-    'maxQuantity',
+    'minQuantity',
   ],
   bundleItemHeaders: ['productId', 'bundleItemProductId', 'quantity', 'configuration'],
   variationItemHeaders: ['productId', 'variationId', 'key', 'type'],
@@ -97,7 +97,7 @@ const buildPriceRows = (productId: string, prices = []) =>
     isTaxable: p.isTaxable ?? '',
     currencyCode: p.currency?.isoCode ?? '',
     countryCode: p.country?.isoCode ?? '',
-    maxQuantity: p.maxQuantity ?? '',
+    minQuantity: p.minQuantity ?? '',
   }));
 
 const buildBundleRows = (productId: string, bundles = []) =>

--- a/packages/core/src/bulk-importer/handlers/product/create.ts
+++ b/packages/core/src/bulk-importer/handlers/product/create.ts
@@ -18,7 +18,7 @@ export const ProductCreateSpecificationSchema = z.object({
       pricing: z.array(
         z.object({
           amount: z.number(),
-          maxQuantity: z.optional(z.number()),
+          minQuantity: z.optional(z.number().check(z.gte(0))),
           isTaxable: z.optional(z.boolean()),
           isNetPrice: z.optional(z.boolean()),
           currencyCode: z.string().check(z.minLength(1, 'currencyCode is required')),

--- a/packages/core/src/bulk-importer/handlers/product/update.ts
+++ b/packages/core/src/bulk-importer/handlers/product/update.ts
@@ -17,7 +17,7 @@ export const ProductUpdateSpecificationSchema = z.object({
       pricing: z.array(
         z.object({
           amount: z.number(),
-          maxQuantity: z.optional(z.number()),
+          minQuantity: z.optional(z.number().check(z.gte(0))),
           isTaxable: z.optional(z.boolean()),
           isNetPrice: z.optional(z.boolean()),
           currencyCode: z.string().check(z.minLength(1, 'currencyCode is required')),

--- a/packages/core/src/factory/index.ts
+++ b/packages/core/src/factory/index.ts
@@ -7,6 +7,17 @@ import registerVirtualWarehousing from './registerVirtualWarehousing.ts';
 import registerProductSearchFilter from './registerProductSearchFilter.ts';
 import registerAssortmentSearchFilter from './registerAssortmentSearchFilter.ts';
 import registerInvoicePayment from './registerInvoicePayment.ts';
+import registerPaymentProvider from './registerPaymentProvider.ts';
+import registerDeliveryProvider from './registerDeliveryProvider.ts';
+import registerProductPricing from './registerProductPricing.ts';
+import registerOrderPricing from './registerOrderPricing.ts';
+import registerPaymentPricing from './registerPaymentPricing.ts';
+import registerDeliveryPricing from './registerDeliveryPricing.ts';
+import registerProductDiscount from './registerProductDiscount.ts';
+import registerOrderDiscount from './registerOrderDiscount.ts';
+import registerFileAdapter from './registerFileAdapter.ts';
+import registerQuotation from './registerQuotation.ts';
+import registerEnrollment from './registerEnrollment.ts';
 
 export {
   registerProductDiscoverabilityFilter,
@@ -18,4 +29,15 @@ export {
   registerVirtualWarehousing,
   registerProductSearchFilter,
   registerAssortmentSearchFilter,
+  registerPaymentProvider,
+  registerDeliveryProvider,
+  registerProductPricing,
+  registerOrderPricing,
+  registerPaymentPricing,
+  registerDeliveryPricing,
+  registerProductDiscount,
+  registerOrderDiscount,
+  registerFileAdapter,
+  registerQuotation,
+  registerEnrollment,
 };

--- a/packages/core/src/factory/registerAssortmentSearchFilter.ts
+++ b/packages/core/src/factory/registerAssortmentSearchFilter.ts
@@ -3,17 +3,22 @@ import { FilterAdapter, type IPlugin, type IFilterAdapter } from '../core-index.
 import { pluginRegistry } from '../plugins/PluginRegistry.ts';
 
 export default function registerAssortmentSearchFilter({
+  adapterId,
   orderIndex = 0,
   search,
 }: {
+  adapterId?: string;
   orderIndex?: number;
   search: (params: SearchQuery & { queryString: string; locale: Intl.Locale }) => Promise<string[]>;
 }): IPlugin {
+  const id = adapterId ?? crypto.randomUUID();
   const adapter: IFilterAdapter = {
     ...FilterAdapter,
 
-    key: `shop.unchained.filters.assortment-search-${crypto.randomUUID()}`,
-    label: 'Assortment Search Filter (auto-generated)',
+    key: `shop.unchained.filters.assortment-search-${id}`,
+    label: adapterId
+      ? `Assortment Search Filter: ${adapterId}`
+      : 'Assortment Search Filter (auto-generated)',
     version: '1.0.0',
     orderIndex,
 

--- a/packages/core/src/factory/registerDeliveryPricing.ts
+++ b/packages/core/src/factory/registerDeliveryPricing.ts
@@ -1,0 +1,52 @@
+import {
+  DeliveryPricingAdapter,
+  type IPlugin,
+  type IDeliveryPricingAdapter,
+  type IDeliveryPricingSheet,
+  type DeliveryPricingAdapterContext,
+} from '../core-index.ts';
+import { pluginRegistry } from '../plugins/PluginRegistry.ts';
+
+export default function registerDeliveryPricing({
+  adapterId,
+  orderIndex,
+  isActivatedFor,
+  calculate,
+}: {
+  adapterId: string;
+  orderIndex?: number;
+  isActivatedFor?: (context: DeliveryPricingAdapterContext) => boolean;
+  calculate: (sheet: IDeliveryPricingSheet, context: DeliveryPricingAdapterContext) => Promise<void>;
+}): IPlugin {
+  const adapter: IDeliveryPricingAdapter = {
+    ...DeliveryPricingAdapter,
+
+    key: `shop.unchained.pricing.delivery-${adapterId}`,
+    label: 'Delivery Pricing: ' + adapterId,
+    version: '1.0.0',
+    orderIndex: orderIndex ?? 0,
+
+    isActivatedFor: (context) => (isActivatedFor ? isActivatedFor(context) : true),
+
+    actions: (params) => {
+      const pricingAdapter = DeliveryPricingAdapter.actions(params);
+      return {
+        ...pricingAdapter,
+        calculate: async () => {
+          await calculate(pricingAdapter.resultSheet(), params.context);
+          return pricingAdapter.calculate();
+        },
+      };
+    },
+  };
+
+  const plugin: IPlugin = {
+    key: adapter.key,
+    label: adapter.label,
+    version: adapter.version,
+    adapters: [adapter],
+  };
+
+  pluginRegistry.register(plugin);
+  return plugin;
+}

--- a/packages/core/src/factory/registerDeliveryProvider.ts
+++ b/packages/core/src/factory/registerDeliveryProvider.ts
@@ -1,0 +1,84 @@
+import type { DeliveryConfiguration } from '@unchainedshop/core-delivery';
+import { DeliveryProviderType } from '@unchainedshop/core-delivery';
+import {
+  DeliveryAdapter,
+  type DeliveryContext,
+  type IPlugin,
+  type IDeliveryAdapter,
+} from '../core-index.ts';
+import { pluginRegistry } from '../plugins/PluginRegistry.ts';
+import type { Work } from '@unchainedshop/core-worker';
+
+export default function registerDeliveryProvider({
+  adapterId,
+  type = DeliveryProviderType.SHIPPING,
+  active,
+  autoReleaseAllowed,
+  estimatedDeliveryThroughput,
+  send,
+}: {
+  adapterId: string;
+  type?: DeliveryProviderType;
+  active?: boolean;
+  autoReleaseAllowed?: boolean;
+  estimatedDeliveryThroughput?: (
+    warehousingThroughputTime: number,
+    context: DeliveryContext,
+  ) => Promise<number | null>;
+  send:
+    | boolean
+    | ((configuration: DeliveryConfiguration, context: DeliveryContext) => Promise<boolean | Work>);
+}): IPlugin {
+  const adapter: IDeliveryAdapter = {
+    ...DeliveryAdapter,
+
+    key: `shop.unchained.delivery.${adapterId}`,
+    label: 'Delivery: ' + adapterId,
+    version: '1.0.0',
+
+    initialConfiguration: [],
+
+    typeSupported: (deliveryType) => {
+      return deliveryType === type;
+    },
+
+    actions: (config, context) => {
+      return {
+        ...DeliveryAdapter.actions(config, context),
+
+        isActive: () => {
+          return active ?? true;
+        },
+
+        isAutoReleaseAllowed: () => {
+          return autoReleaseAllowed ?? true;
+        },
+
+        configurationError: () => {
+          return null;
+        },
+
+        estimatedDeliveryThroughput: async (warehousingThroughputTime) => {
+          if (estimatedDeliveryThroughput) {
+            return estimatedDeliveryThroughput(warehousingThroughputTime, context);
+          }
+          return 0;
+        },
+
+        send: async () => {
+          return typeof send === 'function' ? await send(config, context) : send;
+        },
+      };
+    },
+  };
+
+  const plugin: IPlugin = {
+    key: adapter.key,
+    label: adapter.label,
+    version: adapter.version,
+    adapters: [adapter],
+  };
+
+  pluginRegistry.register(plugin);
+  return plugin;
+}

--- a/packages/core/src/factory/registerEnrollment.ts
+++ b/packages/core/src/factory/registerEnrollment.ts
@@ -70,9 +70,7 @@ export default function registerEnrollment({
         },
 
         nextPeriod: async () => {
-          return nextPeriod
-            ? nextPeriod(context)
-            : EnrollmentAdapter.actions(context).nextPeriod();
+          return nextPeriod ? nextPeriod(context) : EnrollmentAdapter.actions(context).nextPeriod();
         },
       };
     },

--- a/packages/core/src/factory/registerEnrollment.ts
+++ b/packages/core/src/factory/registerEnrollment.ts
@@ -1,0 +1,90 @@
+import type {
+  EnrollmentOrderPositionTemplate,
+  EnrollmentPeriod,
+  EnrollmentPlan,
+} from '@unchainedshop/core-enrollments';
+import type { ProductPlan } from '@unchainedshop/core-products';
+import type { OrderPosition } from '@unchainedshop/core-orders';
+import {
+  EnrollmentAdapter,
+  type EnrollmentContext,
+  type IPlugin,
+  type IEnrollmentAdapter,
+} from '../core-index.ts';
+import { pluginRegistry } from '../plugins/PluginRegistry.ts';
+
+export default function registerEnrollment({
+  adapterId,
+  isActivatedFor,
+  transformOrderItem,
+  configurationForOrder,
+  isOverdue,
+  isValidForActivation,
+  nextPeriod,
+}: {
+  adapterId: string;
+  isActivatedFor?: (productPlan?: ProductPlan) => boolean;
+  transformOrderItem?: (orderPosition: OrderPosition, unchainedAPI) => Promise<EnrollmentPlan>;
+  configurationForOrder: (
+    params: { period: EnrollmentPeriod },
+    context: EnrollmentContext,
+  ) => Promise<{
+    orderContext?: Record<string, any>;
+    orderPositionTemplates: EnrollmentOrderPositionTemplate[];
+  } | null>;
+  isOverdue?: (context: EnrollmentContext) => Promise<boolean>;
+  isValidForActivation?: (context: EnrollmentContext) => Promise<boolean>;
+  nextPeriod?: (context: EnrollmentContext) => Promise<EnrollmentPeriod | null>;
+}): IPlugin {
+  const adapter: IEnrollmentAdapter = {
+    ...EnrollmentAdapter,
+
+    key: `shop.unchained.enrollment.${adapterId}`,
+    label: 'Enrollment: ' + adapterId,
+    version: '1.0.0',
+
+    isActivatedFor: (productPlan) => {
+      return isActivatedFor ? isActivatedFor(productPlan) : true;
+    },
+
+    transformOrderItemToEnrollmentPlan: async (orderPosition, unchainedAPI) => {
+      return transformOrderItem
+        ? transformOrderItem(orderPosition, unchainedAPI)
+        : EnrollmentAdapter.transformOrderItemToEnrollmentPlan(orderPosition, unchainedAPI);
+    },
+
+    actions: (context) => {
+      return {
+        ...EnrollmentAdapter.actions(context),
+
+        configurationForOrder: async (params) => {
+          return configurationForOrder(params, context);
+        },
+
+        isOverdue: async () => {
+          return isOverdue ? isOverdue(context) : false;
+        },
+
+        isValidForActivation: async () => {
+          return isValidForActivation ? isValidForActivation(context) : false;
+        },
+
+        nextPeriod: async () => {
+          return nextPeriod
+            ? nextPeriod(context)
+            : EnrollmentAdapter.actions(context).nextPeriod();
+        },
+      };
+    },
+  };
+
+  const plugin: IPlugin = {
+    key: adapter.key,
+    label: adapter.label,
+    version: adapter.version,
+    adapters: [adapter],
+  };
+
+  pluginRegistry.register(plugin);
+  return plugin;
+}

--- a/packages/core/src/factory/registerFileAdapter.ts
+++ b/packages/core/src/factory/registerFileAdapter.ts
@@ -1,0 +1,66 @@
+import {
+  FileAdapter,
+  type IFileAdapter,
+  type UploadedFile,
+  type UploadFileData,
+} from '@unchainedshop/core-files';
+import { type IPlugin } from '../core-index.ts';
+import { pluginRegistry } from '../plugins/PluginRegistry.ts';
+
+export default function registerFileAdapter<Context = unknown>({
+  adapterId,
+  createSignedURL,
+  uploadFileFromStream,
+  createDownloadURL,
+  removeFiles,
+  uploadFileFromURL,
+}: {
+  adapterId: string;
+  createSignedURL: (
+    directoryName: string,
+    fileName: string,
+    unchainedAPI: Context,
+  ) => Promise<(UploadFileData & { putURL: string }) | null>;
+  uploadFileFromStream: (
+    directoryName: string,
+    rawFile: any,
+    unchainedAPI: Context,
+    options?: Record<string, any>,
+  ) => Promise<UploadFileData>;
+  createDownloadURL?: (file: UploadedFile, expiry?: number) => Promise<string | null>;
+  removeFiles?: (files: UploadedFile[], unchainedContext: Context) => Promise<void>;
+  uploadFileFromURL?: (
+    directoryName: string,
+    fileInput: {
+      fileLink: string;
+      fileName: string;
+      fileId?: string;
+      headers?: Record<string, unknown>;
+    },
+    unchainedAPI: Context,
+  ) => Promise<UploadFileData>;
+}): IPlugin {
+  const adapter: IFileAdapter<Context> = {
+    ...FileAdapter,
+
+    key: `shop.unchained.file-upload.${adapterId}`,
+    label: 'File Adapter: ' + adapterId,
+    version: '1.0.0',
+
+    createSignedURL,
+    uploadFileFromStream,
+    ...(createDownloadURL ? { createDownloadURL } : {}),
+    ...(removeFiles ? { removeFiles } : {}),
+    ...(uploadFileFromURL ? { uploadFileFromURL } : {}),
+  };
+
+  const plugin: IPlugin = {
+    key: adapter.key,
+    label: adapter.label,
+    version: adapter.version,
+    adapters: [adapter],
+  };
+
+  pluginRegistry.register(plugin);
+  return plugin;
+}

--- a/packages/core/src/factory/registerOrderDiscount.ts
+++ b/packages/core/src/factory/registerOrderDiscount.ts
@@ -1,0 +1,73 @@
+import type { PricingCalculation } from '@unchainedshop/utils';
+import {
+  OrderDiscountAdapter,
+  type DiscountContext,
+  type IDiscountAdapter,
+  type IPricingSheet,
+  type OrderDiscountConfiguration,
+  type IPlugin,
+} from '../core-index.ts';
+import { pluginRegistry } from '../plugins/PluginRegistry.ts';
+
+export default function registerOrderDiscount({
+  adapterId,
+  isValidForSystemTriggering,
+  isValidForCodeTriggering,
+  discountForPricingAdapterKey,
+  reserve,
+  release,
+}: {
+  adapterId: string;
+  isValidForSystemTriggering?: (context: DiscountContext) => Promise<boolean>;
+  isValidForCodeTriggering?: (code: string, context: DiscountContext) => Promise<boolean>;
+  discountForPricingAdapterKey: (
+    params: { pricingAdapterKey: string; calculationSheet: IPricingSheet<PricingCalculation> },
+    context: DiscountContext,
+  ) => OrderDiscountConfiguration | null;
+  reserve?: (code: string | undefined, context: DiscountContext) => Promise<any>;
+  release?: (context: DiscountContext) => Promise<void>;
+}): IPlugin {
+  const adapter: IDiscountAdapter<OrderDiscountConfiguration> = {
+    ...OrderDiscountAdapter,
+
+    key: `shop.unchained.discount.order-${adapterId}`,
+    label: 'Order Discount: ' + adapterId,
+    version: '1.0.0',
+
+    actions: async ({ context }) => {
+      return {
+        ...(await OrderDiscountAdapter.actions({ context })),
+
+        isValidForSystemTriggering: async () => {
+          return isValidForSystemTriggering ? isValidForSystemTriggering(context) : false;
+        },
+
+        isValidForCodeTriggering: async ({ code }) => {
+          return isValidForCodeTriggering ? isValidForCodeTriggering(code, context) : false;
+        },
+
+        discountForPricingAdapterKey: (params) => {
+          return discountForPricingAdapterKey(params, context);
+        },
+
+        reserve: async ({ code }) => {
+          return reserve ? reserve(code, context) : {};
+        },
+
+        release: async () => {
+          if (release) await release(context);
+        },
+      };
+    },
+  };
+
+  const plugin: IPlugin = {
+    key: adapter.key,
+    label: adapter.label,
+    version: adapter.version,
+    adapters: [adapter],
+  };
+
+  pluginRegistry.register(plugin);
+  return plugin;
+}

--- a/packages/core/src/factory/registerOrderPricing.ts
+++ b/packages/core/src/factory/registerOrderPricing.ts
@@ -1,0 +1,52 @@
+import {
+  OrderPricingAdapter,
+  type IPlugin,
+  type IOrderPricingAdapter,
+  type IOrderPricingSheet,
+  type OrderPricingAdapterContext,
+} from '../core-index.ts';
+import { pluginRegistry } from '../plugins/PluginRegistry.ts';
+
+export default function registerOrderPricing({
+  adapterId,
+  orderIndex,
+  isActivatedFor,
+  calculate,
+}: {
+  adapterId: string;
+  orderIndex?: number;
+  isActivatedFor?: (context: OrderPricingAdapterContext) => boolean;
+  calculate: (sheet: IOrderPricingSheet, context: OrderPricingAdapterContext) => Promise<void>;
+}): IPlugin {
+  const adapter: IOrderPricingAdapter = {
+    ...OrderPricingAdapter,
+
+    key: `shop.unchained.pricing.order-${adapterId}`,
+    label: 'Order Pricing: ' + adapterId,
+    version: '1.0.0',
+    orderIndex: orderIndex ?? 0,
+
+    isActivatedFor: (context) => (isActivatedFor ? isActivatedFor(context) : true),
+
+    actions: (params) => {
+      const pricingAdapter = OrderPricingAdapter.actions(params);
+      return {
+        ...pricingAdapter,
+        calculate: async () => {
+          await calculate(pricingAdapter.resultSheet(), params.context);
+          return pricingAdapter.calculate();
+        },
+      };
+    },
+  };
+
+  const plugin: IPlugin = {
+    key: adapter.key,
+    label: adapter.label,
+    version: adapter.version,
+    adapters: [adapter],
+  };
+
+  pluginRegistry.register(plugin);
+  return plugin;
+}

--- a/packages/core/src/factory/registerPaymentPricing.ts
+++ b/packages/core/src/factory/registerPaymentPricing.ts
@@ -1,0 +1,52 @@
+import {
+  PaymentPricingAdapter,
+  type IPlugin,
+  type IPaymentPricingAdapter,
+  type IPaymentPricingSheet,
+  type PaymentPricingAdapterContext,
+} from '../core-index.ts';
+import { pluginRegistry } from '../plugins/PluginRegistry.ts';
+
+export default function registerPaymentPricing({
+  adapterId,
+  orderIndex,
+  isActivatedFor,
+  calculate,
+}: {
+  adapterId: string;
+  orderIndex?: number;
+  isActivatedFor?: (context: PaymentPricingAdapterContext) => boolean;
+  calculate: (sheet: IPaymentPricingSheet, context: PaymentPricingAdapterContext) => Promise<void>;
+}): IPlugin {
+  const adapter: IPaymentPricingAdapter = {
+    ...PaymentPricingAdapter,
+
+    key: `shop.unchained.pricing.payment-${adapterId}`,
+    label: 'Payment Pricing: ' + adapterId,
+    version: '1.0.0',
+    orderIndex: orderIndex ?? 0,
+
+    isActivatedFor: (context) => (isActivatedFor ? isActivatedFor(context) : true),
+
+    actions: (params) => {
+      const pricingAdapter = PaymentPricingAdapter.actions(params);
+      return {
+        ...pricingAdapter,
+        calculate: async () => {
+          await calculate(pricingAdapter.resultSheet(), params.context);
+          return pricingAdapter.calculate();
+        },
+      };
+    },
+  };
+
+  const plugin: IPlugin = {
+    key: adapter.key,
+    label: adapter.label,
+    version: adapter.version,
+    adapters: [adapter],
+  };
+
+  pluginRegistry.register(plugin);
+  return plugin;
+}

--- a/packages/core/src/factory/registerPaymentProvider.ts
+++ b/packages/core/src/factory/registerPaymentProvider.ts
@@ -1,0 +1,103 @@
+import type { PaymentConfiguration } from '@unchainedshop/core-payment';
+import { PaymentProviderType } from '@unchainedshop/core-payment';
+import {
+  type PaymentContext,
+  PaymentAdapter,
+  type PaymentChargeActionResult,
+  type PaymentError,
+  type IPlugin,
+  type IPaymentAdapter,
+} from '../core-index.ts';
+import { pluginRegistry } from '../plugins/PluginRegistry.ts';
+
+export default function registerPaymentProvider({
+  adapterId,
+  type,
+  charge,
+  sign,
+  validate,
+  isActive,
+  isPayLaterAllowed,
+  configurationError,
+  cancel,
+  confirm,
+}: {
+  adapterId: string;
+  type?: PaymentProviderType;
+  charge:
+    | false
+    | ((
+        configuration: PaymentConfiguration,
+        context: PaymentContext,
+      ) => Promise<PaymentChargeActionResult | false>);
+  sign?: (configuration: PaymentConfiguration, context: PaymentContext) => Promise<string | null>;
+  validate?: (configuration: PaymentConfiguration, context: PaymentContext) => Promise<boolean>;
+  isActive?: boolean;
+  isPayLaterAllowed?: boolean;
+  configurationError?: PaymentError | null;
+  cancel?: (configuration: PaymentConfiguration, context: PaymentContext) => Promise<boolean>;
+  confirm?: (configuration: PaymentConfiguration, context: PaymentContext) => Promise<boolean>;
+}): IPlugin {
+  const providerType = type ?? PaymentProviderType.GENERIC;
+  const adapter: IPaymentAdapter = {
+    ...PaymentAdapter,
+
+    key: `shop.unchained.payment.${adapterId}`,
+    label: 'Payment: ' + adapterId,
+    version: '1.0.0',
+
+    initialConfiguration: [],
+
+    typeSupported: (t) => {
+      return t === providerType;
+    },
+
+    actions: (config, context) => {
+      return {
+        ...PaymentAdapter.actions(config, context),
+
+        isActive: () => {
+          return isActive ?? true;
+        },
+
+        isPayLaterAllowed: () => {
+          return isPayLaterAllowed ?? false;
+        },
+
+        configurationError: () => {
+          return configurationError ?? null;
+        },
+
+        sign: async () => {
+          return sign ? sign(config, context) : null;
+        },
+
+        validate: async () => {
+          return validate ? validate(config, context) : false;
+        },
+
+        cancel: async () => {
+          return cancel ? cancel(config, context) : false;
+        },
+
+        confirm: async () => {
+          return confirm ? confirm(config, context) : false;
+        },
+
+        charge: async () => {
+          return typeof charge === 'function' ? await charge(config, context) : charge;
+        },
+      };
+    },
+  };
+
+  const plugin: IPlugin = {
+    key: adapter.key,
+    label: adapter.label,
+    version: adapter.version,
+    adapters: [adapter],
+  };
+
+  pluginRegistry.register(plugin);
+  return plugin;
+}

--- a/packages/core/src/factory/registerProductDiscount.ts
+++ b/packages/core/src/factory/registerProductDiscount.ts
@@ -1,0 +1,89 @@
+import {
+  ProductDiscountAdapter,
+  type IPlugin,
+  type IDiscountAdapter,
+  type IPricingSheet,
+  type ProductDiscountConfiguration,
+} from '../core-index.ts';
+import type { PricingCalculation } from '@unchainedshop/utils';
+import { pluginRegistry } from '../plugins/PluginRegistry.ts';
+
+export default function registerProductDiscount({
+  adapterId,
+  orderIndex,
+  isManualAdditionAllowed,
+  isManualRemovalAllowed,
+  isValidForSystemTriggering,
+  isValidForCodeTriggering,
+  discountForPricingAdapterKey,
+  reserve,
+  release,
+}: {
+  adapterId: string;
+  orderIndex?: number;
+  isManualAdditionAllowed?: (code?: string) => Promise<boolean>;
+  isManualRemovalAllowed?: () => Promise<boolean>;
+  isValidForSystemTriggering?: () => Promise<boolean>;
+  isValidForCodeTriggering?: (params: { code: string }) => Promise<boolean>;
+  discountForPricingAdapterKey: (params: {
+    pricingAdapterKey: string;
+    calculationSheet: IPricingSheet<PricingCalculation>;
+  }) => ProductDiscountConfiguration | null;
+  reserve?: (params: { code?: string }) => Promise<any>;
+  release?: () => Promise<void>;
+}): IPlugin {
+  const adapter: IDiscountAdapter<ProductDiscountConfiguration> = {
+    ...ProductDiscountAdapter,
+
+    key: `shop.unchained.discount.product-${adapterId}`,
+    label: 'Product Discount: ' + adapterId,
+    version: '1.0.0',
+    orderIndex: orderIndex ?? 0,
+
+    isManualAdditionAllowed: async (code) => {
+      return isManualAdditionAllowed
+        ? isManualAdditionAllowed(code)
+        : ProductDiscountAdapter.isManualAdditionAllowed(code);
+    },
+
+    isManualRemovalAllowed: async () => {
+      return isManualRemovalAllowed
+        ? isManualRemovalAllowed()
+        : ProductDiscountAdapter.isManualRemovalAllowed();
+    },
+
+    actions: async (params) => {
+      return {
+        ...(await ProductDiscountAdapter.actions(params)),
+
+        isValidForSystemTriggering: async () => {
+          return isValidForSystemTriggering ? isValidForSystemTriggering() : false;
+        },
+
+        isValidForCodeTriggering: async ({ code }) => {
+          return isValidForCodeTriggering ? isValidForCodeTriggering({ code }) : false;
+        },
+
+        discountForPricingAdapterKey,
+
+        reserve: async ({ code }) => {
+          return reserve ? reserve({ code }) : {};
+        },
+
+        release: async () => {
+          return release ? release() : undefined;
+        },
+      };
+    },
+  };
+
+  const plugin: IPlugin = {
+    key: adapter.key,
+    label: adapter.label,
+    version: adapter.version,
+    adapters: [adapter],
+  };
+
+  pluginRegistry.register(plugin);
+  return plugin;
+}

--- a/packages/core/src/factory/registerProductDiscoverabilityFilter.ts
+++ b/packages/core/src/factory/registerProductDiscoverabilityFilter.ts
@@ -2,17 +2,22 @@ import { FilterAdapter, type IPlugin, type IFilterAdapter } from '../core-index.
 import { pluginRegistry } from '../plugins/PluginRegistry.ts';
 
 export default function registerProductDiscoverabilityFilter({
+  adapterId,
   orderIndex = 0,
   hiddenTagValue = 'hidden',
 }: {
+  adapterId?: string;
   orderIndex?: number;
   hiddenTagValue?: string;
 }): IPlugin {
+  const id = adapterId ?? crypto.randomUUID();
   const adapter: IFilterAdapter = {
     ...FilterAdapter,
 
-    key: `shop.unchained.filters.product-discoverability-${crypto.randomUUID()}`,
-    label: 'Product Discoverability Filter (auto-generated)',
+    key: `shop.unchained.filters.product-discoverability-${id}`,
+    label: adapterId
+      ? `Product Discoverability Filter: ${adapterId}`
+      : 'Product Discoverability Filter (auto-generated)',
     version: '1.0.0',
     orderIndex,
 

--- a/packages/core/src/factory/registerProductPricing.ts
+++ b/packages/core/src/factory/registerProductPricing.ts
@@ -1,0 +1,52 @@
+import {
+  ProductPricingAdapter,
+  type IPlugin,
+  type IProductPricingAdapter,
+  type IProductPricingSheet,
+  type ProductPricingAdapterContext,
+} from '../core-index.ts';
+import { pluginRegistry } from '../plugins/PluginRegistry.ts';
+
+export default function registerProductPricing({
+  adapterId,
+  orderIndex,
+  isActivatedFor,
+  calculate,
+}: {
+  adapterId: string;
+  orderIndex?: number;
+  isActivatedFor?: (context: ProductPricingAdapterContext) => boolean;
+  calculate: (sheet: IProductPricingSheet, context: ProductPricingAdapterContext) => Promise<void>;
+}): IPlugin {
+  const adapter: IProductPricingAdapter = {
+    ...ProductPricingAdapter,
+
+    key: `shop.unchained.pricing.product-${adapterId}`,
+    label: 'Product Pricing: ' + adapterId,
+    version: '1.0.0',
+    orderIndex: orderIndex ?? 0,
+
+    isActivatedFor: (context) => (isActivatedFor ? isActivatedFor(context) : true),
+
+    actions: (params) => {
+      const pricingAdapter = ProductPricingAdapter.actions(params);
+      return {
+        ...pricingAdapter,
+        calculate: async () => {
+          await calculate(pricingAdapter.resultSheet(), params.context);
+          return pricingAdapter.calculate();
+        },
+      };
+    },
+  };
+
+  const plugin: IPlugin = {
+    key: adapter.key,
+    label: adapter.label,
+    version: adapter.version,
+    adapters: [adapter],
+  };
+
+  pluginRegistry.register(plugin);
+  return plugin;
+}

--- a/packages/core/src/factory/registerProductSearchFilter.ts
+++ b/packages/core/src/factory/registerProductSearchFilter.ts
@@ -3,17 +3,20 @@ import { FilterAdapter, type IPlugin, type IFilterAdapter } from '../core-index.
 import { pluginRegistry } from '../plugins/PluginRegistry.ts';
 
 export default function registerProductSearchFilter({
+  adapterId,
   orderIndex = 0,
   search,
 }: {
+  adapterId?: string;
   orderIndex?: number;
   search: (params: SearchQuery & { queryString: string; locale: Intl.Locale }) => Promise<string[]>;
 }): IPlugin {
+  const id = adapterId ?? crypto.randomUUID();
   const adapter: IFilterAdapter = {
     ...FilterAdapter,
 
-    key: `shop.unchained.filters.product-search-${crypto.randomUUID()}`,
-    label: 'Product Search Filter (auto-generated)',
+    key: `shop.unchained.filters.product-search-${id}`,
+    label: adapterId ? `Product Search Filter: ${adapterId}` : 'Product Search Filter (auto-generated)',
     version: '1.0.0',
     orderIndex,
 

--- a/packages/core/src/factory/registerQuotation.ts
+++ b/packages/core/src/factory/registerQuotation.ts
@@ -1,0 +1,93 @@
+import type { QuotationItemConfiguration, QuotationProposal } from '@unchainedshop/core-quotations';
+import {
+  QuotationAdapter,
+  type QuotationContext,
+  type IPlugin,
+  type IQuotationAdapter,
+} from '../core-index.ts';
+import { pluginRegistry } from '../plugins/PluginRegistry.ts';
+
+export default function registerQuotation({
+  adapterId,
+  isManualRequestVerificationRequired,
+  isManualProposalRequired,
+  quote,
+  submitRequest,
+  verifyRequest,
+  rejectRequest,
+  transformItemConfiguration,
+}: {
+  adapterId: string;
+  isManualRequestVerificationRequired?: boolean;
+  isManualProposalRequired?: boolean;
+  quote?: (context: QuotationContext) => Promise<QuotationProposal>;
+  submitRequest?: (context: QuotationContext) => Promise<boolean>;
+  verifyRequest?: (context: QuotationContext) => Promise<boolean>;
+  rejectRequest?: (context: QuotationContext) => Promise<boolean>;
+  transformItemConfiguration?: (
+    params: QuotationItemConfiguration,
+    context: QuotationContext,
+  ) => Promise<QuotationItemConfiguration | null>;
+}): IPlugin {
+  const adapter: IQuotationAdapter = {
+    ...QuotationAdapter,
+
+    key: `shop.unchained.quotation.${adapterId}`,
+    label: 'Quotation: ' + adapterId,
+    version: '1.0.0',
+
+    isActivatedFor: () => {
+      return true;
+    },
+
+    actions: (context) => {
+      return {
+        ...QuotationAdapter.actions(context),
+
+        configurationError: () => {
+          return null;
+        },
+
+        isManualRequestVerificationRequired: async () => {
+          return isManualRequestVerificationRequired ?? true;
+        },
+
+        isManualProposalRequired: async () => {
+          return isManualProposalRequired ?? true;
+        },
+
+        quote: async () => {
+          return quote ? quote(context) : {};
+        },
+
+        submitRequest: async () => {
+          return submitRequest ? submitRequest(context) : true;
+        },
+
+        verifyRequest: async () => {
+          return verifyRequest ? verifyRequest(context) : true;
+        },
+
+        rejectRequest: async () => {
+          return rejectRequest ? rejectRequest(context) : true;
+        },
+
+        transformItemConfiguration: async (params) => {
+          return transformItemConfiguration
+            ? transformItemConfiguration(params, context)
+            : { quantity: params.quantity, configuration: params.configuration };
+        },
+      };
+    },
+  };
+
+  const plugin: IPlugin = {
+    key: adapter.key,
+    label: adapter.label,
+    version: adapter.version,
+    adapters: [adapter],
+  };
+
+  pluginRegistry.register(plugin);
+  return plugin;
+}

--- a/packages/core/src/factory/registerWorker.ts
+++ b/packages/core/src/factory/registerWorker.ts
@@ -17,7 +17,7 @@ export default function registerWorker<Input = any, Result = any>({
 
     key: 'shop.unchained.worker.' + type.toLowerCase(),
     label: 'Worker: ' + type,
-    version: '1.0',
+    version: '1.0.0',
     external: external ?? false,
     maxParallelAllocations,
     type,

--- a/packages/events/src/EventDirector.ts
+++ b/packages/events/src/EventDirector.ts
@@ -8,6 +8,9 @@ export interface RawPayloadType<T> {
 export interface EmitAdapter {
   publish(eventName: string, data: RawPayloadType<Record<string, any>>): void;
   subscribe(eventName: string, callback: (payload: RawPayloadType<Record<string, any>>) => void): void;
+  // Optional teardown for adapters holding long-lived connections (redis,
+  // eventbridge). Called by startPlatform on graceful shutdown.
+  shutdown?(): Promise<void> | void;
 }
 
 const RegisteredEventsSet = new Set();

--- a/packages/platform/src/startPlatform.ts
+++ b/packages/platform/src/startPlatform.ts
@@ -2,6 +2,7 @@ import { startAPIServer, roles, type UnchainedServerOptions } from '@unchainedsh
 import { initCore, type UnchainedCoreOptions, pluginRegistry } from '@unchainedshop/core';
 import { initDb, mongodb, stopDb } from '@unchainedshop/mongodb';
 import { defaultLogger } from '@unchainedshop/logger';
+import { getEmitAdapter } from '@unchainedshop/events';
 import type { UnchainedCore } from '@unchainedshop/core';
 import { setupAccounts } from './setup/setupAccounts.ts';
 import { setupUploadHandlers } from './setup/setupUploadHandlers.ts';
@@ -161,6 +162,9 @@ export const startPlatform = async ({
 
       defaultLogger.debug('Shutting down plugins', { signal });
       await pluginRegistry.shutdown(unchainedAPI);
+
+      defaultLogger.debug('Shutting down event emitter', { signal });
+      await getEmitAdapter()?.shutdown?.();
 
       defaultLogger.debug('Stopping GraphQL server', { signal });
       await graphqlHandler.dispose();

--- a/packages/plugins/src/events/aws-eventbridge.ts
+++ b/packages/plugins/src/events/aws-eventbridge.ts
@@ -2,17 +2,19 @@
  * AWS EventBridge Event Emitter Adapter
  *
  * NOTE: This file uses a different pattern than the plugin architecture.
- * Events adapters implement EmitAdapter interface and are registered via
- * setEmitAdapter() instead of the standard IPlugin pattern.
+ * Events adapters implement the EmitAdapter interface and are registered
+ * explicitly via setEmitAdapter() instead of the standard IPlugin pattern:
  *
- * This adapter auto-configures itself when EVENT_BRIDGE_* env vars are set.
+ *   import { setEmitAdapter } from '@unchainedshop/events';
+ *   import { EventBridgeEventEmitter } from '@unchainedshop/plugins/events/aws-eventbridge';
+ *   setEmitAdapter(await EventBridgeEventEmitter({ region, source, busName }));
  */
-import { type EmitAdapter, setEmitAdapter } from '@unchainedshop/events';
+import type { EmitAdapter } from '@unchainedshop/events';
 import { createLogger } from '@unchainedshop/logger';
 
 const logger = createLogger('unchained:eventbridge');
 
-const EventBridgeEventEmitter = async ({ region, source, busName }): Promise<EmitAdapter> => {
+export const EventBridgeEventEmitter = async ({ region, source, busName }): Promise<EmitAdapter> => {
   // eslint-disable-next-line
   // @ts-expect-error
   const { EventBridgeClient, PutEventsCommand } = await import('@aws-sdk/client-eventbridge');
@@ -40,15 +42,10 @@ const EventBridgeEventEmitter = async ({ region, source, busName }): Promise<Emi
     subscribe: () => {
       throw new Error("You can't subscribe to EventBridge connected Events");
     },
+    shutdown: () => {
+      ebClient.destroy();
+    },
   };
 };
 
-const { EVENT_BRIDGE_REGION, EVENT_BRIDGE_SOURCE, EVENT_BRIDGE_BUS_NAME } = process.env;
-if (EVENT_BRIDGE_REGION && EVENT_BRIDGE_SOURCE && EVENT_BRIDGE_BUS_NAME) {
-  const eventBridgeAdapter = await EventBridgeEventEmitter({
-    source: EVENT_BRIDGE_SOURCE,
-    region: EVENT_BRIDGE_REGION,
-    busName: EVENT_BRIDGE_BUS_NAME,
-  });
-  setEmitAdapter(eventBridgeAdapter);
-}
+export default EventBridgeEventEmitter;

--- a/packages/plugins/src/events/redis.ts
+++ b/packages/plugins/src/events/redis.ts
@@ -2,19 +2,21 @@
  * Redis Event Emitter Adapter
  *
  * NOTE: This file uses a different pattern than the plugin architecture.
- * Events adapters implement EmitAdapter interface and are registered via
- * setEmitAdapter() instead of the standard IPlugin pattern.
+ * Events adapters implement the EmitAdapter interface and are registered
+ * explicitly via setEmitAdapter() instead of the standard IPlugin pattern:
  *
- * This adapter auto-configures itself when REDIS_HOST is set in environment.
+ *   import { setEmitAdapter } from '@unchainedshop/events';
+ *   import { RedisEventEmitter } from '@unchainedshop/plugins/events/redis';
+ *   setEmitAdapter(RedisEventEmitter());
  */
 import { createClient } from '@redis/client';
-import { setEmitAdapter, type EmitAdapter } from '@unchainedshop/events';
+import type { EmitAdapter } from '@unchainedshop/events';
 
 const { REDIS_PORT = '6379', REDIS_HOST, REDIS_DB = '0' } = process.env;
 
 const subscribedEvents = new Set();
 
-const RedisEventEmitter = (): EmitAdapter => {
+export const RedisEventEmitter = (): EmitAdapter => {
   const redisPublisher = createClient({
     url: `redis://${REDIS_HOST}:${REDIS_PORT}`,
     database: parseInt(REDIS_DB, 10),
@@ -35,9 +37,10 @@ const RedisEventEmitter = (): EmitAdapter => {
         subscribedEvents.add(eventName);
       }
     },
+    shutdown: async () => {
+      await Promise.allSettled([redisPublisher.close(), redisSubscriber.close()]);
+    },
   };
 };
 
-if (REDIS_HOST && REDIS_PORT && REDIS_DB) {
-  setEmitAdapter(RedisEventEmitter());
-}
+export default RedisEventEmitter;

--- a/packages/plugins/src/presets/base.ts
+++ b/packages/plugins/src/presets/base.ts
@@ -50,6 +50,9 @@ import { BulkExportPlugin } from '../worker/bulk-export/index.ts';
 
 export function registerBasePlugins() {
   // Files
+  // GridFS is the default storage backend. The S3/Minio backend is opt-in:
+  // register MinioPlugin from '@unchainedshop/plugins/files/minio' *instead of*
+  // GridFSPlugin (getFileAdapter() uses the first registered file adapter).
   pluginRegistry.register(GridFSPlugin);
   pluginRegistry.register(TempUploadPlugin);
 

--- a/tests/plugins-cryptopay.test.js
+++ b/tests/plugins-cryptopay.test.js
@@ -45,7 +45,7 @@ test.describe('Plugins: Cryptopay', () => {
         pricing: [
           {
             amount: 10 ** 7, // 0.1 BTC
-            maxQuantity: 0,
+            minQuantity: 0,
             isTaxable: false,
             isNetPrice: false,
             currencyCode: 'BTC',

--- a/tests/product-commerce.test.js
+++ b/tests/product-commerce.test.js
@@ -71,7 +71,7 @@ test.describe('Product: Commerce', async () => {
             pricing: [
               {
                 amount: 100,
-                maxQuantity: 50,
+                minQuantity: 0,
                 isTaxable: true,
                 isNetPrice: false,
                 currencyCode: 'CHF',
@@ -108,7 +108,7 @@ test.describe('Product: Commerce', async () => {
             pricing: [
               {
                 amount: 100,
-                maxQuantity: 50,
+                minQuantity: 0,
                 isTaxable: true,
                 isNetPrice: false,
                 currencyCode: 'CHF',
@@ -137,7 +137,7 @@ test.describe('Product: Commerce', async () => {
             pricing: [
               {
                 amount: 100,
-                maxQuantity: 50,
+                minQuantity: 0,
                 isTaxable: true,
                 isNetPrice: false,
                 currencyCode: 'CHF',
@@ -169,7 +169,7 @@ test.describe('Product: Commerce', async () => {
             pricing: [
               {
                 amount: 100,
-                maxQuantity: 50,
+                minQuantity: 0,
                 isTaxable: true,
                 isNetPrice: false,
                 currencyCode: 'CHF',

--- a/tests/products.test.js
+++ b/tests/products.test.js
@@ -1863,7 +1863,7 @@ test.describe('Products', () => {
         maxPrice: {
           isTaxable: true,
           isNetPrice: false,
-          amount: 1500000,
+          amount: 10000000,
           currencyCode: 'CHF',
         },
       });
@@ -2010,7 +2010,7 @@ test.describe('Products', () => {
         maxPrice: {
           isTaxable: true,
           isNetPrice: false,
-          amount: 1500000,
+          amount: 10000000,
           currencyCode: 'CHF',
         },
       });

--- a/tests/seeds/assortments.js
+++ b/tests/seeds/assortments.js
@@ -21,7 +21,7 @@ export const SimpleAssortment = [
       pricing: [
         {
           amount: 10000,
-          maxQuantity: 0,
+          minQuantity: 0,
           isTaxable: true,
           isNetPrice: false,
           currencyCode: 'CHF',

--- a/tests/seeds/products.js
+++ b/tests/seeds/products.js
@@ -16,7 +16,7 @@ export const SimpleProduct = {
     pricing: [
       {
         amount: 10000,
-        maxQuantity: 0,
+        minQuantity: 0,
         isTaxable: true,
         isNetPrice: false,
         currencyCode: 'CHF',
@@ -46,7 +46,7 @@ export const LeveledPricingProduct = {
     pricing: [
       {
         amount: 2000,
-        maxQuantity: 3,
+        minQuantity: 3,
         isTaxable: false,
         isNetPrice: false,
         currencyCode: 'CHF',
@@ -54,7 +54,7 @@ export const LeveledPricingProduct = {
       },
       {
         amount: 5000,
-        maxQuantity: 2,
+        minQuantity: 0,
         isTaxable: false,
         isNetPrice: false,
         currencyCode: 'CHF',
@@ -62,6 +62,7 @@ export const LeveledPricingProduct = {
       },
       {
         amount: 10000,
+        minQuantity: 4,
         isTaxable: false,
         isNetPrice: false,
         currencyCode: 'CHF',
@@ -89,7 +90,7 @@ export const SimpleProductDraft = {
     pricing: [
       {
         amount: 10000,
-        maxQuantity: 0,
+        minQuantity: 0,
         isTaxable: true,
         isNetPrice: false,
         currencyCode: 'CHF',
@@ -123,7 +124,7 @@ export const ConfigurableProduct = {
     pricing: [
       {
         amount: 10000,
-        maxQuantity: 0,
+        minQuantity: 0,
         isTaxable: true,
         isNetPrice: false,
         currencyCode: 'CHF',
@@ -157,7 +158,7 @@ export const SimpleProductBundle = {
     pricing: [
       {
         amount: 10000,
-        maxQuantity: 0,
+        minQuantity: 0,
         isTaxable: true,
         isNetPrice: false,
         currencyCode: 'CHF',
@@ -194,7 +195,7 @@ export const PlanProduct = {
     pricing: [
       {
         amount: 10000,
-        maxQuantity: 0,
+        minQuantity: 0,
         isTaxable: true,
         isNetPrice: false,
         currencyCode: 'CHF',
@@ -383,7 +384,7 @@ export const ProxySimpleProduct1 = {
     pricing: [
       {
         amount: 2000000,
-        maxQuantity: 0,
+        minQuantity: 11,
         isTaxable: true,
         isNetPrice: false,
         currencyCode: 'CHF',
@@ -391,14 +392,14 @@ export const ProxySimpleProduct1 = {
       },
       {
         amount: 1500000,
-        maxQuantity: 7,
+        minQuantity: 0,
         isTaxable: true,
         currencyCode: 'CHF',
         countryCode: 'CH',
       },
       {
         amount: 1000000,
-        maxQuantity: 10,
+        minQuantity: 8,
         isTaxable: true,
         currencyCode: 'CHF',
         countryCode: 'CH',
@@ -419,7 +420,7 @@ export const ProxySimpleProduct2 = {
     pricing: [
       {
         amount: 500000,
-        maxQuantity: 1,
+        minQuantity: 0,
         isTaxable: true,
         isNetPrice: false,
         currencyCode: 'CHF',
@@ -427,7 +428,7 @@ export const ProxySimpleProduct2 = {
       },
       {
         amount: 400000,
-        maxQuantity: 5,
+        minQuantity: 2,
         isTaxable: true,
         isNetPrice: false,
         currencyCode: 'CHF',
@@ -435,7 +436,7 @@ export const ProxySimpleProduct2 = {
       },
       {
         amount: 300000,
-        maxQuantity: 10,
+        minQuantity: 6,
         isTaxable: true,
         isNetPrice: false,
         currencyCode: 'CHF',
@@ -459,7 +460,7 @@ export const ProxyPlanProduct1 = {
     pricing: [
       {
         amount: 30000000,
-        maxQuantity: 1,
+        minQuantity: 0,
         isTaxable: true,
         isNetPrice: false,
         currencyCode: 'CHF',
@@ -467,7 +468,7 @@ export const ProxyPlanProduct1 = {
       },
       {
         amount: 20000000,
-        maxQuantity: 2,
+        minQuantity: 2,
         isTaxable: true,
         isNetPrice: false,
         currencyCode: 'CHF',
@@ -475,7 +476,7 @@ export const ProxyPlanProduct1 = {
       },
       {
         amount: 10000000,
-        maxQuantity: 3,
+        minQuantity: 3,
         isTaxable: true,
         currencyCode: 'CHF',
         countryCode: 'CH',
@@ -497,7 +498,7 @@ export const ProxyPlanProduct2 = {
     pricing: [
       {
         amount: 10000000,
-        maxQuantity: 1,
+        minQuantity: 0,
         isTaxable: true,
         isNetPrice: false,
         currencyCode: 'CHF',
@@ -505,14 +506,14 @@ export const ProxyPlanProduct2 = {
       },
       {
         amount: 75000000,
-        maxQuantity: 5,
+        minQuantity: 2,
         isTaxable: true,
         currencyCode: 'CHF',
         countryCode: 'CH',
       },
       {
         amount: 5000000,
-        maxQuantity: 10,
+        minQuantity: 6,
         isTaxable: true,
         currencyCode: 'CHF',
         countryCode: 'CH',
@@ -534,7 +535,7 @@ export const ProxyPlanProduct3 = {
     pricing: [
       {
         amount: 1000000,
-        maxQuantity: 1,
+        minQuantity: 0,
         isTaxable: true,
         isNetPrice: false,
         currencyCode: 'CHF',
@@ -542,14 +543,14 @@ export const ProxyPlanProduct3 = {
       },
       {
         amount: 750000,
-        maxQuantity: 5,
+        minQuantity: 2,
         isTaxable: true,
         currencyCode: 'CHF',
         countryCode: 'CH',
       },
       {
         amount: 5000000,
-        maxQuantity: 10,
+        minQuantity: 6,
         isTaxable: true,
         currencyCode: 'CHF',
         countryCode: 'CH',


### PR DESCRIPTION
## Summary

Five related v5 workstreams plus a documentation overhaul:

1. **Leveled pricing: `maxQuantity` → `minQuantity`** — flips catalog price tiers from inclusive upper bounds to lower-bound floors (base tier `= 0`, highest tier open-ended), with an automatic idempotent startup migration.
2. **`registerX(...)` plugin authoring factories** — a one-call typed factory for a custom adapter of every director type.
3. **Filter factory keys / worker version / Minio** — stable `adapterId`-based keys, version normalization, Minio documented as opt-in.
4. **Events cleanup** — redis/eventbridge emitters are side-effect-free + gain `shutdown()`.
5. **Docs overhaul** — new factory reference, leveled-pricing docs, and removal of the obsolete `Director.registerAdapter()` / class-based pricing API across the site.

## Breaking changes

- **Pricing GraphQL:** `UpdateProductCommercePricingInput.maxQuantity` removed (use `minQuantity`); `PriceLevel.minQuantity` added (`maxQuantity` now derived/nullable); `ProductCatalogPrice.minQuantity` replaces `maxQuantity`. Bulk import/export + MCP product tool use `minQuantity`. **An automatic migration (`20260611120000`) converts existing data on boot — no operator action — but update any code that *writes* prices.**
- **Events:** redis/eventbridge no longer self-register on import — call `setEmitAdapter(RedisEventEmitter())` explicitly.
- **Filter factories:** the 3 filter factories take an optional `adapterId` (stable, dedupe-safe key) instead of a random key.
- `registerPayment` → **`registerPaymentProvider`** (this branch never shipped `registerPayment`).

See `MIGRATION.md` / `CHANGELOG.md` (both updated) for details.

## What's in each commit

| Commit | Area |
|---|---|
| `feat(core-products): key leveled pricing tiers by minQuantity` | Thread A — storage/selection/GraphQL/importer/exporter/MCP flip + migration |
| `docs(changelog): expand v5.0 section` | CHANGELOG v5 |
| `refactor(core): stabilize filter factory keys via optional adapterId` | filter `adapterId`, `registerWorker` version, Minio opt-in doc |
| `refactor(events): side-effect-free emitters + shutdown` | events transport cleanup + `EmitAdapter.shutdown()` |
| `feat(core): generic registerX authoring factories` | 20 `registerX` factories re-exported from `@unchainedshop/core` |
| `docs: v5 plugin registration, registerX factories & leveled pricing` | new Plugin Factories page; concept + pricing rewrites; events/Minio fixes; migration/changelog |

## New public API

`registerPaymentProvider`, `registerDeliveryProvider`, `registerProductPricing`, `registerOrderPricing`, `registerPaymentPricing`, `registerDeliveryPricing`, `registerProductDiscount`, `registerOrderDiscount`, `registerFileAdapter`, `registerQuotation`, `registerEnrollment` (plus the existing invoice/shipping/pickup/physical/virtual/worker/filter factories) — each builds and registers an `IPlugin` in one typed call. `pluginRegistry.register()` remains the low-level primitive.

## Verification

- Full-workspace `tsc -b`: **0 errors**.
- Unit tests green; **~250 pricing-sensitive integration tests pass** (products, cart, orders, enrollment, quotations, cryptopay, …); the migration runs end-to-end on boot.
- Docs: **zero `registerAdapter` code usages remain**; relative links audited (0 broken). The Docusaurus build was not run here (separate project, deps not installed).

## Notes

- The `registerVirtualWarehousing` deletion and ticketing-as-a-plugin were intentionally left to the `built-in-ticket-management` branch.
- Pricing model decision: base tier is `minQuantity: 0` (matches the `quantity: 0` default of range queries), so no selection clamp is needed.
