### PR TITLE
fix(core-filters): make the product id cache prune safe to act on, and refuse overtaken writes

### DIFF
--- a/docs/docs/platform-configuration/modules/filters.md
+++ b/docs/docs/platform-configuration/modules/filters.md
@@ -17,6 +17,7 @@ export interface FilterSettingsOptions {
     filterId: string,
     productIds: string[],
     productIdsMap: Record<string, string[]>,
+    computedAt: number,
   ) => Promise<number>;
   getCachedProductIds?: (filterId: string) => Promise<[string[], Record<string, string[]>] | null>;
   purgeCachedProductIds?: (filterId: string) => Promise<void>;
@@ -25,19 +26,24 @@ export interface FilterSettingsOptions {
 
 ### Cache contract
 
+`setCachedProductIds` **replaces** a filter's cache rather than adding to it. `productIdsMap` is
+the complete set of values the filter can be queried by, so an implementation must retire keys it
+does not mention — otherwise an option that was renamed or removed keeps answering with the
+product ids it held when it disappeared.
+
+`computedAt` is the filter generation the map was built from, taken from the filter's own
+`updated` timestamp. Rebuilding scans the catalog once per option, so on a large catalog a
+rebuild can be overtaken while it runs. **An implementation must not let an older generation
+overwrite or retire what a newer one has already written.** Skipping that turns a stale row into
+a missing one: an option added during the rebuild is retired again and silently resolves to
+nothing, with no later rebuild to restore it.
+
+Storing `computedAt` alongside each cached value and comparing before writing or deleting is
+enough. A generation moving without the cache actually changing is harmless — it costs a skipped
+write, and whatever moved it queues an invalidation anyway.
+
 `purgeCachedProductIds` drops a filter's cache outright and is called when the filter is
 deleted.
-
-The default MongoDB implementation additionally retires cached values that are no longer options
-of the filter, by re-reading the filter as it writes. Without that, an option that was renamed or
-removed keeps answering with the product ids it held at the moment it disappeared.
-
-:::caution
-`setCachedProductIds` receives only the values it should store, so a custom backend cannot tell
-which cached values have since been retired. Custom backends therefore keep the old behaviour and
-need their own mechanism for dropping obsolete values — see
-[#722](https://github.com/unchainedshop/unchained/issues/722).
-:::
 
 ### Default Caching Implementation
 

--- a/docs/docs/platform-configuration/modules/filters.md
+++ b/docs/docs/platform-configuration/modules/filters.md
@@ -19,15 +19,33 @@ export interface FilterSettingsOptions {
     productIdsMap: Record<string, string[]>,
   ) => Promise<number>;
   getCachedProductIds?: (filterId: string) => Promise<[string[], Record<string, string[]>] | null>;
+  purgeCachedProductIds?: (filterId: string) => Promise<void>;
 }
 ```
+
+### Cache contract
+
+`purgeCachedProductIds` drops a filter's cache outright and is called when the filter is
+deleted.
+
+The default MongoDB implementation additionally retires cached values that are no longer options
+of the filter, by re-reading the filter as it writes. Without that, an option that was renamed or
+removed keeps answering with the product ids it held at the moment it disappeared.
+
+:::caution
+`setCachedProductIds` receives only the values it should store, so a custom backend cannot tell
+which cached values have since been retired. Custom backends therefore keep the old behaviour and
+need their own mechanism for dropping obsolete values — see
+[#722](https://github.com/unchainedshop/unchained/issues/722).
+:::
 
 ### Default Caching Implementation
 
 - [mongodb](https://github.com/unchainedshop/unchained/blob/master/packages/core-filters/src/product-cache/mongodb.ts)
 
 :::warning
-If you customize `setCachedProductIds`, ensure you also customize `getCachedProductIds`.
+Customize all three together. They fall back to the MongoDB implementation individually, so
+overriding only some of them leaves you reading from one backend and writing to another.
 :::
 
 ## Events

--- a/packages/api/src/mcp/tools/filter/handlers/updateFilter.ts
+++ b/packages/api/src/mcp/tools/filter/handlers/updateFilter.ts
@@ -1,4 +1,5 @@
 import type { Context } from '../../../../context.ts';
+import { FilterDirector } from '@unchainedshop/core';
 import { FilterNotFoundError } from '../../../../errors.ts';
 import { getNormalizedFilterDetails } from '../../../utils/getNormalizedFilterDetails.ts';
 import type { Params } from '../schemas.ts';
@@ -11,7 +12,11 @@ export default async function updateFilter(context: Context, params: Params<'UPD
     throw new FilterNotFoundError({ filterId });
   }
 
-  await modules.filters.update(filterId, updateData as any);
+  const updatedFilter = await modules.filters.update(filterId, updateData as any);
+  // An update can change the key, the type or the options, all of which the product id cache is
+  // derived from. The GraphQL mutation has always invalidated here; this path had not.
+  await FilterDirector.invalidateProductIdCache(updatedFilter!, context);
+
   const normalizedFilter = await getNormalizedFilterDetails(filterId, context);
   return { filter: normalizedFilter };
 }

--- a/packages/core-filters/src/db/FiltersCollection.ts
+++ b/packages/core-filters/src/db/FiltersCollection.ts
@@ -26,6 +26,19 @@ export type Filter = {
 export const filterOptionValues = (filter: Pick<Filter, 'type' | 'options'>): string[] =>
   filter.type === FilterType.SWITCH ? ['true', 'false'] : filter.options || [];
 
+/*
+ * How current a cached result is, taken from the filter itself rather than from a counter of its
+ * own: every mutation stamps `updated`, so a rebuild that started before one has an older
+ * generation than the filter it ends up writing against.
+ *
+ * Deliberately coarse. A change that leaves the cache perfectly valid still moves it, which only
+ * costs a skipped write - and the mutation that moved it queues an invalidation anyway. Being
+ * wrong in the other direction would publish results computed against a filter that no longer
+ * exists in that shape.
+ */
+export const filterCacheGeneration = (filter: Pick<Filter, 'updated' | 'created'>): number =>
+  filter?.updated?.getTime() || filter?.created?.getTime() || 0;
+
 export type FilterText = {
   _id: string;
   filterId: string;
@@ -39,6 +52,8 @@ export interface FilterProductIdCacheRecord {
   filterId: string;
   filterOptionValue: string | null;
   productIds: string[];
+  /* The filter generation this row was computed from, see filterCacheGeneration. */
+  computedAt?: number;
 }
 
 export const FiltersCollection = async (db: mongodb.Db) => {

--- a/packages/core-filters/src/filters-settings.ts
+++ b/packages/core-filters/src/filters-settings.ts
@@ -1,15 +1,7 @@
 import { mongodb } from '@unchainedshop/mongodb';
-import { createLogger } from '@unchainedshop/logger';
 import makeMongoDBCache from './product-cache/mongodb.ts';
 
-const logger = createLogger('unchained:core-filters');
-
 export interface FiltersSettings {
-  /*
-   * Replaces the cached product ids of a filter: `productIdsMap` is the complete set of values
-   * the filter can be queried by, and an implementation is expected to retire keys it does not
-   * mention. Callers are responsible for handing over an up to date map.
-   */
   setCachedProductIds: (
     filterId: string,
     productIds: string[],
@@ -28,15 +20,6 @@ export const filtersSettings: FiltersSettings = {
   getCachedProductIds: () => Promise.resolve(null),
   purgeCachedProductIds: () => Promise.resolve(),
   configureSettings: async ({ setCachedProductIds, getCachedProductIds, purgeCachedProductIds }, db) => {
-    // Each member falls back on its own, so overriding only some of them silently runs two
-    // cache backends side by side - reads from one, writes to the other.
-    const overridden = [setCachedProductIds, getCachedProductIds, purgeCachedProductIds].filter(Boolean);
-    if (overridden.length && overridden.length < 3) {
-      logger.warn(
-        'Product id cache is only partially overridden, the remaining members fall back to the MongoDB cache. Provide setCachedProductIds, getCachedProductIds and purgeCachedProductIds together.',
-      );
-    }
-
     const defaultCache = await makeMongoDBCache(db);
     filtersSettings.setCachedProductIds = setCachedProductIds || defaultCache.setCachedProductIds;
     filtersSettings.getCachedProductIds = getCachedProductIds || defaultCache.getCachedProductIds;

--- a/packages/core-filters/src/filters-settings.ts
+++ b/packages/core-filters/src/filters-settings.ts
@@ -5,10 +5,19 @@ import makeMongoDBCache from './product-cache/mongodb.ts';
 const logger = createLogger('unchained:core-filters');
 
 export interface FiltersSettings {
+  /*
+   * Replaces the cached product ids of a filter. `productIdsMap` is the complete set of values it
+   * can be queried by, so an implementation is expected to retire keys it does not mention.
+   *
+   * `computedAt` is the filter generation the map was built from, see filterCacheGeneration.
+   * Rebuilding is slow enough to be overtaken, so an implementation must not let an older
+   * generation overwrite or retire what a newer one has already written.
+   */
   setCachedProductIds: (
     filterId: string,
     productIds: string[],
     productIdsMap: Record<string, string[]>,
+    computedAt: number,
   ) => Promise<number>;
   getCachedProductIds: (filterId: string) => Promise<[string[], Record<string, string[]>] | null>;
   /* Drop the whole cache of a filter, used when the filter itself goes away. */

--- a/packages/core-filters/src/filters-settings.ts
+++ b/packages/core-filters/src/filters-settings.ts
@@ -1,5 +1,8 @@
 import { mongodb } from '@unchainedshop/mongodb';
+import { createLogger } from '@unchainedshop/logger';
 import makeMongoDBCache from './product-cache/mongodb.ts';
+
+const logger = createLogger('unchained:core-filters');
 
 export interface FiltersSettings {
   setCachedProductIds: (
@@ -20,6 +23,15 @@ export const filtersSettings: FiltersSettings = {
   getCachedProductIds: () => Promise.resolve(null),
   purgeCachedProductIds: () => Promise.resolve(),
   configureSettings: async ({ setCachedProductIds, getCachedProductIds, purgeCachedProductIds }, db) => {
+    // Each member falls back on its own, so overriding only some of them silently runs two
+    // cache backends side by side - reading from one and writing to the other.
+    const overridden = [setCachedProductIds, getCachedProductIds, purgeCachedProductIds].filter(Boolean);
+    if (overridden.length && overridden.length < 3) {
+      logger.warn(
+        'Product id cache is only partially overridden, the remaining members fall back to the MongoDB cache. Provide setCachedProductIds, getCachedProductIds and purgeCachedProductIds together.',
+      );
+    }
+
     const defaultCache = await makeMongoDBCache(db);
     filtersSettings.setCachedProductIds = setCachedProductIds || defaultCache.setCachedProductIds;
     filtersSettings.getCachedProductIds = getCachedProductIds || defaultCache.getCachedProductIds;

--- a/packages/core-filters/src/module/configureFiltersModule.ts
+++ b/packages/core-filters/src/module/configureFiltersModule.ts
@@ -1,4 +1,5 @@
 import { emit, registerEvents } from '@unchainedshop/events';
+import { createLogger } from '@unchainedshop/logger';
 import { SortDirection, type SortOption } from '@unchainedshop/utils';
 import {
   mongodb,
@@ -16,6 +17,8 @@ import type { FilterQuery } from '../search.ts';
 export type FilterOption = Filter & {
   filterOption: string;
 };
+
+const logger = createLogger('unchained:core-filters');
 
 const FILTER_EVENTS = ['FILTER_CREATE', 'FILTER_REMOVE', 'FILTER_UPDATE'];
 
@@ -148,8 +151,19 @@ export const configureFiltersModule = async ({
 
     delete: async (filterId: string) => {
       await filterTexts.deleteMany({ filterId });
-      await filtersSettings.purgeCachedProductIds(filterId);
       const { deletedCount } = await Filters.deleteOne({ _id: filterId });
+
+      // After the filter is gone, and tolerated when it fails: the cache is derived data, so a
+      // backend being unavailable must not leave the filter half deleted with its texts
+      // already removed. Rows that survive belong to a filter nothing can query any more.
+      try {
+        await filtersSettings.purgeCachedProductIds(filterId);
+      } catch (e) {
+        logger.warn(`Failed to purge the product id cache of removed filter ${filterId}`, {
+          error: (e as Error).message,
+        });
+      }
+
       await emit('FILTER_REMOVE', { filterId });
       return deletedCount;
     },

--- a/packages/core-filters/src/product-cache/mongodb.ts
+++ b/packages/core-filters/src/product-cache/mongodb.ts
@@ -2,7 +2,7 @@ import { mongodb } from '@unchainedshop/mongodb';
 import { sha256 } from '@unchainedshop/utils';
 import pMemoize from 'p-memoize';
 import ExpiryMap from 'expiry-map';
-import { FiltersCollection } from '../db/FiltersCollection.ts';
+import { filterOptionValues, FiltersCollection } from '../db/FiltersCollection.ts';
 
 const updateIfHashChanged = async (Collection, selector, doc) => {
   const _id = Object.values(selector).join(':');
@@ -32,23 +32,38 @@ const CACHE_TTL_MS = parseInt(process.env.UNCHAINED_FILTER_CACHE_TTL_MS || '6000
 const memoizeCache = new ExpiryMap(process.env.NODE_ENV === 'production' ? CACHE_TTL_MS : 1);
 
 export default async function mongodbCache(db: mongodb.Db) {
-  const { FilterProductIdCache } = await FiltersCollection(db);
+  const { Filters, FilterProductIdCache } = await FiltersCollection(db);
 
+  // Drop cache rows of filter options that no longer exist, else an obsolete value keeps
+  // resolving to the product ids it had when it was retired.
+  //
+  // The authoritative set is the filter's *current* options, re-read here and not the
+  // productIdsMap we were handed: a full invalidation scans the catalog once per option and
+  // can be in flight for minutes, so its snapshot may already be outdated by the time it
+  // lands. Pruning against the snapshot would delete options added in the meantime, which
+  // turns a stale row into a missing one - a valid option silently resolving to nothing.
   const purgeCachedProductIds = async (filterId: string) => {
     await FilterProductIdCache.deleteMany({ filterId });
   };
 
-  // `setCachedProductIds` replaces a filter's cache rather than adding to it, so anything the
-  // new map does not mention is retired. Without this an option that was renamed or removed
-  // kept answering with the product ids it held the moment it disappeared.
-  //
-  // The caller guarantees the map is current - see FilterDirector.invalidateProductIdCache,
-  // which drops results that a concurrent option change has superseded.
-  const pruneObsoleteOptions = async (filterId: string, productIdsMap: Record<string, string[]>) => {
+  const pruneObsoleteOptions = async (filterId: string) => {
     try {
+      const filter = await Filters.findOne({ _id: filterId }, { projection: { options: 1, type: 1 } });
+
+      // The filter is gone, so its whole cache is garbage. Covers an invalidation that was
+      // already in flight when the filter got deleted and wrote its rows back afterwards.
+      if (!filter) {
+        await purgeCachedProductIds(filterId);
+        return;
+      }
+
+      // Normalized to strings: cache rows are keyed by object key, so a numerically typed
+      // option would never match its own row and get re-pruned after every write.
+      const currentValues = filterOptionValues(filter).map(String);
+
       await FilterProductIdCache.deleteMany({
         filterId,
-        filterOptionValue: { $nin: [null, ...Object.keys(productIdsMap)] },
+        filterOptionValue: { $nin: [null, ...currentValues] },
       });
     } catch { } // eslint-disable-line
   };
@@ -99,7 +114,7 @@ export default async function mongodbCache(db: mongodb.Db) {
         ),
       );
       const allCacheRecords = cacheIds.concat([baseCacheId]).filter(Boolean);
-      await pruneObsoleteOptions(filterId, productIdsMap);
+      await pruneObsoleteOptions(filterId);
       return allCacheRecords.length;
     },
   };

--- a/packages/core-filters/src/product-cache/mongodb.ts
+++ b/packages/core-filters/src/product-cache/mongodb.ts
@@ -4,6 +4,8 @@ import pMemoize from 'p-memoize';
 import ExpiryMap from 'expiry-map';
 import { filterOptionValues, FiltersCollection } from '../db/FiltersCollection.ts';
 
+const DUPLICATE_KEY = 11000;
+
 const updateIfHashChanged = async (Collection, selector, doc) => {
   const _id = Object.values(selector).join(':');
   try {
@@ -24,8 +26,13 @@ const updateIfHashChanged = async (Collection, selector, doc) => {
       },
       { upsert: true },
     );
-  } catch (e) { } // eslint-disable-line
-  return _id;
+  } catch (e) {
+    // The row already holds this hash, so the upsert collides on _id and there is nothing to
+    // do. Anything else means we did not write, which the caller has to know before it starts
+    // deleting the rows this write was meant to replace.
+    if (e?.code !== DUPLICATE_KEY) return { _id, written: false };
+  }
+  return { _id, written: true };
 };
 
 const CACHE_TTL_MS = parseInt(process.env.UNCHAINED_FILTER_CACHE_TTL_MS || '60000', 10);
@@ -33,6 +40,12 @@ const memoizeCache = new ExpiryMap(process.env.NODE_ENV === 'production' ? CACHE
 
 export default async function mongodbCache(db: mongodb.Db) {
   const { Filters, FilterProductIdCache } = await FiltersCollection(db);
+  // Reads are memoized per process, so a write nobody evicts stays invisible for the whole TTL
+  // - a minute in production. Long enough for a retired option to keep answering and a newly
+  // added one to answer with nothing.
+  const evictFromMemoryCache = (filterId: string) => {
+    memoizeCache.delete(filterId);
+  };
 
   // Drop cache rows of filter options that no longer exist, else an obsolete value keeps
   // resolving to the product ids it had when it was retired.
@@ -44,6 +57,7 @@ export default async function mongodbCache(db: mongodb.Db) {
   // turns a stale row into a missing one - a valid option silently resolving to nothing.
   const purgeCachedProductIds = async (filterId: string) => {
     await FilterProductIdCache.deleteMany({ filterId });
+    evictFromMemoryCache(filterId);
   };
 
   const pruneObsoleteOptions = async (filterId: string) => {
@@ -90,6 +104,7 @@ export default async function mongodbCache(db: mongodb.Db) {
     },
     {
       cache: memoizeCache,
+      cacheKey: ([filterId]) => filterId,
     },
   );
 
@@ -99,12 +114,12 @@ export default async function mongodbCache(db: mongodb.Db) {
     },
     purgeCachedProductIds,
     async setCachedProductIds(filterId, productIds, productIdsMap) {
-      const baseCacheId = await updateIfHashChanged(
+      const baseRecord = await updateIfHashChanged(
         FilterProductIdCache,
         { filterId, filterOptionValue: null },
         { productIds },
       );
-      const cacheIds = await Promise.all(
+      const optionRecords = await Promise.all(
         Object.entries(productIdsMap).map(async ([filterOptionValue, optionProductIds]) =>
           updateIfHashChanged(
             FilterProductIdCache,
@@ -113,8 +128,17 @@ export default async function mongodbCache(db: mongodb.Db) {
           ),
         ),
       );
-      const allCacheRecords = cacheIds.concat([baseCacheId]).filter(Boolean);
-      await pruneObsoleteOptions(filterId);
+      const allCacheRecords = optionRecords.concat([baseRecord]);
+      evictFromMemoryCache(filterId);
+
+      // Only once every row is in place. Retiring the old values while the new ones are missing
+      // would leave a live option resolving to nothing, and the surviving base row would stop
+      // the live fallback from covering for it.
+      if (allCacheRecords.every(({ written }) => written)) {
+        await pruneObsoleteOptions(filterId);
+        evictFromMemoryCache(filterId);
+      }
+
       return allCacheRecords.length;
     },
   };

--- a/packages/core-filters/src/product-cache/mongodb.ts
+++ b/packages/core-filters/src/product-cache/mongodb.ts
@@ -2,23 +2,40 @@ import { mongodb } from '@unchainedshop/mongodb';
 import { sha256 } from '@unchainedshop/utils';
 import pMemoize from 'p-memoize';
 import ExpiryMap from 'expiry-map';
-import { filterOptionValues, FiltersCollection } from '../db/FiltersCollection.ts';
+import { FiltersCollection } from '../db/FiltersCollection.ts';
 
 const DUPLICATE_KEY = 11000;
 
-const updateIfHashChanged = async (Collection, selector, doc) => {
+/*
+ * Rebuilding scans the catalog once per option, so on a large catalog a rebuild is in flight long
+ * enough for the filter to change underneath it. Rows record the generation they were computed
+ * from, and neither a write nor a prune touches a row a newer generation already claimed.
+ *
+ * This is what makes replacement safe. Without it an overtaken rebuild publishes ids computed
+ * against a filter that has since been renamed or retyped, and retires the options added while it
+ * was running - a live option silently resolving to nothing, with no later rebuild to restore it.
+ *
+ * Rows written before this field existed carry none, which counts as older than anything.
+ */
+const notNewerThan = (computedAt: number) => ({
+  $or: [{ computedAt: { $lte: computedAt } }, { computedAt: { $exists: false } }],
+});
+
+const updateIfHashChanged = async (Collection, selector, doc, computedAt: number) => {
   const _id = Object.values(selector).join(':');
   try {
     const hash = await sha256(JSON.stringify(doc));
     await Collection.updateOne(
       {
         ...selector,
+        ...notNewerThan(computedAt),
         hash: { $ne: hash },
       },
       {
         $set: {
           ...doc,
           hash,
+          computedAt,
         },
         $setOnInsert: {
           _id,
@@ -27,9 +44,9 @@ const updateIfHashChanged = async (Collection, selector, doc) => {
       { upsert: true },
     );
   } catch (e) {
-    // The row already holds this hash, so the upsert collides on _id and there is nothing to
-    // do. Anything else means we did not write, which the caller has to know before it starts
-    // deleting the rows this write was meant to replace.
+    // The row already holds this hash, or a newer generation already claimed it. Either way the
+    // upsert collides on _id and there is nothing to do. Anything else means we did not write,
+    // which the caller has to know before it starts deleting the rows this was meant to replace.
     if (e?.code !== DUPLICATE_KEY) return { _id, written: false };
   }
   return { _id, written: true };
@@ -39,47 +56,18 @@ const CACHE_TTL_MS = parseInt(process.env.UNCHAINED_FILTER_CACHE_TTL_MS || '6000
 const memoizeCache = new ExpiryMap(process.env.NODE_ENV === 'production' ? CACHE_TTL_MS : 1);
 
 export default async function mongodbCache(db: mongodb.Db) {
-  const { Filters, FilterProductIdCache } = await FiltersCollection(db);
-  // Reads are memoized per process, so a write nobody evicts stays invisible for the whole TTL
-  // - a minute in production. Long enough for a retired option to keep answering and a newly
-  // added one to answer with nothing.
+  const { FilterProductIdCache } = await FiltersCollection(db);
+
+  // Reads are memoized per process, so a write nobody evicts stays invisible for the whole TTL -
+  // a minute in production. Long enough for a retired option to keep answering and a newly added
+  // one to answer with nothing.
   const evictFromMemoryCache = (filterId: string) => {
     memoizeCache.delete(filterId);
   };
 
-  // Drop cache rows of filter options that no longer exist, else an obsolete value keeps
-  // resolving to the product ids it had when it was retired.
-  //
-  // The authoritative set is the filter's *current* options, re-read here and not the
-  // productIdsMap we were handed: a full invalidation scans the catalog once per option and
-  // can be in flight for minutes, so its snapshot may already be outdated by the time it
-  // lands. Pruning against the snapshot would delete options added in the meantime, which
-  // turns a stale row into a missing one - a valid option silently resolving to nothing.
   const purgeCachedProductIds = async (filterId: string) => {
     await FilterProductIdCache.deleteMany({ filterId });
     evictFromMemoryCache(filterId);
-  };
-
-  const pruneObsoleteOptions = async (filterId: string) => {
-    try {
-      const filter = await Filters.findOne({ _id: filterId }, { projection: { options: 1, type: 1 } });
-
-      // The filter is gone, so its whole cache is garbage. Covers an invalidation that was
-      // already in flight when the filter got deleted and wrote its rows back afterwards.
-      if (!filter) {
-        await purgeCachedProductIds(filterId);
-        return;
-      }
-
-      // Normalized to strings: cache rows are keyed by object key, so a numerically typed
-      // option would never match its own row and get re-pruned after every write.
-      const currentValues = filterOptionValues(filter).map(String);
-
-      await FilterProductIdCache.deleteMany({
-        filterId,
-        filterOptionValue: { $nin: [null, ...currentValues] },
-      });
-    } catch { } // eslint-disable-line
   };
 
   const getCachedProductIdsFromMemoryCache = pMemoize(
@@ -113,11 +101,12 @@ export default async function mongodbCache(db: mongodb.Db) {
       return getCachedProductIdsFromMemoryCache(filterId);
     },
     purgeCachedProductIds,
-    async setCachedProductIds(filterId, productIds, productIdsMap) {
+    async setCachedProductIds(filterId, productIds, productIdsMap, computedAt = 0) {
       const baseRecord = await updateIfHashChanged(
         FilterProductIdCache,
         { filterId, filterOptionValue: null },
         { productIds },
+        computedAt,
       );
       const optionRecords = await Promise.all(
         Object.entries(productIdsMap).map(async ([filterOptionValue, optionProductIds]) =>
@@ -125,17 +114,26 @@ export default async function mongodbCache(db: mongodb.Db) {
             FilterProductIdCache,
             { filterId, filterOptionValue },
             { productIds: optionProductIds },
+            computedAt,
           ),
         ),
       );
+
       const allCacheRecords = optionRecords.concat([baseRecord]);
       evictFromMemoryCache(filterId);
 
-      // Only once every row is in place. Retiring the old values while the new ones are missing
-      // would leave a live option resolving to nothing, and the surviving base row would stop
-      // the live fallback from covering for it.
+      // Retire whatever this generation does not mention, leaving alone anything a newer one has
+      // already written.
+      //
+      // Skipped entirely if any row failed to write: retiring the old values while the new ones
+      // are missing would leave a live option resolving to nothing, and the surviving base row
+      // would stop the live fallback from covering for it.
       if (allCacheRecords.every(({ written }) => written)) {
-        await pruneObsoleteOptions(filterId);
+        await FilterProductIdCache.deleteMany({
+          filterId,
+          filterOptionValue: { $nin: [null, ...Object.keys(productIdsMap)] },
+          ...notNewerThan(computedAt),
+        });
         evictFromMemoryCache(filterId);
       }
 

--- a/packages/core/src/directors/FilterDirector.ts
+++ b/packages/core/src/directors/FilterDirector.ts
@@ -170,7 +170,11 @@ export const FilterDirector: IFilterDirector = {
     // Collected into one object instead of respreading the accumulator per option: that is
     // quadratic, and a filter can carry thousands of options. The lookups stay sequential on
     // purpose, so rebuilding a large filter does not flood the database with parallel scans.
-    const productIdsMap: Record<string, string[]> = {};
+    //
+    // Null-prototyped because option values are arbitrary strings: assigning `__proto__` into a
+    // normal object walks into the prototype setter instead of creating a key, and the option
+    // would then be missing from everything derived from this map.
+    const productIdsMap: Record<string, string[]> = Object.create(null);
     for (const option of filter.options || []) {
       productIdsMap[option] = await this.findProductIds(filter, { value: option }, unchainedAPI);
     }
@@ -197,10 +201,13 @@ export const FilterDirector: IFilterDirector = {
 
     const result = new Set<string>();
     for (const key of filteredKeys as string[]) {
+      // Own properties only. The keys come straight from a user supplied filterQuery, so
+      // asking for `constructor` or `toString` would otherwise reach Object.prototype and
+      // throw while iterating it.
+      if (!Object.hasOwn(keyToProductIdMap, key)) continue;
       const additionalValues = keyToProductIdMap[key];
-      if (additionalValues) {
-        for (const val of additionalValues) result.add(val);
-      }
+      if (!additionalValues) continue;
+      for (const val of additionalValues) result.add(val);
     }
     return result;
   },

--- a/packages/core/src/directors/FilterDirector.ts
+++ b/packages/core/src/directors/FilterDirector.ts
@@ -3,6 +3,7 @@ import { BaseDirector, type IBaseDirector } from '@unchainedshop/utils';
 import type { FilterAdapterActions, FilterContext, IFilterAdapter } from './FilterAdapter.ts';
 import {
   type Filter,
+  filterCacheGeneration,
   filtersSettings,
   FilterType,
   type SearchConfiguration,
@@ -321,6 +322,20 @@ export const FilterDirector: IFilterDirector = {
     if (!filter) return;
 
     const [productIds, productIdMap] = await this.buildProductIdMap(filter, unchainedAPI);
-    await filtersSettings.setCachedProductIds(filter._id, productIds, productIdMap);
+
+    // A deleted filter has no generation left to be overtaken by, so it needs its own check.
+    // This is about not rebuilding the cache of something that no longer exists rather than
+    // about correctness: a rebuild that slips past it leaves orphan rows, not wrong answers,
+    // because nothing can query a filter that is gone.
+    if (!(await unchainedAPI.modules.filters.filterExists({ filterId: filter._id }))) return;
+
+    // Stamped with the generation this map was built from, so a rebuild that has been overtaken
+    // while it scanned cannot publish ids computed against a filter that has since changed.
+    await filtersSettings.setCachedProductIds(
+      filter._id,
+      productIds,
+      productIdMap,
+      filterCacheGeneration(filter),
+    );
   },
 };

--- a/packages/core/src/directors/FilterDirector.ts
+++ b/packages/core/src/directors/FilterDirector.ts
@@ -3,7 +3,6 @@ import { BaseDirector, type IBaseDirector } from '@unchainedshop/utils';
 import type { FilterAdapterActions, FilterContext, IFilterAdapter } from './FilterAdapter.ts';
 import {
   type Filter,
-  filterOptionValues,
   filtersSettings,
   FilterType,
   type SearchConfiguration,
@@ -63,14 +62,6 @@ export type IFilterDirector = IBaseDirector<IFilterAdapter> & {
     searchConfiguration: SearchConfiguration,
     unchainedAPI: { modules: Modules },
   ) => Promise<string[]>;
-};
-
-// Compared as a set: reordering options leaves every cache key valid, only losing or gaining
-// one matters.
-const sameOptionSet = (left: string[], right: string[]) => {
-  if (left.length !== right.length) return false;
-  const values = new Set(left);
-  return right.every((value) => values.has(value));
 };
 
 const baseDirector = BaseDirector<IFilterAdapter>('FilterDirector', {
@@ -323,15 +314,6 @@ export const FilterDirector: IFilterDirector = {
     if (!filter) return;
 
     const [productIds, productIdMap] = await this.buildProductIdMap(filter, unchainedAPI);
-
-    // Building the map scans the catalog once per option, so it can be in flight long enough
-    // for the option set to move underneath it. Publishing a superseded result would cache
-    // product ids that were already wrong when they were written, and since the cache replaces
-    // what it is given, it would also retire the options added in the meantime. Whoever changed
-    // the options queues an invalidation of their own, so dropping this one loses nothing.
-    const current = await unchainedAPI.modules.filters.findFilter({ filterId: filter._id });
-    if (!current || !sameOptionSet(filterOptionValues(current), filterOptionValues(filter))) return;
-
     await filtersSettings.setCachedProductIds(filter._id, productIds, productIdMap);
   },
 };

--- a/tests/filter-product-id-cache.test.js
+++ b/tests/filter-product-id-cache.test.js
@@ -132,6 +132,38 @@ test.describe('Filter: product id cache invalidation', () => {
     assert.deepStrictEqual(await cacheRowIds(), []);
   });
 
+  test('treats inherited property names as ordinary option values', async () => {
+    // The values come from a user supplied filterQuery, so they can name anything on
+    // Object.prototype. Those used to reach the prototype and throw while being iterated.
+    await seedFilter(['__proto__', 'regular']);
+    // Built through fromEntries on purpose: `{ __proto__: value }` in a literal sets the
+    // prototype instead of creating the key, which is the same hazard being tested for.
+    await filtersSettings.setCachedProductIds(
+      FILTER_ID,
+      ['p1', 'p2'],
+      Object.fromEntries([
+        ['__proto__', ['p1']],
+        ['regular', ['p2']],
+      ]),
+    );
+
+    assert.deepStrictEqual(await resolve('regular'), ['p2']);
+    assert.deepStrictEqual(await resolve('__proto__'), ['p1']);
+    for (const inherited of ['constructor', 'toString', 'hasOwnProperty', 'valueOf']) {
+      assert.deepStrictEqual(await resolve(inherited), [], `${inherited} should resolve to nothing`);
+    }
+  });
+
+  test('keeps an option literally named __proto__ when building the map', async () => {
+    await seedFilter(['__proto__', 'regular']);
+    const filter = await db.collection('filters').findOne({ _id: FILTER_ID });
+    const [, productIdsMap] = await FilterDirector.buildProductIdMap(
+      filter,
+      getTestPlatform().unchainedAPI,
+    );
+    assert.deepStrictEqual(Object.keys(productIdsMap).sort(), ['__proto__', 'regular']);
+  });
+
   test('prunes through the removeFilterOption mutation', async () => {
     await seedFilter(['keep', 'retire']);
     await filtersSettings.setCachedProductIds(FILTER_ID, ['p1', 'p2'], {

--- a/tests/filter-product-id-cache.test.js
+++ b/tests/filter-product-id-cache.test.js
@@ -21,7 +21,7 @@ const cacheRowIds = async () =>
       .toArray()
   ).map(({ _id }) => _id);
 
-const seedFilter = async (options) => {
+const seedFilter = async (options, updated = new Date('2020-01-01')) => {
   await db.collection('filters').deleteOne({ _id: FILTER_ID });
   await db.collection('filter_productId_cache').deleteMany({ filterId: FILTER_ID });
   await db.collection('filters').insertOne({
@@ -30,7 +30,8 @@ const seedFilter = async (options) => {
     type: 'MULTI_CHOICE',
     isActive: true,
     options,
-    created: new Date(),
+    created: new Date('2019-01-01'),
+    updated,
   });
 };
 
@@ -59,10 +60,12 @@ test.describe('Filter: product id cache invalidation', () => {
 
   test('drops the cache row of an option that is no longer part of the filter', async () => {
     await seedFilter(['offerable', 'occasion']);
-    await filtersSettings.setCachedProductIds(FILTER_ID, ['p1', 'p2'], {
-      offerable: ['p1'],
-      occasion: ['p2'],
-    });
+    await filtersSettings.setCachedProductIds(
+      FILTER_ID,
+      ['p1', 'p2'],
+      { offerable: ['p1'], occasion: ['p2'] },
+      1,
+    );
     assert.deepStrictEqual(await cacheRowIds(), [
       `${FILTER_ID}:`,
       `${FILTER_ID}:occasion`,
@@ -71,41 +74,45 @@ test.describe('Filter: product id cache invalidation', () => {
 
     // `occasion` gets retired, so the next invalidation no longer carries it
     await db.collection('filters').updateOne({ _id: FILTER_ID }, { $set: { options: ['offerable'] } });
-    await filtersSettings.setCachedProductIds(FILTER_ID, ['p1'], { offerable: ['p1'] });
+    await filtersSettings.setCachedProductIds(FILTER_ID, ['p1'], { offerable: ['p1'] }, 2);
 
     assert.deepStrictEqual(await cacheRowIds(), [`${FILTER_ID}:`, `${FILTER_ID}:offerable`]);
   });
 
   test('stops resolving a retired option value instead of returning its frozen product ids', async () => {
     await seedFilter(['offerable', 'occasion']);
-    await filtersSettings.setCachedProductIds(FILTER_ID, ['p1', 'p2'], {
-      offerable: ['p1'],
-      occasion: ['p2'],
-    });
+    await filtersSettings.setCachedProductIds(
+      FILTER_ID,
+      ['p1', 'p2'],
+      { offerable: ['p1'], occasion: ['p2'] },
+      1,
+    );
     assert.deepStrictEqual(await resolve('occasion'), ['p2']);
 
     await db.collection('filters').updateOne({ _id: FILTER_ID }, { $set: { options: ['offerable'] } });
-    await filtersSettings.setCachedProductIds(FILTER_ID, ['p1'], { offerable: ['p1'] });
+    await filtersSettings.setCachedProductIds(FILTER_ID, ['p1'], { offerable: ['p1'] }, 2);
 
     assert.deepStrictEqual(await resolve('occasion'), []);
     assert.deepStrictEqual(await resolve('offerable'), ['p1']);
   });
 
-  test('keeps an option that was added while a slow invalidation was still in flight', async () => {
+  test('an overtaken rebuild neither publishes its result nor retires the newer option', async () => {
+    const older = new Date('2020-01-01').getTime();
+    const newer = new Date('2020-06-01').getTime();
     await seedFilter(['a', 'b']);
-    // a full invalidation starts here and snapshots [a, b]
-    const staleSnapshot = { a: ['p1'], b: ['p2'] };
+    await filtersSettings.setCachedProductIds(FILTER_ID, ['p1', 'p2'], { a: ['p1'], b: ['p2'] }, older);
 
-    // meanwhile `c` gets added and invalidated on its own
+    // `c` is added and published by a later generation
     await db.collection('filters').updateOne({ _id: FILTER_ID }, { $push: { options: 'c' } });
-    await filtersSettings.setCachedProductIds(FILTER_ID, ['p1', 'p2', 'p3'], {
-      a: ['p1'],
-      b: ['p2'],
-      c: ['p3'],
-    });
+    await filtersSettings.setCachedProductIds(
+      FILTER_ID,
+      ['p1', 'p2', 'p3'],
+      { a: ['p1'], b: ['p2'], c: ['p3'] },
+      newer,
+    );
 
-    // the slow invalidation lands last, carrying an option set that predates `c`
-    await filtersSettings.setCachedProductIds(FILTER_ID, ['p1', 'p2'], staleSnapshot);
+    // only now does the rebuild that started before it get round to writing
+    await filtersSettings.setCachedProductIds(FILTER_ID, ['p1', 'p2'], { a: ['p1'], b: ['p2'] }, older);
 
     assert.deepStrictEqual(await cacheRowIds(), [
       `${FILTER_ID}:`,
@@ -114,11 +121,52 @@ test.describe('Filter: product id cache invalidation', () => {
       `${FILTER_ID}:c`,
     ]);
     assert.deepStrictEqual(await resolve('c'), ['p3']);
+    const base = await db
+      .collection('filter_productId_cache')
+      .findOne({ filterId: FILTER_ID, filterOptionValue: null });
+    assert.deepStrictEqual([...base.productIds].sort(), ['p1', 'p2', 'p3']);
+  });
+
+  test('a key rename is caught even though the option values are unchanged', async () => {
+    const older = new Date('2020-01-01').getTime();
+    const newer = new Date('2020-06-01').getTime();
+    await seedFilter(['a']);
+    // the rename bumps the generation, and its rebuild publishes first
+    await filtersSettings.setCachedProductIds(
+      FILTER_ID,
+      ['from-new-key'],
+      { a: ['from-new-key'] },
+      newer,
+    );
+    // the rebuild that ran under the old key has the same options but an older generation
+    await filtersSettings.setCachedProductIds(
+      FILTER_ID,
+      ['from-old-key'],
+      { a: ['from-old-key'] },
+      older,
+    );
+
+    const row = await db
+      .collection('filter_productId_cache')
+      .findOne({ filterId: FILTER_ID, filterOptionValue: 'a' });
+    assert.deepStrictEqual(row.productIds, ['from-new-key']);
+  });
+
+  test('carries the filter generation through invalidateProductIdCache', async () => {
+    await seedFilter(['a'], new Date('2020-06-01'));
+    const filter = await db.collection('filters').findOne({ _id: FILTER_ID });
+    await FilterDirector.invalidateProductIdCache(filter, getTestPlatform().unchainedAPI);
+
+    const row = await db
+      .collection('filter_productId_cache')
+      .findOne({ filterId: FILTER_ID, filterOptionValue: null });
+    assert.strictEqual(row.computedAt, new Date('2020-06-01').getTime());
   });
 
   test('drops every cache row of a deleted filter, including a late invalidation', async () => {
     await seedFilter(['a', 'b']);
-    await filtersSettings.setCachedProductIds(FILTER_ID, ['p1', 'p2'], { a: ['p1'], b: ['p2'] });
+    const snapshot = await db.collection('filters').findOne({ _id: FILTER_ID });
+    await filtersSettings.setCachedProductIds(FILTER_ID, ['p1', 'p2'], { a: ['p1'], b: ['p2'] }, 1);
     assert.strictEqual((await cacheRowIds()).length, 3);
 
     const { data: { removeFilter } = {} } = await graphqlFetch({
@@ -134,21 +182,30 @@ test.describe('Filter: product id cache invalidation', () => {
     assert.strictEqual(removeFilter._id, FILTER_ID);
     assert.deepStrictEqual(await cacheRowIds(), []);
 
-    // an invalidation that was already in flight when the filter got deleted
-    await filtersSettings.setCachedProductIds(FILTER_ID, ['p1', 'p2'], { a: ['p1'], b: ['p2'] });
+    // An invalidation already in flight when the filter got deleted must not rebuild the cache
+    // of something that no longer exists.
+    const original = FilterDirector.buildProductIdMap;
+    FilterDirector.buildProductIdMap = async () => [['p1', 'p2'], { a: ['p1'], b: ['p2'] }];
+    try {
+      await FilterDirector.invalidateProductIdCache(snapshot, getTestPlatform().unchainedAPI);
+    } finally {
+      FilterDirector.buildProductIdMap = original;
+    }
     assert.deepStrictEqual(await cacheRowIds(), []);
   });
 
   test('a retired option stops resolving immediately, without waiting out the memo', async () => {
     await seedFilter(['offerable', 'occasion']);
-    await filtersSettings.setCachedProductIds(FILTER_ID, ['p1', 'p2'], {
-      offerable: ['p1'],
-      occasion: ['p2'],
-    });
+    await filtersSettings.setCachedProductIds(
+      FILTER_ID,
+      ['p1', 'p2'],
+      { offerable: ['p1'], occasion: ['p2'] },
+      1,
+    );
     assert.deepStrictEqual(await resolveNow('occasion'), ['p2']);
 
     await db.collection('filters').updateOne({ _id: FILTER_ID }, { $set: { options: ['offerable'] } });
-    await filtersSettings.setCachedProductIds(FILTER_ID, ['p1'], { offerable: ['p1'] });
+    await filtersSettings.setCachedProductIds(FILTER_ID, ['p1'], { offerable: ['p1'] }, 2);
 
     // No sleep: a write has to evict the memo, or production serves this for a minute.
     assert.deepStrictEqual(await resolveNow('occasion'), []);
@@ -157,7 +214,7 @@ test.describe('Filter: product id cache invalidation', () => {
 
   test('removes a filter even when purging its cache fails', async () => {
     await seedFilter(['a', 'b']);
-    await filtersSettings.setCachedProductIds(FILTER_ID, ['p1', 'p2'], { a: ['p1'], b: ['p2'] });
+    await filtersSettings.setCachedProductIds(FILTER_ID, ['p1', 'p2'], { a: ['p1'], b: ['p2'] }, 1);
 
     const purge = filtersSettings.purgeCachedProductIds;
     filtersSettings.purgeCachedProductIds = async () => {
@@ -195,6 +252,7 @@ test.describe('Filter: product id cache invalidation', () => {
         ['__proto__', ['p1']],
         ['regular', ['p2']],
       ]),
+      1,
     );
 
     assert.deepStrictEqual(await resolve('regular'), ['p2']);
@@ -216,10 +274,12 @@ test.describe('Filter: product id cache invalidation', () => {
 
   test('prunes through the removeFilterOption mutation', async () => {
     await seedFilter(['keep', 'retire']);
-    await filtersSettings.setCachedProductIds(FILTER_ID, ['p1', 'p2'], {
-      keep: ['p1'],
-      retire: ['p2'],
-    });
+    await filtersSettings.setCachedProductIds(
+      FILTER_ID,
+      ['p1', 'p2'],
+      { keep: ['p1'], retire: ['p2'] },
+      1,
+    );
 
     await graphqlFetch({
       query: /* GraphQL */ `

--- a/tests/filter-product-id-cache.test.js
+++ b/tests/filter-product-id-cache.test.js
@@ -34,18 +34,6 @@ const seedFilter = async (options) => {
   });
 };
 
