### PR TITLE
fix(core-worker): stop autoscheduled work from being queued with a null input (port from v4.8.x)

### DIFF
--- a/packages/core-worker/src/module/configureWorkerModule.ts
+++ b/packages/core-worker/src/module/configureWorkerModule.ts
@@ -534,7 +534,10 @@ export const configureWorkerModule = async ({ db, options }: ModuleInput<WorkerS
           query,
           {
             $set: {
-              input,
+              // Autoscheduled work usually carries no input, and an undefined `$set` value is
+              // stored as null rather than skipped. Keep the same shape `addWork` writes, so
+              // an adapter destructuring its input never faces a null.
+              input: input || {},
               worker: null,
               updated: created,
               retries,

--- a/packages/core/src/directors/WorkerDirector.ts
+++ b/packages/core/src/directors/WorkerDirector.ts
@@ -94,7 +94,9 @@ export const WorkerDirector: IWorkerDirector = {
     }
 
     try {
-      const output = await adapter.doWork(input, unchainedAPI, workId);
+      // Work queued by older versions can still hold a null input, which no default parameter
+      // guards against, so settle it here rather than in every adapter.
+      const output = await adapter.doWork(input ?? {}, unchainedAPI, workId);
       return output;
     } catch (error) {
       // DO not use this as flow control. The adapter should catch expected errors and return status: FAILED

--- a/tests/worker-autoschedule-input.test.js
+++ b/tests/worker-autoschedule-input.test.js
@@ -1,0 +1,80 @@
+import { setupDatabase, disconnect } from './helpers.js';
+import { getTestPlatform } from './setup.js';
+import { WorkerDirector } from '@unchainedshop/core';
+import assert from 'node:assert';
+import test from 'node:test';
+
+let db;
+let modules;
+
+const SCHEDULE_ID = 'shop.unchained.worker-plugin.autoschedule-input-regression';
+const TYPE = 'HEARTBEAT';
+
+const ensure = (input) =>
+  modules.worker.ensureOneWork({
+    type: TYPE,
+    scheduleId: SCHEDULE_ID,
+    scheduled: new Date('2030-01-01T00:30:00.000Z'),
+    retries: 0,
+    input,
+  });
+
+test.describe('Work Queue: autoscheduled input', () => {
+  test.before(async () => {
+    [db] = await setupDatabase();
+    ({ modules } = getTestPlatform().unchainedAPI);
+  });
+
+  test.after(async () => {
+    await db.collection('work_queue').deleteMany({ scheduleId: SCHEDULE_ID });
+    await disconnect();
+  });
+
+  test('stores an empty object when the schedule carries no input', async () => {
+    // An undefined `$set` value is serialized as null rather than skipped, which used to leave
+    // `input: null` on every autoscheduled work item.
+    const work = await ensure(undefined);
+
+    assert.notStrictEqual(work.input, null);
+    assert.deepStrictEqual(work.input, {});
+
+    const stored = await db.collection('work_queue').findOne({ _id: work._id });
+    assert.deepStrictEqual(stored.input, {});
+  });
+
+  test('keeps an input the schedule does provide', async () => {
+    const work = await ensure({ maxAgeDays: 7 });
+    assert.deepStrictEqual(work.input, { maxAgeDays: 7 });
+  });
+
+  test('hands an adapter an object even when the stored input is null', async () => {
+    // Work queued by an older version still holds a null input, and a `= {}` default parameter
+    // only guards undefined - which is what made every GC_GUESTS run fail.
+    let destructured = false;
+    const probe = {
+      key: 'shop.unchained.worker-plugin.autoschedule-input-probe',
+      label: 'Autoschedule input probe',
+      version: '1.0.0',
+      type: 'AUTOSCHEDULE_INPUT_PROBE',
+      doWork: async ({ anything } = {}) => {
+        destructured = true;
+        return { success: true, result: { anything: anything ?? null } };
+      },
+    };
+
+    // Stubbed rather than registered: adapter registration is process wide and differs between
+    // branches, and neither offers a clean way to take a single adapter back out again.
+    const getAdapterByType = WorkerDirector.getAdapterByType;
+    WorkerDirector.getAdapterByType = () => probe;
+    try {
+      const output = await WorkerDirector.doWork(
+        { type: probe.type, input: null, _id: 'probe-work' },
+        getTestPlatform().unchainedAPI,
+      );
+      assert.strictEqual(destructured, true);
+      assert.strictEqual(output.success, true);
+    } finally {
+      WorkerDirector.getAdapterByType = getAdapterByType;
+    }
+  });
+});


### PR DESCRIPTION
Ports 0308e31bf from `v4.8.x`.

## What was wrong

`ensureOneWork` passed `input` straight into `$set`. An undefined value is serialized as null
rather than skipped, so **every autoscheduled work item was stored with `input: null`**.

Adapters that destructure their input with a `= {}` default then threw, because a default
parameter only guards `undefined`:

```
Cannot destructure property 'guestUserMaxAgeInDays' of
'(intermediate value)(intermediate value)(intermediate value)' as it is null.
```

The correlation on a live instance is exact — the only autoscheduled adapters that destructure
are the only ones that ever failed:

| Type | signature | runs |
|---|---|---|
| `GC_GUESTS` | `({ guestUserMaxAgeInDays } = {})` | **0 ok / 11 failed** |
| `INVALIDATE_CARTS` | `({ maxAgeDays } = {})` | **0 ok / 1 failed** |
| `ZOMBIE_KILLER` | `(input, …)` | 11 ok |
| `ENROLLMENT_ORDER_GENERATOR` | `(input, …)` | 308 ok |

Guest garbage collection had therefore never once run since it was introduced.

## Fix

`addWork` has always normalised this with `input || {}`; `ensureOneWork` now does the same. That
asymmetry between the two work-creation paths was the actual defect. Because `ensureOneWork`
`$set`s onto the existing NEW document on each tick, it also repairs queued items in place.

Work queued by already-released versions still holds a null input and does not all self-heal, so
`WorkerDirector.doWork` settles it once at the dispatch boundary rather than leaving every
adapter to guard itself.

The adapters themselves are deliberately untouched — their `= {}` default is correct JavaScript;
they were simply being handed something the contract should never have produced.

## Verification on master

- Integration **999 pass, 0 fail**; unit **589 pass, 0 fail**; build + ESLint clean
- Reverting only `packages/` makes 2 of the 3 new tests fail. The third ("keeps an input the
  schedule does provide") passes either way by design — it is the control that proves the other
  two are not vacuous.

## Difference from the v4.8.x commit

Only the test. `v4.8.x` registers a probe adapter via `WorkerDirector.registerAdapter` /
`unregisterAdapter`; on `master` adapters come from `pluginRegistry`, which has no
single-plugin removal (only `clear()`, far too blunt for a shared test process). The test now
stubs `getAdapterByType` and restores it in a `finally`, which works the same on both branches
and mutates no process-wide state.
