### PR TITLE
Fix filter cache duplicate-key noise and admin list behavior

### DIFF
--- a/admin-ui/src/modules/common/hooks/useScrollRestoration.ts
+++ b/admin-ui/src/modules/common/hooks/useScrollRestoration.ts
@@ -1,0 +1,62 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+
+// Module-level cache of the last scroll position per list route. It persists
+// across the inline list <-> detail remount: on the products and orders index
+// pages the detail view is rendered on the *same* route via a query param
+// (e.g. `/products?slug=…`), so the list subtree unmounts on the way in and
+// remounts on the way back, losing its scroll position.
+const scrollPositions = new Map<string, number>();
+
+/**
+ * Preserves and restores the window scroll position of a list page whose detail
+ * view is rendered inline on the same route. Without it, returning from a detail
+ * view (browser back or the breadcrumb link) drops the user at the top of the
+ * list instead of where they left off. The already-loaded rows survive in the
+ * Apollo cache, so only the scroll position needs restoring.
+ *
+ * @param isActive whether the list (not the inline detail) is currently shown.
+ */
+const useScrollRestoration = (isActive: boolean) => {
+  const router = useRouter();
+  const key = router.pathname;
+
+  // Save the scroll position when we navigate away while the list is shown.
+  // routeChangeStart fires before Next.js scrolls the next view to the top, so
+  // window.scrollY here is still the list's position (e.g. the moment the user
+  // clicks into a detail view).
+  useEffect(() => {
+    if (!isActive || typeof window === 'undefined') return undefined;
+    const save = () => {
+      scrollPositions.set(key, window.scrollY);
+    };
+    router.events.on('routeChangeStart', save);
+    return () => {
+      router.events.off('routeChangeStart', save);
+    };
+  }, [isActive, key, router.events]);
+
+  // Restore the saved position once the list is shown again. Retry across a few
+  // animation frames so the restore still sticks after the (cached) list has
+  // rendered enough rows for the document to be tall enough to scroll, and to
+  // win against Next.js' default scroll-to-top on the returning navigation.
+  useEffect(() => {
+    if (!isActive || typeof window === 'undefined') return undefined;
+    const target = scrollPositions.get(key);
+    if (!target) return undefined;
+
+    let frame: number;
+    let attempts = 0;
+    const restore = () => {
+      window.scrollTo(0, target);
+      attempts += 1;
+      if (Math.abs(window.scrollY - target) > 2 && attempts < 30) {
+        frame = requestAnimationFrame(restore);
+      }
+    };
+    frame = requestAnimationFrame(restore);
+    return () => cancelAnimationFrame(frame);
+  }, [isActive, key]);
+};
+
+export default useScrollRestoration;

--- a/admin-ui/src/modules/common/utils/useFormatDateTime.ts
+++ b/admin-ui/src/modules/common/utils/useFormatDateTime.ts
@@ -1,11 +1,23 @@
 import { format } from 'date-fns';
 import { fromZonedTime } from 'date-fns-tz';
