### PR TITLE
Fix admin history restoration and shared date formatting

### DIFF
--- a/admin-ui/CLAUDE.md
+++ b/admin-ui/CLAUDE.md
@@ -128,3 +128,13 @@ const form = useForm({
 ```bash
 NEXT_PUBLIC_LOGO=url_to_logo
 ```
+
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/admin-ui/cypress/component/date-formatting.cy.tsx
+++ b/admin-ui/cypress/component/date-formatting.cy.tsx
@@ -1,0 +1,174 @@
+import { ApolloClient, ApolloLink, InMemoryCache } from '@apollo/client';
+import { ApolloProvider } from '@apollo/client/react';
+import { useState } from 'react';
+import { IntlProvider } from 'react-intl';
+import AppContext from '../../src/modules/common/components/AppContext.tsx';
+import useFormatDateTime, {
+  resolveDateTimeLocale,
+} from '../../src/modules/common/utils/useFormatDateTime.ts';
+
+const orderDate = '2026-09-07T08:58:00Z';
+const orderOptions: Intl.DateTimeFormatOptions = {
+  dateStyle: 'short',
+  timeStyle: 'short',
+  timeZone: 'UTC',
+};
+
+const DateDisplay = ({ dates, options }) => {
+  const { formatDateTime, locale } = useFormatDateTime();
+  return (
+    <div>
+      <output data-cy="date-locale">{locale}</output>
+      {dates.map((date, index) => (
+        <output key={index} data-cy={`date-${index}`}>
+          {formatDateTime(date, options)}
+        </output>
+      ))}
+    </div>
+  );
+};
+
+const mountDates = ({
+  locale = 'en',
+  country = 'CH',
+  selectedLocale = undefined as string | undefined,
+  dates = [orderDate] as (string | number | Date | null | undefined)[],
+  options = orderOptions,
+} = {}) => {
+  const cache = new InMemoryCache().restore({
+    ROOT_QUERY: {
+      __typename: 'Query',
+      shopInfo: {
+        _id: 'shop',
+        version: 'test',
+        language: null,
+        country: country
+          ? {
+              _id: country,
+              isoCode: country,
+              flagEmoji: '',
+              name: country,
+              defaultCurrency: null,
+            }
+          : null,
+        adminUiConfig: null,
+      },
+    },
+  });
+  const client = new ApolloClient({ cache, link: ApolloLink.empty() });
+  const Harness = () => {
+    const [uiLocale, setUiLocale] = useState(locale);
+    const [contentLocale, setContentLocale] = useState(selectedLocale);
+    return (
+      <ApolloProvider client={client}>
+        <IntlProvider locale={uiLocale} messages={{}}>
+          <button onClick={() => setUiLocale('de')}>Deutsch</button>
+          <button onClick={() => setContentLocale('en-US')}>US content</button>
+          <AppContext.Provider
+            value={
+              contentLocale
+                ? {
+                    selectedLocale: contentLocale,
+                    setSelectedLocale: setContentLocale,
+                    languageDialectList: [],
+                    isSystemReady: true,
+                    shopInfo: null,
+                  }
+                : undefined
+            }
+          >
+            <DateDisplay dates={dates} options={options} />
+          </AppContext.Provider>
+        </IntlProvider>
+      </ApolloProvider>
+    );
+  };
+
+  cy.mount(<Harness />);
+};
+
+describe('regional date formatting', () => {
+  it('preserves the selected content locale and updates when it changes', () => {
+    mountDates({
+      selectedLocale: 'de-CH',
+      dates: ['2026-05-08T08:58:00Z'],
+      options: { month: 'long', timeZone: 'UTC' },
+    });
+
+    cy.get('[data-cy="date-locale"]').should('have.text', 'de-CH');
+    cy.get('[data-cy="date-0"]').should('have.text', 'Mai');
+    cy.contains('button', 'US content').click();
+    cy.get('[data-cy="date-locale"]').should('have.text', 'en-US');
+    cy.get('[data-cy="date-0"]').should('have.text', 'May');
+  });
+
+  it('falls back to the UI language and shop region for invalid stored locales', () => {
+    mountDates({ selectedLocale: 'invalid_locale' });
+
+    cy.get('[data-cy="date-locale"]').should('have.text', 'en-CH');
+    cy.get('[data-cy="date-0"]').should('have.text', '07.09.2026, 08:58');
+  });
+
+  it('formats order dates with the shop region while viewing English', () => {
+    mountDates();
+
+    cy.get('[data-cy="date-locale"]').should('have.text', 'en-CH');
+    cy.get('[data-cy="date-0"]').should('have.text', '07.09.2026, 08:58');
+  });
+
+  it('updates the formatting language when the UI language changes', () => {
+    mountDates({
+      options: { month: 'long', timeZone: 'UTC' },
+      dates: ['2026-05-08T08:58:00Z'],
+    });
+
+    cy.get('[data-cy="date-0"]').should('have.text', 'May');
+    cy.contains('button', 'Deutsch').click();
+    cy.get('[data-cy="date-locale"]').should('have.text', 'de-CH');
+    cy.get('[data-cy="date-0"]').should('have.text', 'Mai');
+  });
+
+  it('keeps an explicit UI region and uses the UI language without a shop country', () => {
+    expect(resolveDateTimeLocale('en-US', 'CH')).to.equal('en-US');
+    mountDates({ country: null });
+
+    cy.get('[data-cy="date-locale"]').should('have.text', 'en');
+    cy.get('[data-cy="date-0"]').should('have.text', '9/7/26, 8:58 AM');
+  });
+
+  it('distinguishes script subtags from regions and tolerates invalid country codes', () => {
+    expect(resolveDateTimeLocale('zh-Hant', 'TW')).to.equal('zh-Hant-TW');
+    expect(resolveDateTimeLocale('en', 'invalid')).to.equal('en');
+  });
+
+  it('formats epoch values and rejects only missing or invalid dates', () => {
+    mountDates({
+      dates: [
+        0,
+        new Date(0),
+        '1970-01-01T00:00:00Z',
+        null,
+        undefined,
+        '',
+        'invalid',
+        new Date(NaN),
+      ],
+    });
+
+    for (const index of [0, 1, 2]) {
+      cy.get(`[data-cy="date-${index}"]`).should(
+        'have.text',
+        '01.01.1970, 00:00',
+      );
+    }
+    for (const index of [3, 4, 5, 6, 7]) {
+      cy.get(`[data-cy="date-${index}"]`).should('have.text', 'n/a');
+    }
+  });
+
+  it('preserves the caller’s time zone and date options', () => {
+    mountDates({ options: { ...orderOptions, timeZone: 'America/New_York' } });
+
+    cy.get('[data-cy="date-0"]').should('have.text', '07.09.2026, 04:58');
+  });
+});

--- a/admin-ui/cypress/component/infinite-scroll.cy.tsx
+++ b/admin-ui/cypress/component/infinite-scroll.cy.tsx
@@ -1,0 +1,70 @@
+import InfiniteScroll from '../../src/modules/common/components/InfiniteScroll.tsx';
+
+const mountWithObserver = () => {
+  let callback: IntersectionObserverCallback;
+  let sentinel: Element;
+  const observer = {
+    observe: cy.stub().callsFake((target: Element) => {
+      sentinel = target;
+    }),
+    disconnect: cy.stub(),
+    unobserve: cy.stub(),
+    takeRecords: () => [],
+    root: null,
+    rootMargin: '200px',
+    thresholds: [0],
+  } as IntersectionObserver;
+  const onLoadMore = cy.stub().as('loadMore');
+
+  // Imported components execute in the spec window, while their DOM is mounted
+  // in Cypress's application iframe.
+  cy.stub(globalThis, 'IntersectionObserver').callsFake(
+    (listener: IntersectionObserverCallback) => {
+      callback = listener;
+      return observer;
+    },
+  );
+
+  cy.mount(
+    <InfiniteScroll loading={false} hasMore onLoadMore={onLoadMore}>
+      <div>First page</div>
+    </InfiniteScroll>,
+  );
+
+  return (intersections: boolean[]) => {
+    cy.wrap(observer.observe).should('have.been.calledOnce');
+    cy.then(() => {
+      expect(sentinel.isConnected).to.equal(true);
+      const bounds = sentinel.getBoundingClientRect();
+      const entries = intersections.map((isIntersecting, index) => ({
+        target: sentinel,
+        time: index + 1,
+        isIntersecting,
+        intersectionRatio: isIntersecting ? 1 : 0,
+        boundingClientRect: bounds,
+        intersectionRect: isIntersecting ? bounds : new DOMRect(),
+        rootBounds: null,
+      }));
+
+      callback(entries, observer);
+    });
+  };
+};
+
+describe('batched infinite-scroll intersections', () => {
+  it('loads once when the sentinel enters the viewport at the end of a batch', () => {
+    const deliverIntersections = mountWithObserver();
+
+    deliverIntersections([false, true]);
+
+    cy.get('@loadMore').should('have.been.calledOnce');
+  });
+
+  it('does not load when the sentinel leaves the viewport at the end of a batch', () => {
+    const deliverIntersections = mountWithObserver();
+
+    deliverIntersections([true, false]);
+
+    cy.get('@loadMore').should('not.have.been.called');
+  });
+});

--- a/admin-ui/cypress/e2e/scroll-restoration.cy.ts
+++ b/admin-ui/cypress/e2e/scroll-restoration.cy.ts
@@ -1,0 +1,203 @@
+import { SingleUserResponse, UserListResponse, UserOperations } from '../mock/user.js';
+import hasOperationName from '../utils/hasOperationName.ts';
+
+const users = Array.from({ length: 60 }, (_, index) => ({
+  ...UserListResponse.data.users[0],
+  _id: `scroll-user-${index}`,
+  username: `Scroll user ${index}`,
+  name: `Scroll user ${index}`,
+  deleted: null,
+  cart: null,
+  orders: [],
+}));
+
+const listLinks = 'a[href^="/users/?userId=scroll-user-"]';
+
+const openDetail = () => {
+  cy.get(listLinks).first().click({ force: true, scrollBehavior: false });
+  cy.location('search').should('include', 'userId=scroll-user-0');
+  cy.get('h2').should('contain.text', users[0].username);
+};
+
+const settleLayout = () => {
+  cy.window().then(
+    (win) =>
+      new Cypress.Promise<void>((resolve) => {
+        win.requestAnimationFrame(() => win.requestAnimationFrame(() => resolve()));
+      }),
+  );
+};
+
+const expectScroll = (y: number) => {
+  settleLayout();
+  cy.window().its('scrollY').should('be.closeTo', y, 2);
+};
+
+describe('List scroll restoration', () => {
+  beforeEach(() => {
+    cy.intercept('POST', '/graphql', (req) => {
+      if (hasOperationName(req, UserOperations.GetUserList)) {
+        req.reply({ data: { users, usersCount: users.length } });
+      }
+      if (
+        hasOperationName(req, UserOperations.GetPermissions) ||
+        hasOperationName(req, UserOperations.GetSingle)
+      ) {
+        req.reply({
+          data: {
+            user: {
+              ...SingleUserResponse.data.user,
+              ...users[0],
+            },
+          },
+        });
+      }
+    });
+    cy.visit('/users/');
+    cy.get(listLinks).should('have.length.greaterThan', users.length);
+  });
+
+  it('returns to the same position after opening a query-based detail view', () => {
+    cy.scrollTo(0, 1600);
+    expectScroll(1600);
+    openDetail();
+    expectScroll(0);
+    cy.go('back');
+    cy.location('search').should('eq', '');
+    expectScroll(1600);
+    cy.go('forward');
+    cy.location('search').should('include', 'userId=scroll-user-0');
+    expectScroll(0);
+    cy.go('back');
+    expectScroll(1600);
+  });
+
+  it('keeps a separate position for each visit to the same list URL', () => {
+    cy.scrollTo(0, 1600);
+    openDetail();
+    cy.get('a[href="/users/"]').first().click({ force: true });
+    cy.location('search').should('eq', '');
+    cy.get(listLinks).should('have.length.greaterThan', users.length);
+    expectScroll(0);
+    cy.scrollTo(0, 800);
+    expectScroll(800);
+    cy.go('back');
+    cy.location('search').should('include', 'userId=scroll-user-0');
+    cy.go('back');
+    cy.location('search').should('eq', '');
+    expectScroll(1600);
+  });
+
+  it('restores after the list has to be fetched again', () => {
+    cy.visit('/users/?queryString=scroll');
+    cy.get(listLinks).should('have.length.greaterThan', users.length);
+    cy.scrollTo(0, 1600);
+    openDetail();
+    cy.reload();
+    cy.get('h2').should('contain.text', users[0].username);
+    cy.intercept('POST', '/graphql', (req) => {
+      if (hasOperationName(req, UserOperations.GetUserList)) {
+        req.alias = 'delayedUsers';
+        req.reply({
+          delay: 500,
+          body: { data: { users, usersCount: users.length } },
+        });
+      }
+    });
+    cy.go('back');
+    cy.location('search').should('eq', '?queryString=scroll');
+    cy.wait('@delayedUsers');
+    expectScroll(1600);
+  });
+
+  ['user input', 'another navigation'].forEach((cancelWith) => {
+    it(`stops waiting for a delayed list after ${cancelWith}`, () => {
+      cy.visit('/users/?queryString=scroll');
+      cy.get(listLinks).should('have.length.greaterThan', users.length);
+      cy.scrollTo(0, 1600);
+      openDetail();
+      cy.reload();
+      cy.get('h2').should('contain.text', users[0].username);
+
+      let releaseUsers: () => void;
+      cy.intercept('POST', '/graphql', (req) => {
+        if (
+          hasOperationName(req, UserOperations.GetUserList) &&
+          req.body.variables.queryString === 'scroll'
+        ) {
+          req.alias = 'delayedUsers';
+          return new Cypress.Promise<void>((resolve) => {
+            releaseUsers = () => {
+              req.reply({ data: { users, usersCount: users.length } });
+              resolve();
+            };
+          });
+        }
+      });
+
+      cy.go('back');
+      cy.location('search').should('eq', '?queryString=scroll');
+      cy.get(listLinks).should('not.exist');
+      expectScroll(0);
+      if (cancelWith === 'user input') {
+        cy.window().then((win) => {
+          win.document.body.dispatchEvent(
+            new win.WheelEvent('wheel', { deltaY: 100, bubbles: true }),
+          );
+        });
+      } else {
+        cy.get('a[href="/users/"]').first().click({ force: true });
+        cy.location('search').should('eq', '');
+      }
+      cy.then(() => releaseUsers());
+      cy.wait('@delayedUsers');
+      cy.get(listLinks).should('have.length.greaterThan', users.length);
+      expectScroll(0);
+    });
+  });
+
+  it('loads enough infinite-scroll pages to reach an uncached position', () => {
+    let returning = false;
+    cy.intercept('POST', '/graphql', (req) => {
+      if (
+        hasOperationName(req, UserOperations.GetUserList) &&
+        req.body.variables.queryString === 'paginated'
+      ) {
+        const offset = req.body.variables.offset || 0;
+        req.alias = `${returning ? 'return' : 'initial'}Page${offset}`;
+        req.reply({
+          delay: 100,
+          body: {
+            data: {
+              // Start with an already populated list; after losing the cache,
+              // the same scroll position requires fetching three pages.
+              users: returning ? users.slice(offset, offset + 20) : users,
+              usersCount: users.length,
+            },
+          },
+        });
+      }
+    });
+
+    cy.visit('/users/?queryString=paginated');
+    cy.wait('@initialPage0');
+    cy.get('a[href="/users/?userId=scroll-user-59"]').should('exist');
+    cy.document().then((doc) => cy.scrollTo(0, doc.documentElement.scrollHeight));
+    cy.window()
+      .its('scrollY')
+      .then((position) => {
+        openDetail();
+        cy.reload();
+        cy.get('h2').should('contain.text', users[0].username);
+        cy.then(() => {
+          returning = true;
+        });
+        cy.go('back');
+        cy.location('search').should('eq', '?queryString=paginated');
+        cy.wait('@returnPage0');
+        cy.wait('@returnPage20');
+        cy.wait('@returnPage40');
+        expectScroll(position);
+      });
+  });
+});

--- a/admin-ui/next.config.js
+++ b/admin-ui/next.config.js
@@ -22,4 +22,9 @@ export default {
   images: {
     unoptimized: true,
   },
+  experimental: {
+    // Preserve each history entry's position, including query-based detail
+    // views. useScrollRestoration retries after asynchronous list loads.
+    scrollRestoration: true,
+  },
 };

--- a/admin-ui/src/modules/accounts/components/UserListItem.tsx
+++ b/admin-ui/src/modules/accounts/components/UserListItem.tsx
@@ -7,24 +7,23 @@ import MiniUserAvatar from '../../common/components/MiniUserAvatar';
 import Table from '../../common/components/Table';
 import TableActionsMenu from '../../common/components/TableActionsMenu';
 import formatUsername from '../../common/utils/formatUsername';
+import useFormatDateTime from '@/modules/common/utils/useFormatDateTime';
 import { ShoppingBagIcon, ShoppingCartIcon } from '@heroicons/react/24/outline';
 
 const UserLastLogin = ({ lastLogin }) => {
-  const { locale } = useIntl();
+  const { formatDateTime } = useFormatDateTime();
   const loginDate = new Date(lastLogin?.timestamp);
-  if (!loginDate?.getTime()) return null;
-  const formattedDate = loginDate.toLocaleDateString(locale, {
-    year: 'numeric',
-    month: 'numeric',
-    day: 'numeric',
-  });
-  const formattedTime = loginDate.toLocaleTimeString(locale, {
-    hour: '2-digit',
-    minute: '2-digit',
-  });
+  if (lastLogin?.timestamp == null || Number.isNaN(loginDate.getTime()))
+    return null;
   return (
     <div className="text-sm text-slate-500">
-      {formattedDate}, {formattedTime}
+      {formatDateTime(lastLogin.timestamp, {
+        year: 'numeric',
+        month: 'numeric',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      })}
     </div>
   );
 };

--- a/admin-ui/src/modules/common/components/InfiniteScroll.tsx
+++ b/admin-ui/src/modules/common/components/InfiniteScroll.tsx
@@ -30,8 +30,15 @@ const InfiniteScroll = ({
     if (!sentinel) return;
 
     const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting && hasMoreRef.current && !loadingRef.current) {
+      (entries) => {
+        // One sentinel is observed, but its transitions can arrive in a batch.
+        // The newest record describes whether it is currently visible.
+        const entry = entries.at(-1);
+        if (
+          entry?.isIntersecting &&
+          hasMoreRef.current &&
+          !loadingRef.current
+        ) {
           onLoadMoreRef.current();
         }
       },

--- a/admin-ui/src/modules/common/hooks/useScrollRestoration.ts
+++ b/admin-ui/src/modules/common/hooks/useScrollRestoration.ts
@@ -1,62 +1,123 @@
 import { useEffect } from 'react';
-import { useRouter } from 'next/router';
+import Router from 'next/router';
 
-// Module-level cache of the last scroll position per list route. It persists
-// across the inline list <-> detail remount: on the products and orders index
-// pages the detail view is rendered on the *same* route via a query param
-// (e.g. `/products?slug=…`), so the list subtree unmounts on the way in and
-// remounts on the way back, losing its scroll position.
-const scrollPositions = new Map<string, number>();
+const RESTORE_TIMEOUT_MS = 5000;
+
+interface ScrollPosition {
+  x: number;
+  y: number;
+}
+
+const readHistoryPosition = (): ScrollPosition | undefined => {
+  // This storage format and history key belong to the Pages Router's
+  // experimental.scrollRestoration feature enabled in next.config.js.
+  // Reuse its per-entry positions so separate visits to one URL stay distinct.
+  const key = window.history.state?.key;
+  if (typeof key !== 'string') return;
+  try {
+    const position = JSON.parse(sessionStorage.getItem(`__next_scroll_${key}`));
+    if (
+      Number.isFinite(position?.x) &&
+      Number.isFinite(position?.y) &&
+      position.x >= 0 &&
+      position.y >= 0
+    ) {
+      return position;
+    }
+  } catch {
+    // Missing, malformed, or unavailable storage leaves restoration to Next.
+  }
+};
+
+const restoreWhenReady = ({ x, y }: ScrollPosition) => {
+  const deadline = performance.now() + RESTORE_TIMEOUT_MS;
+  let frame = 0;
+  let previousMaxY = -1;
+
+  const cancel = () => {
+    cancelAnimationFrame(frame);
+    window.removeEventListener('wheel', cancel);
+    window.removeEventListener('touchstart', cancel);
+    window.removeEventListener('keydown', cancel);
+  };
+
+  const attempt = () => {
+    const maxY = Math.max(
+      document.documentElement.scrollHeight - window.innerHeight,
+      0,
+    );
+    if (maxY >= y || performance.now() >= deadline) {
+      window.scrollTo(x, Math.min(y, maxY));
+      cancel();
+    } else {
+      // Let new content render for a frame before following the list's bottom.
+      // Its IntersectionObserver must see the sentinel leave the viewport
+      // before scrolling back to it can request the next page.
+      if (maxY === previousMaxY) window.scrollTo(x, maxY);
+      previousMaxY = maxY;
+      frame = requestAnimationFrame(attempt);
+    }
+  };
+
+  window.addEventListener('wheel', cancel, { passive: true });
+  window.addEventListener('touchstart', cancel, { passive: true });
+  window.addEventListener('keydown', cancel);
+  frame = requestAnimationFrame(attempt);
+  return cancel;
+};
 
 /**
- * Preserves and restores the window scroll position of a list page whose detail
- * view is rendered inline on the same route. Without it, returning from a detail
- * view (browser back or the breadcrumb link) drops the user at the top of the
- * list instead of where they left off. The already-loaded rows survive in the
- * Apollo cache, so only the scroll position needs restoring.
- *
- * @param isActive whether the list (not the inline detail) is currently shown.
+ * Next restores before asynchronously fetched lists have rendered, which clamps
+ * the saved position to the top. Retry that same history entry's position while
+ * the list grows, stopping when the user scrolls or starts another navigation.
  */
-const useScrollRestoration = (isActive: boolean) => {
-  const router = useRouter();
-  const key = router.pathname;
-
-  // Save the scroll position when we navigate away while the list is shown.
-  // routeChangeStart fires before Next.js scrolls the next view to the top, so
-  // window.scrollY here is still the list's position (e.g. the moment the user
-  // clicks into a detail view).
+const useScrollRestoration = () => {
   useEffect(() => {
-    if (!isActive || typeof window === 'undefined') return undefined;
-    const save = () => {
-      scrollPositions.set(key, window.scrollY);
-    };
-    router.events.on('routeChangeStart', save);
-    return () => {
-      router.events.off('routeChangeStart', save);
-    };
-  }, [isActive, key, router.events]);
+    let historyTarget: { url: string; position: ScrollPosition } | undefined;
+    let routeTarget: typeof historyTarget;
+    let cancelRestore: (() => void) | undefined;
 
-  // Restore the saved position once the list is shown again. Retry across a few
-  // animation frames so the restore still sticks after the (cached) list has
-  // rendered enough rows for the document to be tall enough to scroll, and to
-  // win against Next.js' default scroll-to-top on the returning navigation.
-  useEffect(() => {
-    if (!isActive || typeof window === 'undefined') return undefined;
-    const target = scrollPositions.get(key);
-    if (!target) return undefined;
+    const reset = () => {
+      historyTarget = undefined;
+      routeTarget = undefined;
+      cancelRestore?.();
+      cancelRestore = undefined;
+    };
 
-    let frame: number;
-    let attempts = 0;
-    const restore = () => {
-      window.scrollTo(0, target);
-      attempts += 1;
-      if (Math.abs(window.scrollY - target) > 2 && attempts < 30) {
-        frame = requestAnimationFrame(restore);
+    Router.beforePopState(({ as }) => {
+      const position = readHistoryPosition();
+      historyTarget = position ? { url: as, position } : undefined;
+      return true;
+    });
+
+    const onRouteChangeStart = (url: string) => {
+      const target = historyTarget;
+      reset();
+      if (target?.url === url) routeTarget = target;
+    };
+
+    const onRouteChangeComplete = (url: string) => {
+      const target = routeTarget;
+      reset();
+      if (target?.url === url) {
+        cancelRestore = restoreWhenReady(target.position);
       }
     };
-    frame = requestAnimationFrame(restore);
-    return () => cancelAnimationFrame(frame);
-  }, [isActive, key]);
+
+    Router.events.on('routeChangeStart', onRouteChangeStart);
+    Router.events.on('routeChangeComplete', onRouteChangeComplete);
+    Router.events.on('routeChangeError', reset);
+    Router.events.on('hashChangeStart', reset);
+
+    return () => {
+      reset();
+      Router.beforePopState(() => true);
+      Router.events.off('routeChangeStart', onRouteChangeStart);
+      Router.events.off('routeChangeComplete', onRouteChangeComplete);
+      Router.events.off('routeChangeError', reset);
+      Router.events.off('hashChangeStart', reset);
+    };
+  }, []);
 };
 
 export default useScrollRestoration;

--- a/admin-ui/src/modules/common/utils/useFormatDateTime.ts
+++ b/admin-ui/src/modules/common/utils/useFormatDateTime.ts
@@ -2,24 +2,65 @@ import { format } from 'date-fns';
 import { fromZonedTime } from 'date-fns-tz';
 import { useContext } from 'react';
 import { useIntl } from 'react-intl';
-import AppContext from '../components/AppContext';
+import AppContext from '@/modules/common/components/AppContext';
+import useShopInfo from '@/modules/common/hooks/useShopInfo';
+
+/**
+ * Resolves the BCP 47 locale used for date & time formatting in the Admin UI.
+ *
+ * Preserves the selected content locale. Without a valid selection, combines
+ * the Admin UI language with the shop country for regional conventions.
+ * An explicit region in the UI locale takes precedence over the shop country.
+ */
+export const resolveDateTimeLocale = (
+  uiLocale?: string | null,
+  countryCode?: string | null,
+  selectedLocale?: string | null,
+): string => {
+  if (selectedLocale) {
+    try {
+      return new Intl.Locale(selectedLocale).toString();
+    } catch {
+      // Ignore invalid stored selections and use the UI language and shop.
+    }
+  }
+  const locale = new Intl.Locale(uiLocale || 'en');
+  if (locale.region || !countryCode) return locale.toString();
+
+  try {
+    return new Intl.Locale(locale, {
+      region: countryCode.toUpperCase(),
+    }).toString();
+  } catch {
+    return locale.toString();
+  }
+};
 
 const useFormatDateTime = () => {
-  const { locale } = useIntl();
-  // Prefer the region-qualified locale the user selected for viewing content
-  // (e.g. "de-CH", which defaults to the shop's country) so dates follow the
-  // region, and fall back to the UI language. Reading the context directly
-  // (instead of the throwing useApp hook) keeps this shared helper usable
-  // outside the AppContext provider, where it defaults to the UI locale.
+  const { locale: uiLocale } = useIntl();
+  const { shopInfo } = useShopInfo();
   const appContext = useContext(AppContext);
-  const activeLocale = appContext?.selectedLocale || locale || undefined;
+  const locale = resolveDateTimeLocale(
+    uiLocale,
+    shopInfo?.country?.isoCode,
+    appContext?.selectedLocale,
+  );
 
-  const formatDateTime = (date, options: Intl.DateTimeFormatOptions = {}) => {
-    if (!date || !Date.parse(date)) return 'n/a';
+  const formatDateTime = (
+    date: unknown,
+    options: Intl.DateTimeFormatOptions = {},
+  ) => {
+    if (
+      (typeof date !== 'string' &&
+        typeof date !== 'number' &&
+        !(date instanceof Date)) ||
+      date === ''
+    )
+      return 'n/a';
+    const timestamp = new Date(date).getTime();
+    if (Number.isNaN(timestamp)) return 'n/a';
 
-    return Intl.DateTimeFormat(activeLocale, options).format(
-      new Date(date).getTime(),
-    );
+    return new Intl.DateTimeFormat(locale, options).format(timestamp);
   };
 
   const getDateFormatPattern = () => {
@@ -38,7 +79,7 @@ const useFormatDateTime = () => {
       }
     };
 
-    return new Intl.DateTimeFormat(activeLocale)
+    return new Intl.DateTimeFormat(locale)
       .formatToParts(new Date())
       .map(getPatternForPart)
       .join('');
@@ -51,7 +92,7 @@ const useFormatDateTime = () => {
     );
   };
 
-  return { formatDateTime, getDateFormatPattern, parseDate };
+  return { formatDateTime, getDateFormatPattern, parseDate, locale };
 };
 
 export default useFormatDateTime;

--- a/admin-ui/src/modules/copilot/components/AssortmentListItem.tsx
+++ b/admin-ui/src/modules/copilot/components/AssortmentListItem.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 import { FolderIcon, CalendarIcon } from '@heroicons/react/24/outline';
 import Badge from '@/components/ui/Badge';
 import generateUniqueId from '../../common/utils/getUniqueId';
+import useFormatDateTime from '@/modules/common/utils/useFormatDateTime';
 
 interface AssortmentListItemProps {
   assortment: any;
@@ -16,6 +17,7 @@ const AssortmentListItem: React.FC<AssortmentListItemProps> = ({
   className,
 }) => {
   const { formatMessage } = useIntl();
+  const { formatDateTime } = useFormatDateTime();
 
   const getStatusBadge = (isActive: boolean) => {
     return (
@@ -58,7 +60,7 @@ const AssortmentListItem: React.FC<AssortmentListItemProps> = ({
 
   const formatDate = (dateString: string) => {
     if (!dateString) return '';
-    return new Date(dateString).toLocaleDateString();
+    return formatDateTime(dateString, { dateStyle: 'medium' });
   };
 
   return (

--- a/admin-ui/src/modules/copilot/components/AssortmentListItemCompact.tsx
+++ b/admin-ui/src/modules/copilot/components/AssortmentListItemCompact.tsx
@@ -5,9 +5,11 @@ import ImageWithFallback from '@/components/ui/ImageWithFallback';
 import Badge from '@/components/ui/Badge';
 import generateUniqueId from '../../common/utils/getUniqueId';
 import CopyableId from './shared/CopyableId';
+import useFormatDateTime from '@/modules/common/utils/useFormatDateTime';
 
 const AssortmentListItemCompact = ({ assortment, children = null }) => {
   const { formatMessage } = useIntl();
+  const { formatDateTime } = useFormatDateTime();
   if (!assortment) return null;
 
   const {
@@ -29,7 +31,7 @@ const AssortmentListItemCompact = ({ assortment, children = null }) => {
   const thumbnailUrl = media[0]?.file?.url;
 
   const formatDate = (dateString?: string) =>
-    dateString ? new Date(dateString).toLocaleDateString() : '';
+    dateString ? formatDateTime(dateString, { dateStyle: 'medium' }) : '';
 
   return (
     <div className="relative border rounded-xl p-4 shadow-sm bg-surface-input space-y-4">

--- a/admin-ui/src/modules/copilot/components/CopilotProviderList.tsx
+++ b/admin-ui/src/modules/copilot/components/CopilotProviderList.tsx
@@ -5,6 +5,7 @@ import Badge from '@/components/ui/Badge';
 import { useIntl } from 'react-intl';
 import CopyableId from './shared/CopyableId';
 import ConfigurationDisplay from './shared/ConfigurationDisplay';
+import useFormatDateTime from '@/modules/common/utils/useFormatDateTime';
 
 const getNormalizedDetailPageLink = (type, provider) => {
   if (type === 'PAYMENT')
@@ -16,6 +17,7 @@ const getNormalizedDetailPageLink = (type, provider) => {
 };
 export const CopilotProviderListItem = ({ provider, type }) => {
   const { formatMessage } = useIntl();
+  const { formatDateTime } = useFormatDateTime();
   return (
     <div className="relative border rounded-xl p-4 shadow-sm bg-surface-input space-y-4 w-full">
       <Link
@@ -45,7 +47,7 @@ export const CopilotProviderListItem = ({ provider, type }) => {
             />
             <span>
               {formatMessage({ id: 'created', defaultMessage: 'Created' })}:{' '}
-              {new Date(provider.created).toLocaleDateString()}
+              {formatDateTime(provider.created, { dateStyle: 'medium' })}
             </span>
             <span>
               {formatMessage({

--- a/admin-ui/src/modules/copilot/components/product/VariationListItemCompact.tsx
+++ b/admin-ui/src/modules/copilot/components/product/VariationListItemCompact.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useIntl } from 'react-intl';
+import useFormatDateTime from '@/modules/common/utils/useFormatDateTime';
 
 interface VariationListItemCompactProps {
   variation: {
@@ -17,6 +18,7 @@ const VariationListItemCompact: React.FC<VariationListItemCompactProps> = ({
   variation,
 }) => {
   const { formatMessage } = useIntl();
+  const { formatDateTime } = useFormatDateTime();
 
   return (
     <div className="flex items-center gap-4 p-3 bg-surface rounded-lg shadow-sm border border-border-subtle hover:shadow-md transition-shadow duration-200 w-full overflow-hidden">
@@ -58,14 +60,22 @@ const VariationListItemCompact: React.FC<VariationListItemCompactProps> = ({
             id: 'created',
             defaultMessage: 'Created',
           })}
-          : {new Date(variation.created).toLocaleString()}
+          :{' '}
+          {formatDateTime(variation.created, {
+            dateStyle: 'medium',
+            timeStyle: 'short',
+          })}
         </span>
         <span>
           {formatMessage({
             id: 'updated',
             defaultMessage: 'Updated',
           })}
-          : {new Date(variation.updated).toLocaleString()}
+          :{' '}
+          {formatDateTime(variation.updated, {
+            dateStyle: 'medium',
+            timeStyle: 'short',
+          })}
         </span>
       </div>
     </div>

--- a/admin-ui/src/modules/work/hooks/useRecentExports.ts
+++ b/admin-ui/src/modules/work/hooks/useRecentExports.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { ISortOptionInput, IWorkStatus, IWorkType } from '../../../gql/types';
 import useWorkQueue from './useWorkQueue';
+import useFormatDateTime from '@/modules/common/utils/useFormatDateTime';
 
 interface ExportFileInfo {
   url: string;
@@ -34,14 +35,22 @@ interface RecentExportsResult {
   exports: ExportGroup[];
 }
 
+type FormatDateTime = ReturnType<typeof useFormatDateTime>['formatDateTime'];
+
 const getActiveFilesAndCount = (
   workQueue: ExportedWork[],
+  formatDateTime: FormatDateTime,
 ): RecentExportsResult => {
   if (!workQueue?.length) {
     return { exports: [], count: 0 };
   }
 
   const now = Date.now();
+  const formatTimestamp = (timestamp: number | string | Date) =>
+    formatDateTime(timestamp, {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    });
 
   const groupedData = workQueue
     .map((work): ExportGroup | null => {
@@ -56,7 +65,7 @@ const getActiveFilesAndCount = (
         .map(([key, file]) => ({
           name: key.toUpperCase(),
           url: file!.url,
-          expiresAt: new Date(finishedTime + file!.expires).toLocaleString(),
+          expiresAt: formatTimestamp(finishedTime + file!.expires),
         }));
 
       if (activeFiles.length === 0) return null;
@@ -64,7 +73,7 @@ const getActiveFilesAndCount = (
       return {
         id: work._id,
         type: work.input?.type,
-        finished: new Date(work.finished).toLocaleString(),
+        finished: formatTimestamp(work.finished),
         files: activeFiles,
       };
     })
@@ -94,6 +103,7 @@ const useRecentExports = ({
     [],
   );
 
+  const { formatDateTime } = useFormatDateTime();
   const { workQueue } = useWorkQueue({
     types: [IWorkType.BulkExport],
     queryString,
@@ -103,7 +113,7 @@ const useRecentExports = ({
     skip,
   });
 
-  return getActiveFilesAndCount(workQueue as ExportedWork[]);
+  return getActiveFilesAndCount(workQueue as ExportedWork[], formatDateTime);
 };
 
 export default useRecentExports;

--- a/admin-ui/src/pages/_app.tsx
+++ b/admin-ui/src/pages/_app.tsx
@@ -22,6 +22,7 @@ import { ChatProvider } from '../modules/copilot/ChatContext';
 import { PluginProvider } from '../modules/plugins/PluginContext';
 import ImageWithFallback from '@/components/ui/ImageWithFallback';
 import { AppContextWrapper } from '../modules/common/components/AppContext';
+import useScrollRestoration from '@/modules/common/hooks/useScrollRestoration';
 
 const handleRouteChange = (url) => {
   matomo.pageView(document.location.origin + url, document.title);
@@ -29,6 +30,7 @@ const handleRouteChange = (url) => {
 
 const UnchainedAdmin = ({ Component, componentName, pageProps, router }) => {
   const apollo = useApollo(pageProps);
+  useScrollRestoration();
 
   const getLayout = Component.getLayout
     ? (page) => (

--- a/admin-ui/src/pages/orders/index.tsx
+++ b/admin-ui/src/pages/orders/index.tsx
@@ -25,7 +25,6 @@ import {
 } from '../../gql/types';
 import usePaymentProviders from '../../modules/payment-providers/hooks/usePaymentProviders';
 import useDeliveryProviders from '../../modules/delivery-provider/hooks/useDeliveryProviders';
-import useScrollRestoration from '../../modules/common/hooks/useScrollRestoration';
 
 const Orders = () => {
   const { formatMessage } = useIntl();
@@ -80,7 +79,6 @@ const Orders = () => {
       ',',
     ) as IPaymentProviderType[],
   });
-  useScrollRestoration(!orderId);
 
   if (orderId) return <OrderDetailPage orderId={orderId} />;
 

--- a/admin-ui/src/pages/products/index.tsx
+++ b/admin-ui/src/pages/products/index.tsx
@@ -22,7 +22,6 @@ import AnimatedCounter from '@/components/ui/AnimatedCounter';
 import ProductExport from '../../modules/product/components/ProductExport';
 import ProductImport from '../../modules/product/components/ProductImport';
 import useApp from '../../modules/common/hooks/useApp';
-import useScrollRestoration from '../../modules/common/hooks/useScrollRestoration';
 
 const Products = () => {
   const { formatMessage } = useIntl();
@@ -55,7 +54,6 @@ const Products = () => {
     includeDrafts,
     tags,
   });
-  useScrollRestoration(!slug);
 
   if (slug) return <ProductDetailPage slug={slug} />;
   const headerText =


### PR DESCRIPTION
Returning to an Admin UI list with browser Back or Forward now restores the position saved for that history entry, including after delayed loading or fetching several infinite-scroll pages. A shared hook replaces the product/order pathname cache, stops on user input or another navigation, and handles the latest batched intersection notification so pagination can continue. Fresh breadcrumb/sidebar visits start at the top.

Date formatting preserves the selected content locale and falls back to the UI language plus shop country when no valid selection is available. User, copilot, and export dates use the shared formatter, which also accepts epoch timestamps and handles missing or invalid dates.

Validation:
- 10 Cypress component tests for locale selection, regional formatting, and batched infinite-scroll notifications.
- 6 Cypress browser navigation regressions, including delayed and three-page restoration.
- Admin UI TypeScript and targeted ESLint checks; one existing image-element warning.
- Full repository test suite after refreshing package build output: 1,769 passed, 4 skipped, 0 failed.

The scroll hook reads Next Pages Router's experimental history storage; the navigation regressions should be rerun when upgrading Next.
