### PR TITLE
perf(core): stop rebuilding the product id accumulator per filter option (port from v4.8.x)

### DIFF
--- a/packages/core/src/directors/FilterDirector.ts
+++ b/packages/core/src/directors/FilterDirector.ts
@@ -169,19 +169,24 @@ export const FilterDirector: IFilterDirector = {
     unchainedAPI: { modules: Modules },
   ): Promise<[string[], Record<string, string[]>]> {
     const allProductIds = await this.findProductIds(filter, {}, unchainedAPI);
-    const productIdsMap =
-      filter.type === FilterType.SWITCH
-        ? {
-            true: await this.findProductIds(filter, { value: true }, unchainedAPI),
-            false: await this.findProductIds(filter, { value: { $in: [null, false] } }, unchainedAPI),
-          }
-        : await (filter.options || []).reduce(async (accumulatorPromise, option) => {
-            const accumulator = await accumulatorPromise;
-            return {
-              ...accumulator,
-              [option]: await this.findProductIds(filter, { value: option }, unchainedAPI),
-            };
-          }, Promise.resolve({}));
+
+    if (filter.type === FilterType.SWITCH) {
+      return [
+        allProductIds,
+        {
+          true: await this.findProductIds(filter, { value: true }, unchainedAPI),
+          false: await this.findProductIds(filter, { value: { $in: [null, false] } }, unchainedAPI),
+        },
+      ];
+    }
+
+    // Collected into one object instead of respreading the accumulator per option: that is
+    // quadratic, and a filter can carry thousands of options. The lookups stay sequential on
+    // purpose, so rebuilding a large filter does not flood the database with parallel scans.
+    const productIdsMap: Record<string, string[]> = {};
+    for (const option of filter.options || []) {
+      productIdsMap[option] = await this.findProductIds(filter, { value: option }, unchainedAPI);
+    }
 
     return [allProductIds, productIdsMap];
   },


### PR DESCRIPTION
Ports 46adb877e from `v4.8.x`. Follows up on the performance note in #722.

## What was wrong

`buildProductIdMap` collected its per-option results with:

```ts
return {
  ...accumulator,
  [option]: await this.findProductIds(filter, { value: option }, unchainedAPI),
};
```

Respreading the accumulator on every iteration re-copies every key gathered so far, making the
collection quadratic in the number of options. It is synchronous work on the event loop, it runs
once per filter, and `invalidateFilterCache` covers *every* filter on boot and after every bulk
import — so it stalled request handling as well as the rebuild itself.

## Measured

Against the previous form, same process, database stubbed so only the accumulator is visible.
The harness asserts both forms return identical output before reporting a speedup:

| options | before | after | speedup |
|---:|---:|---:|---:|
| 100 | 0.6 ms | 0.2 ms | 3.3x |
| 500 | 11.1 ms | 0.3 ms | 39.6x |
| 1000 | 49.2 ms | 0.5 ms | 94.5x |
| 2000 | 340.2 ms | 1.1 ms | 305.9x |
| 4000 | 1355.0 ms | 2.3 ms | 599.5x |

## Deliberately not changed

**The lookups stay sequential.** `core-assortments` marks its equivalent loop *"Process serially
to reduce load"*, and a filter with thousands of options issuing every query at once would trade
one problem for another. Bounded concurrency is worth doing, but it is a separate change with a
different risk profile — noted in #722.

**No use of the `filterOptionValues` helper here.** That helper arrives with #723; keeping
`filter.options || []` lets this land independently, in either order.

The SWITCH branch became an early return so the two shapes stop sharing a ternary. Its queries
are unchanged — it passes `value: true` and `value: { $in: [null, false] }`, which is why it
cannot share the option loop.

## Verification on master

Integration **996 pass, 0 fail**; unit **589 pass, 0 fail**; build + ESLint clean.
