### PR TITLE
refactor(core-filters/api): isolate the cache collection, move filter invalidation into services

### DIFF
--- a/packages/api/src/mcp/tools/filter/handlers/createFilter.ts
+++ b/packages/api/src/mcp/tools/filter/handlers/createFilter.ts
@@ -1,22 +1,19 @@
 import type { Context } from '../../../../context.ts';
-import { FilterDirector } from '@unchainedshop/core';
 import { getNormalizedFilterDetails } from '../../../utils/getNormalizedFilterDetails.ts';
 import type { Params } from '../schemas.ts';
 import type { FilterText } from '@unchainedshop/core-filters';
 
 export default async function createFilter(context: Context, params: Params<'CREATE'>) {
-  const { modules } = context;
+  const { modules, services } = context;
   const { filter, texts } = params;
   const { key, type, options = [] } = filter as any;
 
-  const newFilter = await modules.filters.create({
+  const newFilter = await services.filters.createFilter({
     key,
     type,
     options,
     isActive: true,
   });
-
-  await FilterDirector.invalidateProductIdCache(newFilter, context);
 
   if (texts && texts.length > 0) {
     await modules.filters.texts.updateTexts({ filterId: newFilter._id }, texts as FilterText[]);

--- a/packages/api/src/mcp/tools/filter/handlers/createFilterOption.ts
+++ b/packages/api/src/mcp/tools/filter/handlers/createFilterOption.ts
@@ -1,22 +1,19 @@
 import type { Context } from '../../../../context.ts';
-import { FilterDirector } from '@unchainedshop/core';
 import { FilterNotFoundError } from '../../../../errors.ts';
 import { getNormalizedFilterDetails } from '../../../utils/getNormalizedFilterDetails.ts';
 import type { Params } from '../schemas.ts';
 import type { FilterText } from '@unchainedshop/core-filters';
 
 export default async function createFilterOption(context: Context, params: Params<'CREATE_OPTION'>) {
-  const { modules } = context;
+  const { modules, services } = context;
   const { filterId, option, optionTexts } = params;
 
   if (!(await modules.filters.filterExists({ filterId }))) {
     throw new FilterNotFoundError({ filterId });
   }
 
-  const newOption = await modules.filters.createFilterOption(filterId, { value: option });
+  const newOption = await services.filters.createFilterOption(filterId, { value: option });
   if (!newOption) return { filter: null };
-
-  await FilterDirector.invalidateProductIdCache(newOption, context);
 
   if (optionTexts && optionTexts.length > 0) {
     await modules.filters.texts.updateTexts(

--- a/packages/api/src/mcp/tools/filter/handlers/removeFilterOption.ts
+++ b/packages/api/src/mcp/tools/filter/handlers/removeFilterOption.ts
@@ -1,25 +1,22 @@
 import type { Context } from '../../../../context.ts';
-import { FilterDirector } from '@unchainedshop/core';
 import { FilterNotFoundError } from '../../../../errors.ts';
 import { getNormalizedFilterDetails } from '../../../utils/getNormalizedFilterDetails.ts';
 import type { Params } from '../schemas.ts';
 
 export default async function removeFilterOption(context: Context, params: Params<'REMOVE_OPTION'>) {
-  const { modules } = context;
+  const { modules, services } = context;
   const { filterId, option } = params;
 
   if (!(await modules.filters.filterExists({ filterId }))) {
     throw new FilterNotFoundError({ filterId });
   }
 
-  const removedFilterOption = await modules.filters.removeFilterOption({
+  const removedFilterOption = await services.filters.removeFilterOption({
     filterId,
     filterOptionValue: option,
   });
 
   if (!removedFilterOption) return { filter: null };
-
-  await FilterDirector.invalidateProductIdCache(removedFilterOption, context);
 
   const normalizedFilter = await getNormalizedFilterDetails(filterId, context);
   return { filter: normalizedFilter };

--- a/packages/api/src/mcp/tools/filter/handlers/updateFilter.ts
+++ b/packages/api/src/mcp/tools/filter/handlers/updateFilter.ts
@@ -1,21 +1,19 @@
 import type { Context } from '../../../../context.ts';
-import { FilterDirector } from '@unchainedshop/core';
 import { FilterNotFoundError } from '../../../../errors.ts';
 import { getNormalizedFilterDetails } from '../../../utils/getNormalizedFilterDetails.ts';
 import type { Params } from '../schemas.ts';
 
 export default async function updateFilter(context: Context, params: Params<'UPDATE'>) {
-  const { modules } = context;
+  const { modules, services } = context;
   const { filterId, updateData } = params;
 
   if (!(await modules.filters.filterExists({ filterId }))) {
     throw new FilterNotFoundError({ filterId });
   }
 
-  const updatedFilter = await modules.filters.update(filterId, updateData as any);
-  // An update can change the key, the type or the options, all of which the product id cache is
-  // derived from. The GraphQL mutation has always invalidated here; this path had not.
-  await FilterDirector.invalidateProductIdCache(updatedFilter!, context);
+  // The service invalidates the product id cache; an update can change the key, type or options,
+  // all of which it is derived from. This MCP path previously did not invalidate at all.
+  await services.filters.updateFilter(filterId, updateData as any);
 
   const normalizedFilter = await getNormalizedFilterDetails(filterId, context);
   return { filter: normalizedFilter };

--- a/packages/api/src/resolvers/mutations/filters/createFilter.ts
+++ b/packages/api/src/resolvers/mutations/filters/createFilter.ts
@@ -1,7 +1,7 @@
 import { log } from '@unchainedshop/logger';
 import type { Filter } from '@unchainedshop/core-filters';
 import type { Context } from '../../../context.ts';
-import { FilterDirector, type FilterInputText } from '@unchainedshop/core';
+import { type FilterInputText } from '@unchainedshop/core';
 import { DuplicateFilterKeyError } from '../../../errors.ts';
 
 export default async function createFilter(
@@ -9,12 +9,10 @@ export default async function createFilter(
   { filter, texts }: { filter: Filter; texts: FilterInputText[] },
   context: Context,
 ) {
-  const { modules, userId } = context;
+  const { modules, services, userId } = context;
   log('mutation createFilter', { userId });
   try {
-    const newFilter = await modules.filters.create(filter);
-
-    await FilterDirector.invalidateProductIdCache(newFilter, context);
+    const newFilter = await services.filters.createFilter(filter);
 
     if (texts) {
       await modules.filters.texts.updateTexts({ filterId: newFilter._id }, texts);

--- a/packages/api/src/resolvers/mutations/filters/createFilterOption.ts
+++ b/packages/api/src/resolvers/mutations/filters/createFilterOption.ts
@@ -1,6 +1,6 @@
 import type { Context } from '../../../context.ts';
 import { log } from '@unchainedshop/logger';
-import { FilterDirector, type FilterInputText } from '@unchainedshop/core';
+import { type FilterInputText } from '@unchainedshop/core';
 import { FilterNotFoundError, InvalidIdError } from '../../../errors.ts';
 
 export default async function createFilterOption(
@@ -8,7 +8,7 @@ export default async function createFilterOption(
   params: { filterId: string; option: string; texts?: FilterInputText[] },
   context: Context,
 ) {
-  const { modules, userId } = context;
+  const { modules, services, userId } = context;
   const { filterId, option, texts } = params;
 
   log(`mutation createFilterOption ${filterId}`, { userId });
@@ -17,8 +17,7 @@ export default async function createFilterOption(
 
   if (!(await modules.filters.filterExists({ filterId }))) throw new FilterNotFoundError({ filterId });
 
-  const filter = await modules.filters.createFilterOption(filterId, { value: option });
-  await FilterDirector.invalidateProductIdCache(filter!, context);
+  const filter = await services.filters.createFilterOption(filterId, { value: option });
 
   if (texts) {
     await modules.filters.texts.updateTexts({ filterId, filterOptionValue: option }, texts);

--- a/packages/api/src/resolvers/mutations/filters/removeFilterOption.ts
+++ b/packages/api/src/resolvers/mutations/filters/removeFilterOption.ts
@@ -1,25 +1,18 @@
 import { log } from '@unchainedshop/logger';
 import { FilterNotFoundError, InvalidIdError } from '../../../errors.ts';
 import type { Context } from '../../../context.ts';
-import { FilterDirector } from '@unchainedshop/core';
 
 export default async function removeFilterOption(
   root: never,
   { filterId, filterOptionValue }: { filterId: string; filterOptionValue: string },
   context: Context,
 ) {
-  const { modules, userId } = context;
+  const { modules, services, userId } = context;
   log(`mutation removeFilterOption ${filterId}`, { userId });
 
   if (!filterId || !filterOptionValue) throw new InvalidIdError({ filterId, filterOptionValue });
 
   if (!(await modules.filters.filterExists({ filterId }))) throw new FilterNotFoundError({ filterId });
 
-  const filter = await modules.filters.removeFilterOption({
-    filterId,
-    filterOptionValue,
-  });
-  await FilterDirector.invalidateProductIdCache(filter!, context);
-
-  return filter;
+  return services.filters.removeFilterOption({ filterId, filterOptionValue });
 }

--- a/packages/api/src/resolvers/mutations/filters/updateFilter.ts
+++ b/packages/api/src/resolvers/mutations/filters/updateFilter.ts
@@ -2,14 +2,13 @@ import { log } from '@unchainedshop/logger';
 import type { Filter } from '@unchainedshop/core-filters';
 import { FilterNotFoundError, InvalidIdError } from '../../../errors.ts';
 import type { Context } from '../../../context.ts';
-import { FilterDirector } from '@unchainedshop/core';
 
 export default async function updateFilter(
   root: never,
   { filter, filterId }: { filter: Filter; filterId: string },
   context: Context,
 ) {
-  const { modules, userId } = context;
+  const { modules, services, userId } = context;
 
   log(`mutation updateFilter ${filterId}`, { userId });
 
@@ -17,8 +16,5 @@ export default async function updateFilter(
 
   if (!(await modules.filters.filterExists({ filterId }))) throw new FilterNotFoundError({ filterId });
 
-  const updatedFilter = await modules.filters.update(filterId, filter);
-  await FilterDirector.invalidateProductIdCache(updatedFilter!, context);
-
-  return updatedFilter;
+  return services.filters.updateFilter(filterId, filter);
 }

--- a/packages/core-filters/src/db/FiltersCollection.ts
+++ b/packages/core-filters/src/db/FiltersCollection.ts
@@ -48,18 +48,9 @@ export type FilterText = {
   title?: string;
 } & TimestampFields;
 
-export interface FilterProductIdCacheRecord {
-  filterId: string;
-  filterOptionValue: string | null;
-  productIds: string[];
-  /* The filter generation this row was computed from, see filterCacheGeneration. */
-  computedAt?: number;
-}
-
 export const FiltersCollection = async (db: mongodb.Db) => {
   const Filters = db.collection<Filter>('filters');
   const FilterTexts = db.collection<FilterText>('filter_texts');
-  const FilterProductIdCache = db.collection<FilterProductIdCacheRecord>('filter_productId_cache');
   await buildDbIndexes(Filters, [
     {
       index: { _id: 'text', key: 'text', options: 'text' },
@@ -92,14 +83,13 @@ export const FiltersCollection = async (db: mongodb.Db) => {
     },
   ]);
 
-  await buildDbIndexes(FilterProductIdCache, [
-    { index: { productIds: 1 } },
-    { index: { filterId: 1, filterOptionValue: 1 } },
-  ]);
+  // The product id cache is the storage of one pluggable cache backend (see filtersSettings), so
+  // its collection and indexes are owned by that backend - product-cache/mongodb.ts - not by this
+  // factory. A shop running a Redis/HTTP backend must not have this Mongo collection provisioned
+  // underneath it.
 
   return {
     Filters,
     FilterTexts,
-    FilterProductIdCache,
   };
 };

--- a/packages/core-filters/src/filters-index.ts
+++ b/packages/core-filters/src/filters-index.ts
@@ -2,3 +2,6 @@ export * from './db/FiltersCollection.ts';
 export * from './module/configureFiltersModule.ts';
 export * from './search.ts';
 export * from './filters-settings.ts';
+// The record type moved to the Mongo cache backend that owns the collection; re-exported here so
+// the package's public surface is unchanged.
+export type { FilterProductIdCacheRecord } from './product-cache/mongodb.ts';

--- a/packages/core-filters/src/filters-settings.ts
+++ b/packages/core-filters/src/filters-settings.ts
@@ -41,9 +41,15 @@ export const filtersSettings: FiltersSettings = {
       );
     }
 
-    const defaultCache = await makeMongoDBCache(db);
-    filtersSettings.setCachedProductIds = setCachedProductIds || defaultCache.setCachedProductIds;
-    filtersSettings.getCachedProductIds = getCachedProductIds || defaultCache.getCachedProductIds;
-    filtersSettings.purgeCachedProductIds = purgeCachedProductIds || defaultCache.purgeCachedProductIds;
+    // Instantiated only when something still needs it. makeMongoDBCache provisions the Mongo
+    // cache collection and its indexes, so a backend that overrides every member must not trigger
+    // it - otherwise a Redis/HTTP shop gets an orphan Mongo collection it never reads.
+    const defaultCache =
+      setCachedProductIds && getCachedProductIds && purgeCachedProductIds
+        ? null
+        : await makeMongoDBCache(db);
+    filtersSettings.setCachedProductIds = setCachedProductIds || defaultCache!.setCachedProductIds;
+    filtersSettings.getCachedProductIds = getCachedProductIds || defaultCache!.getCachedProductIds;
+    filtersSettings.purgeCachedProductIds = purgeCachedProductIds || defaultCache!.purgeCachedProductIds;
   },
 };

--- a/packages/core-filters/src/product-cache/mongodb.ts
+++ b/packages/core-filters/src/product-cache/mongodb.ts
@@ -1,8 +1,15 @@
-import { mongodb } from '@unchainedshop/mongodb';
+import { mongodb, buildDbIndexes } from '@unchainedshop/mongodb';
 import { sha256 } from '@unchainedshop/utils';
 import pMemoize from 'p-memoize';
 import ExpiryMap from 'expiry-map';
-import { FiltersCollection } from '../db/FiltersCollection.ts';
+
+export interface FilterProductIdCacheRecord {
+  filterId: string;
+  filterOptionValue: string | null;
+  productIds: string[];
+  /* The filter generation this row was computed from, see filterCacheGeneration. */
+  computedAt?: number;
+}
 
 const DUPLICATE_KEY = 11000;
 
@@ -56,7 +63,13 @@ const CACHE_TTL_MS = parseInt(process.env.UNCHAINED_FILTER_CACHE_TTL_MS || '6000
 const memoizeCache = new ExpiryMap(process.env.NODE_ENV === 'production' ? CACHE_TTL_MS : 1);
 
 export default async function mongodbCache(db: mongodb.Db) {
-  const { FilterProductIdCache } = await FiltersCollection(db);
+  // This backend owns the cache collection and its indexes, so nothing provisions them unless the
+  // Mongo cache is actually in use.
+  const FilterProductIdCache = db.collection<FilterProductIdCacheRecord>('filter_productId_cache');
+  await buildDbIndexes(FilterProductIdCache, [
+    { index: { productIds: 1 } },
+    { index: { filterId: 1, filterOptionValue: 1 } },
+  ]);
 
   // Reads are memoized per process, so a write nobody evicts stays invisible for the whole TTL -
   // a minute in production. Long enough for a retired option to keep answering and a newly added

--- a/packages/core/src/services/createFilter.ts
+++ b/packages/core/src/services/createFilter.ts
@@ -1,0 +1,17 @@
+import type { Filter } from '@unchainedshop/core-filters';
+import type { Modules } from '../modules.ts';
+import { FilterDirector } from '../core-index.ts';
+
+/*
+ * Creating a filter and priming its product id cache belong together: the cache is derived from
+ * the filter's queryable shape, so anything that creates or changes that shape has to invalidate.
+ * Keeping the pair in one service means no API surface can do one without the other.
+ */
+export async function createFilterService(
+  this: Modules,
+  filter: Parameters<Modules['filters']['create']>[0],
+): Promise<Filter> {
+  const newFilter = await this.filters.create(filter);
+  await FilterDirector.invalidateProductIdCache(newFilter, { modules: this });
+  return newFilter;
+}

--- a/packages/core/src/services/createFilterOption.ts
+++ b/packages/core/src/services/createFilterOption.ts
@@ -1,0 +1,19 @@
+import type { Filter } from '@unchainedshop/core-filters';
+import type { Modules } from '../modules.ts';
+import { FilterDirector } from '../core-index.ts';
+
+/*
+ * Adding an option changes the filter's queryable shape, so it invalidates the product id cache.
+ * See createFilterService for why the mutation and the invalidation live together.
+ */
+export async function createFilterOptionService(
+  this: Modules,
+  filterId: string,
+  { value }: { value: string },
+): Promise<Filter | null> {
+  const filter = await this.filters.createFilterOption(filterId, { value });
+  if (filter) {
+    await FilterDirector.invalidateProductIdCache(filter, { modules: this });
+  }
+  return filter;
+}

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -41,6 +41,10 @@ import { verifyQuotationService } from './verifyQuotation.ts';
 import { loadFiltersService } from './loadFilters.ts';
 import { loadFilterOptionsService } from './loadFilterOptions.ts';
 import { removeFilterService } from './removeFilter.ts';
+import { createFilterService } from './createFilter.ts';
+import { updateFilterService } from './updateFilter.ts';
+import { createFilterOptionService } from './createFilterOption.ts';
+import { removeFilterOptionService } from './removeFilterOption.ts';
 import { removeCartDiscountService } from './removeCartDiscount.ts';
 import { addMultipleCartProductsService } from './addMultipleCartProducts.ts';
 import { ercMetadataService } from './ercMetadata.ts';
@@ -183,6 +187,10 @@ export default function initServices(modules: Modules, customServices: CustomSer
       loadFilters: loadFiltersService as Bound<typeof loadFiltersService>,
       loadFilterOptions: loadFilterOptionsService as Bound<typeof loadFilterOptionsService>,
       removeFilter: removeFilterService as Bound<typeof removeFilterService>,
+      createFilter: createFilterService as Bound<typeof createFilterService>,
+      updateFilter: updateFilterService as Bound<typeof updateFilterService>,
+      createFilterOption: createFilterOptionService as Bound<typeof createFilterOptionService>,
+      removeFilterOption: removeFilterOptionService as Bound<typeof removeFilterOptionService>,
     },
     warehousing: {
       ercMetadata: ercMetadataService as Bound<typeof ercMetadataService>,

--- a/packages/core/src/services/removeFilterOption.ts
+++ b/packages/core/src/services/removeFilterOption.ts
@@ -1,0 +1,19 @@
+import type { Filter } from '@unchainedshop/core-filters';
+import type { Modules } from '../modules.ts';
+import { FilterDirector } from '../core-index.ts';
+
+/*
+ * Removing an option changes the filter's queryable shape. The invalidation rebuilds from the
+ * filter's now-reduced options and prunes the retired option's cache row - which is what stops a
+ * removed value from resolving to its frozen product ids (issue #721). See createFilterService.
+ */
+export async function removeFilterOptionService(
+  this: Modules,
+  { filterId, filterOptionValue }: { filterId: string; filterOptionValue: string },
+): Promise<Filter | null> {
+  const filter = await this.filters.removeFilterOption({ filterId, filterOptionValue });
+  if (filter) {
+    await FilterDirector.invalidateProductIdCache(filter, { modules: this });
+  }
+  return filter;
+}

--- a/packages/core/src/services/updateFilter.ts
+++ b/packages/core/src/services/updateFilter.ts
@@ -1,0 +1,19 @@
+import type { Filter } from '@unchainedshop/core-filters';
+import type { Modules } from '../modules.ts';
+import { FilterDirector } from '../core-index.ts';
+
+/*
+ * An update can change the key, type or options - all of which the product id cache is derived
+ * from - so it always invalidates. See createFilterService for why the two live together.
+ */
+export async function updateFilterService(
+  this: Modules,
+  filterId: string,
+  doc: Partial<Filter>,
+): Promise<Filter | null> {
+  const updatedFilter = await this.filters.update(filterId, doc);
+  if (updatedFilter) {
+    await FilterDirector.invalidateProductIdCache(updatedFilter, { modules: this });
+  }
+  return updatedFilter;
+}


### PR DESCRIPTION
Two architecture cleanups on the filter cache, surfaced while reviewing the #728/#729 work. No
behaviour change for the default MongoDB backend; both validated with the full suite + the live
black-box protocol.

## 1. The Mongo cache backend owns its collection

`filter_productId_cache` and its indexes were provisioned by `FiltersCollection` — the factory
every filter consumer shares — even though the collection is the private storage of one *pluggable*
cache backend. A shop running a custom Redis/HTTP backend through the `filtersSettings` seam still
got the Mongo collection and indexes created underneath it.

- `makeMongoDBCache` now creates and indexes the collection itself; `FilterProductIdCacheRecord`
  moves with it (re-exported from the package index, so the public surface is unchanged).
- `FiltersCollection` returns only the canonical `Filters` and `FilterTexts`.
- `configureSettings` instantiates the Mongo default **lazily** — only when a member isn't
  overridden — so a fully-custom backend never provisions the Mongo collection at all.

Verified: a backend overriding all three members leaves only `filters` and `filter_texts`, no
`filter_productId_cache`.

## 2. Filter mutation + invalidation moved into services

"Mutate the filter, then invalidate the product id cache" was copy-pasted across **8 call sites** —
4 GraphQL resolvers + 4 MCP handlers. Easy to forget one; the MCP update path had in fact forgotten
it until #729.

Following the existing `removeFilter` service precedent, the pair now lives in four services
(`createFilter`, `updateFilter`, `createFilterOption`, `removeFilterOption`) that both surfaces
delegate to. The API layer keeps what's genuinely its own: ACL, logging, existence checks, error
mapping, localized texts, MCP normalization.

**Why not push it down into the `core-filters` module:** rebuilding the cache needs `FilterDirector`
(in `core`), and `core-filters` sits *below* `core`, so an in-module call would be an upward
dependency. The service layer in `core` is the lowest layer that sees both the module and the
director — which is also why the sibling assortments module *can* invalidate in-module (its
invalidation is self-contained) while filters can't.

## Validation

- Unit **560/560**, integration **1006 / 0 fail**, build + ESLint clean.
- Live black-box protocol **68/0** against a `NODE_ENV=production` engine — P1 exercises the
  delegated GraphQL resolvers, P4 the delegated MCP handlers (CREATE, UPDATE incl. key rename,
  REMOVE_OPTION, REMOVE).
