### PR TITLE
fix(core-filters): prune product id cache rows of removed filter options (port from v4.8.x)

### DIFF
--- a/packages/core-filters/src/db/FiltersCollection.ts
+++ b/packages/core-filters/src/db/FiltersCollection.ts
@@ -18,6 +18,14 @@ export type Filter = {
   type: FilterType;
 } & TimestampFields;
 
+/*
+ * The set of values a filter can be queried by, and thus the keys of its product id cache:
+ * a SWITCH is not backed by options but by the two boolean states, every other type is
+ * defined by its options.
+ */
+export const filterOptionValues = (filter: Pick<Filter, 'type' | 'options'>): string[] =>
+  filter.type === FilterType.SWITCH ? ['true', 'false'] : filter.options || [];
+
 export type FilterText = {
   _id: string;
   filterId: string;

--- a/packages/core-filters/src/filters-settings.ts
+++ b/packages/core-filters/src/filters-settings.ts
@@ -8,6 +8,8 @@ export interface FiltersSettings {
     productIdsMap: Record<string, string[]>,
   ) => Promise<number>;
   getCachedProductIds: (filterId: string) => Promise<[string[], Record<string, string[]>] | null>;
+  /* Drop the whole cache of a filter, used when the filter itself goes away. */
+  purgeCachedProductIds: (filterId: string) => Promise<void>;
   configureSettings: (options: FiltersSettingsOptions, db: mongodb.Db) => void;
 }
 
