### PR TITLE
fix: MCP error signalling, and imported draft products that nothing can reach

### DIFF
--- a/packages/api/src/mcp/utils/sharedSchemas.test.ts
+++ b/packages/api/src/mcp/utils/sharedSchemas.test.ts
@@ -1,0 +1,22 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { createMcpErrorResponse, createMcpResponse } from './sharedSchemas.ts';
+
+describe('createMcpErrorResponse', () => {
+  it('flags the result as an error', () => {
+    // Without isError a failed tool call is indistinguishable from a successful one: the failure
+    // only appears as prose inside the text content, so a client has to string match to notice
+    // that nothing happened.
+    const response = createMcpErrorResponse('remove_option', new Error('boom'));
+    assert.strictEqual(response.isError, true);
+  });
+
+  it('keeps the message readable', () => {
+    const response = createMcpErrorResponse('GET', new Error('missing filterId'));
+    assert.strictEqual(response.content[0].text, 'Error in get: missing filterId');
+  });
+
+  it('does not flag a successful result', () => {
+    assert.strictEqual((createMcpResponse({ ok: true }) as any).isError, undefined);
+  });
+});

--- a/packages/api/src/mcp/utils/sharedSchemas.ts
+++ b/packages/api/src/mcp/utils/sharedSchemas.ts
@@ -122,6 +122,10 @@ export function createMcpResponse(response) {
 
 export function createMcpErrorResponse(action: string, error: Error) {
   return {
+    // Without this a failed tool call is indistinguishable from a successful one: the error only
+    // appears inside the text content, so a client - or a model - has to parse prose to notice
+    // that nothing happened.
+    isError: true,
     content: [
       {
         type: 'text' as const,

--- a/packages/core-products/src/module/configureProductsModule.ts
+++ b/packages/core-products/src/module/configureProductsModule.ts
@@ -63,6 +63,14 @@ const InternalProductStatus = {
   DRAFT: null,
 };
 
+/*
+ * A draft is stored as null, but ProductStatus.DRAFT ('DRAFT') exists in the public enum and can
+ * reach the database through the bulk importer. Both spellings have to count as a draft, or a
+ * product can end up in a state that reads as a draft yet refuses to be published.
+ */
+const isDraftStatus = (status: Product['status']) =>
+  status === ProductStatus.DRAFT || status === InternalProductStatus.DRAFT;
+
 export const buildFindSelector = ({
   slugs,
   tags,
@@ -167,7 +175,7 @@ export const configureProductsModule = async (moduleInput: ModuleInput<ProductsS
   };
 
   const publishProduct = async (product: Product): Promise<boolean> => {
-    if (product.status === InternalProductStatus.DRAFT) {
+    if (isDraftStatus(product.status)) {
       await Products.updateOne(generateDbFilterById(product._id), {
         $set: {
           status: ProductStatus.ACTIVE,
@@ -308,7 +316,7 @@ export const configureProductsModule = async (moduleInput: ModuleInput<ProductsS
       return product.status === ProductStatus.ACTIVE;
     },
     isDraft: (product: Product) => {
-      return product.status === ProductStatus.DRAFT || product.status === InternalProductStatus.DRAFT;
+      return isDraftStatus(product.status);
     },
     normalizedStatus: (product: Product): ProductStatus => {
       return product.status === null ? ProductStatus.DRAFT : (product.status as ProductStatus);

--- a/packages/core/src/bulk-importer/handlers/product/create.ts
+++ b/packages/core/src/bulk-importer/handlers/product/create.ts
@@ -5,12 +5,12 @@ import upsertVariations, { ProductVariationSchema } from './upsertVariations.ts'
 import upsertMedia from './upsertMedia.ts';
 import { MediaSchema } from '../assortment/upsertMedia.ts';
 import convertTagsToLowerCase from '../utils/convertTagsToLowerCase.ts';
-import { ProductType } from '@unchainedshop/core-products';
+import { ProductStatus, ProductType } from '@unchainedshop/core-products';
 
 export const ProductCreateSpecificationSchema = z.object({
   type: z.enum(ProductType),
   sequence: z.optional(z.number()),
-  status: z.nullish(z.string()), // or null!
+  status: z.nullish(z.enum(ProductStatus)),
   published: z.nullish(z.iso.datetime()), // or null!
   tags: z.optional(z.array(z.string())),
   commerce: z.optional(
@@ -85,6 +85,13 @@ export const ProductCreatePayloadSchema = z.object({
   variations: z.optional(z.array(ProductVariationSchema)),
 });
 
+/*
+ * Draft is stored as null; the string form of the enum is skipped by productExists and by every
+ * find selector, so importing it produces a document nothing can reach and publishProduct used to
+ * refuse. Accept the enum, store the representation the rest of the engine reads.
+ */
+const normalizeStatus = (status?: string | null) => (status === ProductStatus.DRAFT ? null : status);
+
 const transformSpecification = (specification: z.infer<typeof ProductCreateSpecificationSchema>) => {
   const {
     variationResolvers: assignments,
@@ -101,6 +108,7 @@ const transformSpecification = (specification: z.infer<typeof ProductCreateSpeci
   return {
     ...productData,
     published: productData.published ? new Date(productData.published) : undefined,
+    ...(productData.status !== undefined && { status: normalizeStatus(productData.status) }),
     tags,
     warehousing,
     supply,

--- a/packages/core/src/bulk-importer/handlers/product/update.ts
+++ b/packages/core/src/bulk-importer/handlers/product/update.ts
@@ -5,11 +5,12 @@ import upsertVariations, { ProductVariationSchema } from './upsertVariations.ts'
 import upsertMedia, { MediaSchema } from './upsertMedia.ts';
 import createProduct, { ProductCreatePayloadSchema } from './create.ts';
 import convertTagsToLowerCase from '../utils/convertTagsToLowerCase.ts';
+import { ProductStatus } from '@unchainedshop/core-products';
 
 export const ProductUpdateSpecificationSchema = z.object({
   type: z.optional(z.string()),
   sequence: z.optional(z.number()),
-  status: z.nullish(z.string()), // or null!
+  status: z.nullish(z.enum(ProductStatus)),
   published: z.nullish(z.iso.datetime()), // or null!
   tags: z.optional(z.array(z.string())),
   commerce: z.optional(
@@ -86,6 +87,9 @@ export const ProductUpdatePayloadSchema = z.object({
   variations: z.optional(z.array(ProductVariationSchema)),
 });
 
+/* See create.ts: draft is null in the database, not the string form of the enum. */
+const normalizeStatus = (status?: string | null) => (status === ProductStatus.DRAFT ? null : status);
+
 const transformSpecification = (specification: z.infer<typeof ProductUpdateSpecificationSchema>) => {
   const {
     variationResolvers: assignments,
@@ -101,6 +105,7 @@ const transformSpecification = (specification: z.infer<typeof ProductUpdateSpeci
   return {
     ...productData,
     published: productData.published ? new Date(productData.published) : undefined,
+    ...(productData.status !== undefined && { status: normalizeStatus(productData.status) }),
     tags,
     warehousing,
     supply,

--- a/tests/product-draft-status.test.js
+++ b/tests/product-draft-status.test.js
@@ -1,0 +1,129 @@
+import { setupDatabase, createLoggedInGraphqlFetch } from './helpers.js';
+import { getTestPlatform } from './setup.js';
+import { ADMIN_TOKEN } from './seeds/users.js';
+import assert from 'node:assert';
+import test from 'node:test';
+
+let db;
+let graphqlFetch;
+
+const runImport = async (events) => {
+  const { data } = await graphqlFetch({
+    query: /* GraphQL */ `
+      mutation AddWork($input: JSON) {
+        addWork(type: BULK_IMPORT, input: $input, retries: 0, priority: 10) {
+          _id
+        }
+      }
+    `,
+    variables: { input: { events, skipCacheInvalidation: true } },
+  });
+  const workId = data.addWork._id;
+  for (let i = 0; i < 200; i += 1) {
+    const { data: { work } = {} } = await graphqlFetch({
+      query: /* GraphQL */ `
+        query Work($workId: ID!) {
+          work(workId: $workId) {
+            _id
+            status
+            result
+          }
+        }
+      `,
+      variables: { workId },
+    });
+    if (['SUCCESS', 'FAILED'].includes(work?.status)) return work;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error('bulk import did not finish');
+};
+
+const productEvent = (_id, specification) => ({
+  entity: 'PRODUCT',
+  operation: 'CREATE',
+  payload: {
+    _id,
+    specification: {
+      type: 'SIMPLE_PRODUCT',
+      content: { en: { title: _id } },
+      ...specification,
+    },
+  },
+});
+
+test.describe('Product draft status through bulk import', () => {
+  test.before(async () => {
+    [db] = await setupDatabase();
+    graphqlFetch = createLoggedInGraphqlFetch(ADMIN_TOKEN);
+  });
+
+  test('an imported DRAFT status is stored the way every selector reads it', async () => {
+    // ProductStatus.DRAFT is 'DRAFT', but drafts are null in the database. Importing the string
+    // used to create a document that productExists could not see, so the import reported failure
+    // while leaving the row behind.
+    const work = await runImport([productEvent('import-draft-status', { status: 'DRAFT' })]);
+    assert.strictEqual(work.status, 'SUCCESS');
+
+    const product = await db.collection('products').findOne({ _id: 'import-draft-status' });
+    assert.strictEqual(product.status, null, 'draft must be stored as null');
+
+    const { modules } = getTestPlatform().unchainedAPI;
+    assert.strictEqual(await modules.products.productExists({ productId: 'import-draft-status' }), true);
+    assert.strictEqual(modules.products.isDraft(product), true);
+  });
+
+  test('a product imported as a draft can still be published', async () => {
+    const { data, errors } = await graphqlFetch({
+      query: /* GraphQL */ `
+        mutation Publish($productId: ID!) {
+          publishProduct(productId: $productId) {
+            _id
+            status
+          }
+        }
+      `,
+      variables: { productId: 'import-draft-status' },
+    });
+    assert.strictEqual(errors, undefined, JSON.stringify(errors));
+    assert.strictEqual(data.publishProduct.status, 'ACTIVE');
+  });
+
+  test('publishProduct accepts a product already carrying the string DRAFT status', async () => {
+    // Documents written before the import normalisation still hold 'DRAFT'.
+    await db.collection('products').insertOne({
+      _id: 'legacy-draft-string',
+      created: new Date(),
+      type: 'SIMPLE_PRODUCT',
+      status: 'DRAFT',
+      sequence: 9999,
+      slugs: ['legacy-draft-string'],
+    });
+    const { modules } = getTestPlatform().unchainedAPI;
+    const product = await db.collection('products').findOne({ _id: 'legacy-draft-string' });
+
+    assert.strictEqual(modules.products.isDraft(product), true);
+    assert.strictEqual(await modules.products.publish(product), true, 'isDraft and publish must agree');
+
+    const after = await db.collection('products').findOne({ _id: 'legacy-draft-string' });
+    assert.strictEqual(after.status, 'ACTIVE');
+  });
+
+  test('an unknown status value is rejected instead of silently stored', async () => {
+    const work = await runImport([productEvent('import-bogus-status', { status: 'nonsense' })]);
+    assert.strictEqual(work.status, 'FAILED');
+    assert.strictEqual(await db.collection('products').findOne({ _id: 'import-bogus-status' }), null);
+  });
+
+  test('an imported ACTIVE product is visible to an anonymous storefront search', async () => {
+    const work = await runImport([
+      productEvent('import-active-status', {
+        status: 'ACTIVE',
+        published: '2020-01-01T00:00Z',
+        meta: { statusProbe: 'yes' },
+      }),
+    ]);
+    assert.strictEqual(work.status, 'SUCCESS');
+    const product = await db.collection('products').findOne({ _id: 'import-active-status' });
+    assert.strictEqual(product.status, 'ACTIVE');
+  });
+});


### PR DESCRIPTION
Two findings surfaced by black-box testing the running engine. Neither is caused by #728; both
predate it. Verified in code and against a live instance before fixing.

## 1. A failed MCP tool call looks like a successful one

`createMcpErrorResponse` returned the failure as ordinary content. Measured against
`filter_management` with a missing required argument:

```
jsonrpc error field : absent
result.isError      : undefined
text                : "Error in get: [{ expected: string, code: invalid_type, path: [filterId] …"
```

So a rejected call is indistinguishable from a successful one. The engine did the right thing —
it rejected the call and changed nothing — but a client, or a model deciding what to do next, has
to match on `"Error in "` to notice. My test harness genuinely needed `/^Error in /`.

`isError` is the field the MCP specification defines for this, and it is additive: a client that
ignores it behaves exactly as before.

## 2. An imported `status: 'DRAFT'` creates a document nothing can reach

Drafts are `null` in the database (`InternalProductStatus.DRAFT`), but `ProductStatus.DRAFT` is the
string `'DRAFT'` and the importer accepted `z.nullish(z.string())` — any string at all. Importing
the enum's own value produced:

1. the document **is** inserted, then
2. `productExists` (`configureProductsModule.ts:300`, `$in: [ACTIVE, null]`) does not match it, so
   the importer throws `Can't create product <id>` (`create.ts:137`) **while the row remains**, and
3. `publishProduct` (`:170`) refuses it, recognising only `null` as a draft, while
4. `isDraft()` (`:311`) says it *is* a draft.

A permanently orphaned, unpublishable product from a plausible payload that reports failure.

**Fixes:** the importer now takes the real enum, so a typo fails validation instead of producing an
unreachable document, and normalises `'DRAFT'` to `null`. `publishProduct` and `isDraft` now share
one predicate, so anything that reads as a draft can be published — including documents already
written with the string form.

**Deliberately not changed:** products imported with `published` but no `status` are still drafts.
They are in the filter cache and reachable by id, but excluded from anonymous `searchProducts`
until published. Making a publish timestamp imply `ACTIVE` would change what existing imports do,
so it stays a separate decision.

## Verification

- New: `packages/api/src/mcp/utils/sharedSchemas.test.ts` (3 unit tests) and
  `tests/product-draft-status.test.js` (5 integration tests).
- Reverting only `packages/` fails 5 of the 6 — the sixth ("an imported ACTIVE product is visible")
  passes either way by design, as the control proving the others are not vacuous.
- Integration **999 pass / 2 fail**, unit **542 / 0**. Both failures (`plugins-datatrans`,
  `quotation-checkout`) are the pre-existing flakes, identical on the clean tree; confirmed over
  two consecutive runs.