+import { useContext } from 'react';
+import { useIntl } from 'react-intl';
+import AppContext from '../components/AppContext';
 
 const useFormatDateTime = () => {
+  const { locale } = useIntl();
+  // Prefer the region-qualified locale the user selected for viewing content
+  // (e.g. "de-CH", which defaults to the shop's country) so dates follow the
+  // region, and fall back to the UI language. Reading the context directly
+  // (instead of the throwing useApp hook) keeps this shared helper usable
+  // outside the AppContext provider, where it defaults to the UI locale.
+  const appContext = useContext(AppContext);
+  const activeLocale = appContext?.selectedLocale || locale || undefined;
+
   const formatDateTime = (date, options: Intl.DateTimeFormatOptions = {}) => {
     if (!date || !Date.parse(date)) return 'n/a';
 
-    return Intl.DateTimeFormat(undefined, options).format(
+    return Intl.DateTimeFormat(activeLocale, options).format(
       new Date(date).getTime(),
     );
   };
@@ -26,7 +38,7 @@ const useFormatDateTime = () => {
       }
     };
 
-    return new Intl.DateTimeFormat(undefined)
+    return new Intl.DateTimeFormat(activeLocale)
       .formatToParts(new Date())
       .map(getPatternForPart)
       .join('');

--- a/admin-ui/src/modules/product/components/ProductListItem.tsx
+++ b/admin-ui/src/modules/product/components/ProductListItem.tsx
@@ -163,14 +163,14 @@ const ProductListItem = ({
       <Table.Cell>
         {product?.status !== 'DELETED' ? (
           <Link href={productUrl} className="block">
-            <div className="flex flex-wrap gap-2">
+            <div className="flex max-w-xs flex-wrap gap-2">
               {product.tags?.map((t) => (
                 <Badge key={t} text={t} color="slate" />
               ))}
             </div>
           </Link>
         ) : (
-          <div className="flex flex-wrap gap-2">
+          <div className="flex max-w-xs flex-wrap gap-2">
             {product.tags?.map((t) => (
               <Badge key={t} text={t} color="slate" />
             ))}

--- a/admin-ui/src/pages/orders/index.tsx
+++ b/admin-ui/src/pages/orders/index.tsx
@@ -25,6 +25,7 @@ import {
 } from '../../gql/types';
 import usePaymentProviders from '../../modules/payment-providers/hooks/usePaymentProviders';
 import useDeliveryProviders from '../../modules/delivery-provider/hooks/useDeliveryProviders';
+import useScrollRestoration from '../../modules/common/hooks/useScrollRestoration';
 
 const Orders = () => {
   const { formatMessage } = useIntl();
@@ -79,6 +80,8 @@ const Orders = () => {
       ',',
     ) as IPaymentProviderType[],
   });
+  useScrollRestoration(!orderId);
+
   if (orderId) return <OrderDetailPage orderId={orderId} />;
 
   const headerText =

--- a/admin-ui/src/pages/products/index.tsx
+++ b/admin-ui/src/pages/products/index.tsx
@@ -22,6 +22,7 @@ import AnimatedCounter from '@/components/ui/AnimatedCounter';
 import ProductExport from '../../modules/product/components/ProductExport';
 import ProductImport from '../../modules/product/components/ProductImport';
 import useApp from '../../modules/common/hooks/useApp';
+import useScrollRestoration from '../../modules/common/hooks/useScrollRestoration';
 
 const Products = () => {
   const { formatMessage } = useIntl();
@@ -54,6 +55,7 @@ const Products = () => {
     includeDrafts,
     tags,
   });
+  useScrollRestoration(!slug);
 
   if (slug) return <ProductDetailPage slug={slug} />;
   const headerText =

--- a/packages/core-filters/src/product-cache/mongodb.ts
+++ b/packages/core-filters/src/product-cache/mongodb.ts
@@ -9,8 +9,6 @@ export interface FilterProductIdCacheRecord {
   computedAt?: number;
 }
 
-const DUPLICATE_KEY = 11000;
-
 /*
  * Rebuilding scans the catalog once per option, so on a large catalog a rebuild is in flight long
  * enough for the filter to change underneath it. Rows record the generation they were computed
@@ -26,33 +24,47 @@ const notNewerThan = (computedAt: number) => ({
   $or: [{ computedAt: { $lte: computedAt } }, { computedAt: { $exists: false } }],
 });
 
+/* Aggregation-expression twin of notNewerThan, evaluated against the row inside the update. */
+const missingOrNotNewerThan = (field: string, computedAt: number) => ({
+  $or: [{ $in: [{ $type: field }, ['missing', 'null']] }, { $lte: [field, computedAt] }],
+});
+
+const literal = (value: unknown) => ({ $literal: value });
+
 const updateIfHashChanged = async (Collection, selector, doc, computedAt: number) => {
   const _id = Object.values(selector).join(':');
   try {
     const hash = await sha256(JSON.stringify(doc));
+    // The generation and hash guards are decided inside the update, not in the filter. Guards in
+    // the filter turn an unchanged row (or one a newer generation owns) into a non-match, so the
+    // upsert tries to insert the _id a second time and mongod logs an E11000 for every rebuild of
+    // a stable catalog - thousands an hour on a busy cluster, all harmless, all indistinguishable
+    // in the logs from a real duplicate-key bug. Here the row is always addressed by _id (created
+    // if absent) and the server keeps the existing values whenever this generation may not write.
+    const mayWrite = {
+      $and: [{ $ne: ['$hash', hash] }, missingOrNotNewerThan('$computedAt', computedAt)],
+    };
+    const writeOrKeep = (field: string, value: unknown) => ({
+      $cond: [mayWrite, literal(value), `$${field}`],
+    });
     await Collection.updateOne(
-      {
-        ...selector,
-        ...notNewerThan(computedAt),
-        hash: { $ne: hash },
-      },
-      {
-        $set: {
-          ...doc,
-          hash,
-          computedAt,
+      { _id },
+      [
+        {
+          $set: {
+            ...Object.fromEntries(Object.entries(selector).map(([k, v]) => [k, literal(v)])),
+            ...Object.fromEntries(
+              Object.entries({ ...doc, hash, computedAt }).map(([k, v]) => [k, writeOrKeep(k, v)]),
+            ),
+          },
         },
-        $setOnInsert: {
-          _id,
-        },
-      },
+      ],
       { upsert: true },
     );
-  } catch (e) {
-    // The row already holds this hash, or a newer generation already claimed it. Either way the
-    // upsert collides on _id and there is nothing to do. Anything else means we did not write,
-    // which the caller has to know before it starts deleting the rows this was meant to replace.
-    if (e?.code !== DUPLICATE_KEY) return { _id, written: false };
+  } catch {
+    // We did not write, which the caller has to know before it starts deleting the rows this was
+    // meant to replace.
+    return { _id, written: false };
   }
   return { _id, written: true };
 };

--- a/tests/filter-product-id-cache.test.js
+++ b/tests/filter-product-id-cache.test.js
@@ -6,6 +6,7 @@ import { FilterDirector } from '@unchainedshop/core';
 import assert from 'node:assert';
 import test from 'node:test';
 import { setTimeout } from 'node:timers/promises';
+import { Collection } from 'mongodb';
 
 let db;
 let graphqlFetch;
@@ -125,6 +126,40 @@ test.describe('Filter: product id cache invalidation', () => {
       .collection('filter_productId_cache')
       .findOne({ filterId: FILTER_ID, filterOptionValue: null });
     assert.deepStrictEqual([...base.productIds].sort(), ['p1', 'p2', 'p3']);
+  });
+
+  test('rebuilding an unchanged cache never trips a duplicate-key error in mongod', async () => {
+    await seedFilter(['a']);
+    const rebuild = () => filtersSettings.setCachedProductIds(FILTER_ID, ['p1'], { a: ['p1'] }, 1);
+    // A guarded upsert that finds nothing to match tries to insert the _id again. The backend
+    // used to swallow the resulting E11000, but mongod had already logged it - and stable
+    // catalogs are rebuilt all day long. So the write itself must not raise for unchanged rows.
+    const raised = [];
+    const original = Collection.prototype.updateOne;
+    Collection.prototype.updateOne = async function updateOneSpy(...args) {
+      try {
+        return await original.apply(this, args);
+      } catch (e) {
+        if (this.collectionName === 'filter_productId_cache') raised.push(e?.code);
+        throw e;
+      }
+    };
+
+    try {
+      await rebuild();
+      await rebuild();
+      await rebuild();
+    } finally {
+      Collection.prototype.updateOne = original;
+    }
+
+    assert.deepStrictEqual(raised, []);
+    assert.deepStrictEqual(await cacheRowIds(), [`${FILTER_ID}:`, `${FILTER_ID}:a`]);
+    const row = await db
+      .collection('filter_productId_cache')
+      .findOne({ filterId: FILTER_ID, filterOptionValue: 'a' });
+    assert.deepStrictEqual(row.productIds, ['p1']);
+    assert.strictEqual(row.computedAt, 1);
   });
 
   test('a key rename is caught even though the option values are unchanged', async () => {


### PR DESCRIPTION
Repeated filter-cache rebuilds of an unchanged catalog currently trigger duplicate-key errors. Move the write guards into a MongoDB update pipeline so existing rows match without attempting another insert, and add a regression test for repeated rebuilds.

Also restore list scroll positions when returning from product and order details, format admin dates using the selected content locale, and constrain product tag wrapping.

Validation: 12 cache integration tests; ESLint on changed files; core-filters TypeScript build.

Known limitations from review: scroll positions are also restored after sidebar navigation; invalid stored locales can throw during date formatting; the pre-existing unchanged-ID generation race remains.