@@ -16,9 +18,11 @@ export type FiltersSettingsOptions = Omit<Partial<FiltersSettings>, 'configureSe
 export const filtersSettings: FiltersSettings = {
   setCachedProductIds: () => Promise.resolve(0),
   getCachedProductIds: () => Promise.resolve(null),
-  configureSettings: async ({ setCachedProductIds, getCachedProductIds }, db) => {
+  purgeCachedProductIds: () => Promise.resolve(),
+  configureSettings: async ({ setCachedProductIds, getCachedProductIds, purgeCachedProductIds }, db) => {
     const defaultCache = await makeMongoDBCache(db);
     filtersSettings.setCachedProductIds = setCachedProductIds || defaultCache.setCachedProductIds;
     filtersSettings.getCachedProductIds = getCachedProductIds || defaultCache.getCachedProductIds;
+    filtersSettings.purgeCachedProductIds = purgeCachedProductIds || defaultCache.purgeCachedProductIds;
   },
 };

--- a/packages/core-filters/src/module/configureFiltersModule.ts
+++ b/packages/core-filters/src/module/configureFiltersModule.ts
@@ -148,6 +148,7 @@ export const configureFiltersModule = async ({
 
     delete: async (filterId: string) => {
       await filterTexts.deleteMany({ filterId });
+      await filtersSettings.purgeCachedProductIds(filterId);
       const { deletedCount } = await Filters.deleteOne({ _id: filterId });
       await emit('FILTER_REMOVE', { filterId });
       return deletedCount;

--- a/packages/core-filters/src/product-cache/mongodb.ts
+++ b/packages/core-filters/src/product-cache/mongodb.ts
@@ -1,6 +1,6 @@
 import { mongodb } from '@unchainedshop/mongodb';
 import { sha256, memoizeWithTTL } from '@unchainedshop/utils';
-import { FiltersCollection } from '../db/FiltersCollection.ts';
+import { filterOptionValues, FiltersCollection } from '../db/FiltersCollection.ts';
 
 const updateIfHashChanged = async (Collection, selector, doc) => {
   const _id = Object.values(selector).join(':');
@@ -30,7 +30,41 @@ const defaultCacheTtlMs = process.env.NODE_ENV === 'production' ? 60000 : 1;
 const cacheTtlMs = parseInt(process.env.UNCHAINED_FILTER_CACHE_TTL_MS || String(defaultCacheTtlMs), 10);
 
 export default async function mongodbCache(db: mongodb.Db) {
-  const { FilterProductIdCache } = await FiltersCollection(db);
+  const { Filters, FilterProductIdCache } = await FiltersCollection(db);
+
+  // Drop cache rows of filter options that no longer exist, else an obsolete value keeps
+  // resolving to the product ids it had when it was retired.
+  //
+  // The authoritative set is the filter's *current* options, re-read here and not the
+  // productIdsMap we were handed: a full invalidation scans the catalog once per option and
+  // can be in flight for minutes, so its snapshot may already be outdated by the time it
+  // lands. Pruning against the snapshot would delete options added in the meantime, which
+  // turns a stale row into a missing one - a valid option silently resolving to nothing.
+  const purgeCachedProductIds = async (filterId: string) => {
+    await FilterProductIdCache.deleteMany({ filterId });
+  };
+
+  const pruneObsoleteOptions = async (filterId: string) => {
+    try {
+      const filter = await Filters.findOne({ _id: filterId }, { projection: { options: 1, type: 1 } });
+
+      // The filter is gone, so its whole cache is garbage. Covers an invalidation that was
+      // already in flight when the filter got deleted and wrote its rows back afterwards.
+      if (!filter) {
+        await purgeCachedProductIds(filterId);
+        return;
+      }
+
+      // Normalized to strings: cache rows are keyed by object key, so a numerically typed
+      // option would never match its own row and get re-pruned after every write.
+      const currentValues = filterOptionValues(filter).map(String);
+
+      await FilterProductIdCache.deleteMany({
+        filterId,
+        filterOptionValue: { $nin: [null, ...currentValues] },
+      });
+    } catch { } // eslint-disable-line
+  };
 
   const getCachedProductIdsFromMemoryCache = memoizeWithTTL(
     async function getCachedProductIdsFromDatabase(filterId) {
@@ -59,6 +93,7 @@ export default async function mongodbCache(db: mongodb.Db) {
     async getCachedProductIds(filterId: string) {
       return getCachedProductIdsFromMemoryCache(filterId);
     },
+    purgeCachedProductIds,
     async setCachedProductIds(filterId, productIds, productIdsMap) {
       const baseCacheId = await updateIfHashChanged(
         FilterProductIdCache,
@@ -75,6 +110,7 @@ export default async function mongodbCache(db: mongodb.Db) {
         ),
       );
       const allCacheRecords = cacheIds.concat([baseCacheId]).filter(Boolean);
+      await pruneObsoleteOptions(filterId);
       return allCacheRecords.length;
     },
   };

--- a/packages/core/src/services/loadFilterOptions.ts
+++ b/packages/core/src/services/loadFilterOptions.ts
@@ -1,4 +1,4 @@
-import { FilterType, type Filter, type SearchQuery } from '@unchainedshop/core-filters';
+import { filterOptionValues, type Filter, type SearchQuery } from '@unchainedshop/core-filters';
 import type { Modules } from '../modules.ts';
 import { FilterDirector, parseQueryArray } from '../directors/FilterDirector.ts';
 
@@ -16,7 +16,7 @@ export async function loadFilterOptionsService(
   const filterQueryParsed = parseQueryArray(searchQuery?.filterQuery);
   const values = filterQueryParsed[filter.key];
 
-  const allOptions = (filter.type === FilterType.SWITCH && ['true', 'false']) || filter.options || [];
+  const allOptions = filterOptionValues(filter);
   const mappedOptions = await Promise.all(
     allOptions.map(async (value) => {
       const filterOptionProductIds = await FilterDirector.filterProductIds(

--- a/tests/filter-product-id-cache.test.js
+++ b/tests/filter-product-id-cache.test.js
@@ -1,0 +1,156 @@
+import { setupDatabase, createLoggedInGraphqlFetch } from './helpers.js';
+import { getTestPlatform } from './setup.js';
+import { ADMIN_TOKEN } from './seeds/users.js';
+import { filtersSettings } from '@unchainedshop/core-filters';
+import { FilterDirector } from '@unchainedshop/core';
+import assert from 'node:assert';
+import test from 'node:test';
+import { setTimeout } from 'node:timers/promises';
+
+let db;
+let graphqlFetch;
+
+const FILTER_ID = 'regression-721-filter';
+
+const cacheRowIds = async () =>
+  (
+    await db
+      .collection('filter_productId_cache')
+      .find({ filterId: FILTER_ID }, { projection: { _id: 1 } })
+      .sort({ _id: 1 })
+      .toArray()
+  ).map(({ _id }) => _id);
+
+const seedFilter = async (options) => {
+  await db.collection('filters').deleteOne({ _id: FILTER_ID });
+  await db.collection('filter_productId_cache').deleteMany({ filterId: FILTER_ID });
+  await db.collection('filters').insertOne({
+    _id: FILTER_ID,
+    key: 'regression-721-tags',
+    type: 'MULTI_CHOICE',
+    isActive: true,
+    options,
+    created: new Date(),
+  });
+};
+
+const resolve = async (value) => {
+  // Cached reads are memoized in process (1ms TTL outside production, 60s in it). Two reads
+  // within the same millisecond both hit that memo, so wait it out - otherwise we assert
+  // against a map built before the prune rather than against the prune itself.
+  await setTimeout(25);
+  const filter = await db.collection('filters').findOne({ _id: FILTER_ID });
+  const { unchainedAPI } = getTestPlatform();
+  return [...(await FilterDirector.filterProductIds(filter, { values: [value] }, unchainedAPI))];
+};
+
+test.describe('Filter: product id cache invalidation', () => {
+  test.before(async () => {
+    [db] = await setupDatabase();
+    graphqlFetch = createLoggedInGraphqlFetch(ADMIN_TOKEN);
+  });
+
+  test('drops the cache row of an option that is no longer part of the filter', async () => {
+    await seedFilter(['offerable', 'occasion']);
+    await filtersSettings.setCachedProductIds(FILTER_ID, ['p1', 'p2'], {
+      offerable: ['p1'],
+      occasion: ['p2'],
+    });
+    assert.deepStrictEqual(await cacheRowIds(), [
+      `${FILTER_ID}:`,
+      `${FILTER_ID}:occasion`,
+      `${FILTER_ID}:offerable`,
+    ]);
+
+    // `occasion` gets retired, so the next invalidation no longer carries it
+    await db.collection('filters').updateOne({ _id: FILTER_ID }, { $set: { options: ['offerable'] } });
+    await filtersSettings.setCachedProductIds(FILTER_ID, ['p1'], { offerable: ['p1'] });
+
+    assert.deepStrictEqual(await cacheRowIds(), [`${FILTER_ID}:`, `${FILTER_ID}:offerable`]);
+  });
+
+  test('stops resolving a retired option value instead of returning its frozen product ids', async () => {
+    await seedFilter(['offerable', 'occasion']);
+    await filtersSettings.setCachedProductIds(FILTER_ID, ['p1', 'p2'], {
+      offerable: ['p1'],
+      occasion: ['p2'],
+    });
+    assert.deepStrictEqual(await resolve('occasion'), ['p2']);
+
+    await db.collection('filters').updateOne({ _id: FILTER_ID }, { $set: { options: ['offerable'] } });
+    await filtersSettings.setCachedProductIds(FILTER_ID, ['p1'], { offerable: ['p1'] });
+
+    assert.deepStrictEqual(await resolve('occasion'), []);
+    assert.deepStrictEqual(await resolve('offerable'), ['p1']);
+  });
+
+  test('keeps an option that was added while a slow invalidation was still in flight', async () => {
+    await seedFilter(['a', 'b']);
+    // a full invalidation starts here and snapshots [a, b]
+    const staleSnapshot = { a: ['p1'], b: ['p2'] };
+
+    // meanwhile `c` gets added and invalidated on its own
+    await db.collection('filters').updateOne({ _id: FILTER_ID }, { $push: { options: 'c' } });
+    await filtersSettings.setCachedProductIds(FILTER_ID, ['p1', 'p2', 'p3'], {
+      a: ['p1'],
+      b: ['p2'],
+      c: ['p3'],
+    });
+
+    // the slow invalidation lands last, carrying an option set that predates `c`
+    await filtersSettings.setCachedProductIds(FILTER_ID, ['p1', 'p2'], staleSnapshot);
+
+    assert.deepStrictEqual(await cacheRowIds(), [
+      `${FILTER_ID}:`,
+      `${FILTER_ID}:a`,
+      `${FILTER_ID}:b`,
+      `${FILTER_ID}:c`,
+    ]);
+    assert.deepStrictEqual(await resolve('c'), ['p3']);
+  });
+
+  test('drops every cache row of a deleted filter, including a late invalidation', async () => {
+    await seedFilter(['a', 'b']);
+    await filtersSettings.setCachedProductIds(FILTER_ID, ['p1', 'p2'], { a: ['p1'], b: ['p2'] });
+    assert.strictEqual((await cacheRowIds()).length, 3);
+
+    const { data: { removeFilter } = {} } = await graphqlFetch({
+      query: /* GraphQL */ `
+        mutation RemoveFilter($filterId: ID!) {
+          removeFilter(filterId: $filterId) {
+            _id
+          }
+        }
+      `,
+      variables: { filterId: FILTER_ID },
+    });
+    assert.strictEqual(removeFilter._id, FILTER_ID);
+    assert.deepStrictEqual(await cacheRowIds(), []);
+
+    // an invalidation that was already in flight when the filter got deleted
+    await filtersSettings.setCachedProductIds(FILTER_ID, ['p1', 'p2'], { a: ['p1'], b: ['p2'] });
+    assert.deepStrictEqual(await cacheRowIds(), []);
+  });
+
+  test('prunes through the removeFilterOption mutation', async () => {
+    await seedFilter(['keep', 'retire']);
+    await filtersSettings.setCachedProductIds(FILTER_ID, ['p1', 'p2'], {
+      keep: ['p1'],
+      retire: ['p2'],
+    });
+
+    await graphqlFetch({
+      query: /* GraphQL */ `
+        mutation RemoveFilterOption($filterId: ID!, $filterOptionValue: String!) {
+          removeFilterOption(filterId: $filterId, filterOptionValue: $filterOptionValue) {
+            _id
+          }
+        }
+      `,
+      variables: { filterId: FILTER_ID, filterOptionValue: 'retire' },
+    });
+
+    assert.deepStrictEqual(await cacheRowIds(), [`${FILTER_ID}:`, `${FILTER_ID}:keep`]);
+    assert.deepStrictEqual(await resolve('retire'), []);
+  });
+});


### PR DESCRIPTION
Ports the #721 fix from `v4.8.x` (30841bb15) to `master`.

## What was wrong

`setCachedProductIds` only ever upserted, so the cache row of a filter option that got renamed
or removed stayed behind. The lookup map is rebuilt from *every* row of a filter, so the
obsolete value kept resolving to the product ids it had at the moment it was retired, frozen
from then on. Re-invalidating did not help: the map is derived from `filter.options`, so a
value that is no longer an option is simply absent — and absent meant "not written", not
"removed".

RANGE filters are hit harder than #721 describes: their parser resolves `start:end` against the
cached keys, so a retired bucket is picked up by an *ordinary* range query, not only by a query
for the obsolete value itself.

## Notes on the approach

The prune resolves the authoritative option set by re-reading the filter at write time rather
than trusting the `productIdsMap` it was handed. That map is a snapshot taken at the start of a
full invalidation, which scans the catalog once per option and can be in flight for minutes;
pruning against it deletes options added in the meantime, turning a stale row into a missing
one so that a *current* option silently resolves to nothing — a louder failure than the bug
being fixed. There is a regression test for exactly that case.

Deleting a filter drops its cache through the new `filtersSettings.purgeCachedProductIds`, so
the module keeps talking to the settings seam instead of reaching into the cache collection.
Option-level pruning still cannot be expressed through that contract, so custom cache backends
keep the old behaviour — tracked in #722.

## Conflict resolved during the port

`product-cache/mongodb.ts` only — `master` uses `memoizeWithTTL` where `v4.8.x` uses
`pMemoize` + `ExpiryMap`. Kept master's memoization, added the `filterOptionValues` import.

## Verification on master

- Integration: **1001 pass, 0 fail** (ran twice)
- Unit: **589 pass, 0 fail**
- Build + ESLint clean
- Reverting only the `packages/` changes makes 4 of the 5 new tests fail, confirming they guard
  the fix. The fifth is the concurrency guard, which passes on unfixed code by construction —
  without a prune nothing is ever deleted.

One test needed a fix during the port that `v4.8.x` did not surface: cached reads are memoized
in process with a 1 ms TTL outside production, and `memoizeWithTTL` expires on
`Date.now() > expiry`, so two reads inside the same millisecond both hit the memo. The test now
waits that out before asserting.
