### PR TITLE
fix(users): use regex values in batch selectors

### DIFF
--- a/packages/core-users/src/module/buildFindSelector.test.ts
+++ b/packages/core-users/src/module/buildFindSelector.test.ts
@@ -29,6 +29,21 @@ describe('buildFindSelector', () => {
     assert.ok(result.username);
   });
 
+  it('Should use Mongo-compatible regular expressions for usernames and emails', () => {
+    assert.deepStrictEqual(
+      buildFindSelector({
+        usernames: [' Mikael ', 'user+tag'],
+        emails: [' Test+tag@example.com '],
+      }),
+      {
+        deleted: null,
+        guest: { $ne: true },
+        username: { $in: [/^Mikael$/i, /^user\+tag$/i] },
+        'emails.address': { $in: [/^Test\+tag@example\.com$/i] },
+      },
+    );
+  });
+
   it('Should include web3Verified filter when passed', () => {
     assert.deepStrictEqual(buildFindSelector({ web3Verified: true }), {
       deleted: null,

--- a/packages/core-users/src/module/configureUsersModule.ts
+++ b/packages/core-users/src/module/configureUsersModule.ts
@@ -86,13 +86,13 @@ export const buildFindSelector = ({
   }
   if (usernames?.length) {
     selector.username = {
-      $in: usernames.map((u) => insensitiveTrimmedRegexOperator(u)),
-    } as any;
+      $in: usernames.map((u) => insensitiveTrimmedRegexOperator(u).$regex),
+    };
   }
   if (emails?.length) {
     selector['emails.address'] = {
-      $in: emails.map((e) => insensitiveTrimmedRegexOperator(e)),
-    } as any;
+      $in: emails.map((e) => insensitiveTrimmedRegexOperator(e).$regex),
+    };
   }
   if (emailVerified === true) {
     selector['emails.verified'] = true;


### PR DESCRIPTION
## Summary
- pass raw regular expressions to MongoDB `$in` for batch username/email lookup
- retain trimming, escaping, anchoring, and case-insensitive matching
- add regression coverage for both selector fields

Fixes #733

## Verification
- `npm run build --workspace @unchainedshop/core-users`
- `node --test packages/core-users/src/module/buildFindSelector.test.ts packages/core-users/src/module/removeConfidentialServiceHashes.test.ts packages/core-users/src/utils/web3-verification.test.ts`
- MongoDB-backed reproduction for `findUsers({ usernames })` and `findUsers({ emails })`