-// Replaces the catalog scan for the duration of one invalidation, so a race that would otherwise
-// need a slow catalog can be staged deterministically.
-const withStubbedBuild = async (buildProductIdMap, run) => {
-  const original = FilterDirector.buildProductIdMap;
-  FilterDirector.buildProductIdMap = buildProductIdMap;
-  try {
-    return await run();
-  } finally {
-    FilterDirector.buildProductIdMap = original;
-  }
-};
-
 const resolve = async (value) => {
   // Cached reads are memoized in process (1ms TTL outside production, 60s in it). Two reads
   // within the same millisecond both hit that memo, so wait it out - otherwise we assert
@@ -96,26 +84,21 @@ test.describe('Filter: product id cache invalidation', () => {
     assert.deepStrictEqual(await resolve('offerable'), ['p1']);
   });
 
-  test('discards an invalidation that a concurrent option change superseded', async () => {
+  test('keeps an option that was added while a slow invalidation was still in flight', async () => {
     await seedFilter(['a', 'b']);
-    const snapshot = await db.collection('filters').findOne({ _id: FILTER_ID });
-    await filtersSettings.setCachedProductIds(FILTER_ID, ['p1', 'p2'], { a: ['p1'], b: ['p2'] });
+    // a full invalidation starts here and snapshots [a, b]
+    const staleSnapshot = { a: ['p1'], b: ['p2'] };
 
-    // Stands in for a build slow enough that the option set moves underneath it: `c` is added
-    // and invalidated on its own while this one is still scanning, so what it returns describes
-    // a filter that no longer exists. Writing it would retire `c` again.
-    await withStubbedBuild(
-      async () => {
-        await db.collection('filters').updateOne({ _id: FILTER_ID }, { $push: { options: 'c' } });
-        await filtersSettings.setCachedProductIds(FILTER_ID, ['p1', 'p2', 'p3'], {
-          a: ['p1'],
-          b: ['p2'],
-          c: ['p3'],
-        });
-        return [['p1', 'p2'], { a: ['p1'], b: ['p2'] }];
-      },
-      () => FilterDirector.invalidateProductIdCache(snapshot, getTestPlatform().unchainedAPI),
-    );
+    // meanwhile `c` gets added and invalidated on its own
+    await db.collection('filters').updateOne({ _id: FILTER_ID }, { $push: { options: 'c' } });
+    await filtersSettings.setCachedProductIds(FILTER_ID, ['p1', 'p2', 'p3'], {
+      a: ['p1'],
+      b: ['p2'],
+      c: ['p3'],
+    });
+
+    // the slow invalidation lands last, carrying an option set that predates `c`
+    await filtersSettings.setCachedProductIds(FILTER_ID, ['p1', 'p2'], staleSnapshot);
 
     assert.deepStrictEqual(await cacheRowIds(), [
       `${FILTER_ID}:`,
@@ -128,7 +111,6 @@ test.describe('Filter: product id cache invalidation', () => {
 
   test('drops every cache row of a deleted filter, including a late invalidation', async () => {
     await seedFilter(['a', 'b']);
-    const snapshot = await db.collection('filters').findOne({ _id: FILTER_ID });
     await filtersSettings.setCachedProductIds(FILTER_ID, ['p1', 'p2'], { a: ['p1'], b: ['p2'] });
     assert.strictEqual((await cacheRowIds()).length, 3);
 
@@ -145,12 +127,8 @@ test.describe('Filter: product id cache invalidation', () => {
     assert.strictEqual(removeFilter._id, FILTER_ID);
     assert.deepStrictEqual(await cacheRowIds(), []);
 
-    // An invalidation that was already in flight when the filter got deleted must not put the
-    // rows back.
-    await withStubbedBuild(
-      async () => [['p1', 'p2'], { a: ['p1'], b: ['p2'] }],
-      () => FilterDirector.invalidateProductIdCache(snapshot, getTestPlatform().unchainedAPI),
-    );
+    // an invalidation that was already in flight when the filter got deleted
+    await filtersSettings.setCachedProductIds(FILTER_ID, ['p1', 'p2'], { a: ['p1'], b: ['p2'] });
     assert.deepStrictEqual(await cacheRowIds(), []);
   });
 

--- a/tests/filter-product-id-cache.test.js
+++ b/tests/filter-product-id-cache.test.js
@@ -34,6 +34,13 @@ const seedFilter = async (options) => {
   });
 };
 
+// Reads without waiting out the in-process memo, so a missing eviction cannot hide behind a sleep.
+const resolveNow = async (value) => {
+  const filter = await db.collection('filters').findOne({ _id: FILTER_ID });
+  const { unchainedAPI } = getTestPlatform();
+  return [...(await FilterDirector.filterProductIds(filter, { values: [value] }, unchainedAPI))];
+};
+
 const resolve = async (value) => {
   // Cached reads are memoized in process (1ms TTL outside production, 60s in it). Two reads
   // within the same millisecond both hit that memo, so wait it out - otherwise we assert
@@ -130,6 +137,49 @@ test.describe('Filter: product id cache invalidation', () => {
     // an invalidation that was already in flight when the filter got deleted
     await filtersSettings.setCachedProductIds(FILTER_ID, ['p1', 'p2'], { a: ['p1'], b: ['p2'] });
     assert.deepStrictEqual(await cacheRowIds(), []);
+  });
+
+  test('a retired option stops resolving immediately, without waiting out the memo', async () => {
+    await seedFilter(['offerable', 'occasion']);
+    await filtersSettings.setCachedProductIds(FILTER_ID, ['p1', 'p2'], {
+      offerable: ['p1'],
+      occasion: ['p2'],
+    });
+    assert.deepStrictEqual(await resolveNow('occasion'), ['p2']);
+
+    await db.collection('filters').updateOne({ _id: FILTER_ID }, { $set: { options: ['offerable'] } });
+    await filtersSettings.setCachedProductIds(FILTER_ID, ['p1'], { offerable: ['p1'] });
+
+    // No sleep: a write has to evict the memo, or production serves this for a minute.
+    assert.deepStrictEqual(await resolveNow('occasion'), []);
+    assert.deepStrictEqual(await resolveNow('offerable'), ['p1']);
+  });
+
+  test('removes a filter even when purging its cache fails', async () => {
+    await seedFilter(['a', 'b']);
+    await filtersSettings.setCachedProductIds(FILTER_ID, ['p1', 'p2'], { a: ['p1'], b: ['p2'] });
+
+    const purge = filtersSettings.purgeCachedProductIds;
+    filtersSettings.purgeCachedProductIds = async () => {
+      throw new Error('cache backend unavailable');
+    };
+    try {
+      await graphqlFetch({
+        query: /* GraphQL */ `
+          mutation RemoveFilter($filterId: ID!) {
+            removeFilter(filterId: $filterId) {
+              _id
+            }
+          }
+        `,
+        variables: { filterId: FILTER_ID },
+      });
+    } finally {
+      filtersSettings.purgeCachedProductIds = purge;
+    }
+
+    // The canonical record goes even though the derived cache could not be dropped.
+    assert.strictEqual(await db.collection('filters').findOne({ _id: FILTER_ID }), null);
   });
 
   test('treats inherited property names as ordinary option values', async () => {


### PR DESCRIPTION
Addresses the review of `001b4b00..d0715dcd2`. Every finding was reproduced before being acted
on, and the ones deliberately left open are listed at the bottom.

## 1. Revert `d0715dcd2`

The freshness read and the write/prune were separate steps, so a newer rebuild could land between
them and have its option deleted by the older one. Reproduced: `options: [a,b,c]` with cache rows
`[base,a,b]`. It does **not** self-heal — the rebuild that would restore `c` is the one that
already ran. That window was also *wider* than the design it replaced, which re-reads inside the
backend one round trip before deleting.

The original prune is therefore back as-is.

## 2. Inherited property names

`filterProductIds` looked values up in a plain object, so `constructor`, `toString` and
`hasOwnProperty` resolved to `Object.prototype` members, were truthy, and threw when iterated.
Reachable unauthenticated against a running engine:

```
searchProducts(filterQuery: [{ key: "tags", value: "constructor" }])   ERROR: Unexpected error.
```

Pre-existing rather than introduced by the reviewed range, but it lives in this code. Lookups now
accept own properties only.

Separately, `buildProductIdMap` collected options into a normal object, so an option literally
named `__proto__` hit the prototype setter instead of creating a key — a real regression from
`46adb877e`, since the spread it replaced created an own property. It builds a null-prototyped
record now.

## 3. Making the prune safe to act on

The prune was right about *which* rows to keep and careless about when and whether to act.

- **Writes that never happened.** `updateIfHashChanged` returned an id regardless: its catch
  swallowed the duplicate-key collision a same-hash upsert raises, and every real failure with
  it. A failed row write was then followed by confidently deleting the rows it was meant to
  replace, leaving a live option resolving to nothing while the surviving base row suppressed the
  live fallback. It now separates the collision from a failure, and nothing is pruned unless
  every row is in place.
- **Memo eviction.** Reads are memoized per process for a minute in production and nothing
  evicted them, so a prune was invisible for the whole TTL — a retired option kept answering, a
  newly added one answered with nothing. The suite could not see this because tests run at a 1 ms
  TTL.
- **Deletion ordering.** The purge ran before `deleteOne`, so a rejecting backend left the filter
  behind with its texts already gone. Canonical record first; a failing purge is logged, not
  fatal.
- **MCP `UPDATE`** changed keys, types and options without invalidating, unlike GraphQL.
- **Contract and docs** now cover `purgeCachedProductIds`, warn that partial overrides mix two
  backends, and state plainly that a custom backend cannot retire obsolete values through the
  current interface.

## Verification

- Filter cache suite **11/11**, and **11/11 under `NODE_ENV=production`** with the 60 s memo — the
  configuration that previously failed 2/5.
- Integration **998 pass / 1 fail** (the pre-existing `plugins-datatrans` flake); unit
  **542 / 0**. Build and ESLint clean.
- New coverage: an overtaken rebuild neither publishing nor retiring, a key rename with unchanged
  options, the generation being carried through `invalidateProductIdCache`, a retired option
  resolving correctly without waiting out the memo, and a filter being deleted even when the
  cache purge throws.

## 4. Refusing writes from an overtaken rebuild

Deciding what to retire from the filter as it looks when the write lands says nothing about
whether the ids being written are still meaningful. Rename a filter's key and the rebuild that ran
under the old one publishes its ids over the correct result — identical options, so nothing in the
old comparison could tell. Reproduced against `30841bb15`: `option a holds: ["from-old-key"]`.

Cache rows now record the generation they were computed from, and neither a write nor a prune
touches a row a newer generation already claimed.

The generation is the filter's own `updated` stamp, not a counter of its own, so **no field is
added to the filter**. It is deliberately coarse — a change that leaves the cache valid still
moves it, which costs a skipped write, and whatever moved it queues an invalidation anyway. Being
wrong the other way publishes results computed against a filter that no longer exists in that
shape.

Because the caller can no longer be overtaken unnoticed, the map it passes is authoritative and
retiring what it omits is safe. That is what **#722** was missing: `setCachedProductIds` now
carries the complete value set *and* the generation it belongs to, so a Redis or HTTP backend can
retire obsolete values with the same guarantee instead of being unable to express it at all. The
MongoDB implementation stops reaching into the `Filters` collection to work it out.

## Knowingly not fixed

- **A rebuild that passes the existence check immediately before the filter is deleted** can still
  leave orphan rows. Garbage rather than wrong answers, since nothing can query a deleted filter.
- **Bounded concurrency** for the per-option catalog scans — different risk profile, and
  `core-assortments` deliberately serialises its equivalent loop.
